### PR TITLE
feat: support GraphQL mutations

### DIFF
--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -258,6 +258,12 @@ func NewEnv(schema *introspection.Schema) Env {
 			// TODO: "lexical" is maybe not the right word anymore
 			env.lexical = &CompositeModule{sub, env.lexical}
 		}
+		// Expose the Mutation type as a named value (not lexical) so fields
+		// are accessed via Mutation.fieldName rather than bare names.
+		if schema.MutationType != nil && t.Name == schema.MutationType.Name {
+			env.Add(t.Name, hm.NewScheme(nil, NonNull(sub)))
+			env.SetVisibility(t.Name, PublicVisibility)
+		}
 	}
 
 	// Make enum types available as values in the module

--- a/tests/errors/ambiguous_mutation.dang
+++ b/tests/errors/ambiguous_mutation.dang
@@ -1,0 +1,7 @@
+# Test that bare Mutation is ambiguous when multiple imports provide it
+
+import Test
+import Other
+
+# This should fail because both Test and Other provide Mutation
+let deleted = Mutation.deleteUser(id: "99")

--- a/tests/test_mutation.dang
+++ b/tests/test_mutation.dang
@@ -1,0 +1,13 @@
+import Test
+
+# Create a user via mutation and verify the result
+let alice = Mutation.createUser(input: CreateUserInput(name: "Alice", email: "alice@example.com"))
+assert { alice.name == "Alice" }
+assert { alice.emails == ["alice@example.com"] }
+assert { alice.status == Status.ACTIVE }
+
+# Create another user and select a scalar field directly
+assert { Mutation.createUser(input: CreateUserInput(name: "Bob", email: "bob@example.com")).name == "Bob" }
+
+# Delete a user (returns scalar directly)
+assert { Mutation.deleteUser(id: "1") == true }

--- a/tests/test_mutation.dang
+++ b/tests/test_mutation.dang
@@ -9,5 +9,6 @@ assert { alice.status == Status.ACTIVE }
 # Create another user and select a scalar field directly
 assert { Mutation.createUser(input: CreateUserInput(name: "Bob", email: "bob@example.com")).name == "Bob" }
 
-# Delete a user (returns scalar directly)
-assert { Mutation.deleteUser(id: "1") == true }
+# Delete a created user (returns scalar directly)
+# Use alice's id to avoid mutating seed data used by other tests
+assert { Mutation.deleteUser(id: alice.id) == true }

--- a/tests/test_mutation_conflict.dang
+++ b/tests/test_mutation_conflict.dang
@@ -1,0 +1,7 @@
+import Test
+import Other
+
+# Both Test and Other provide Mutation — disambiguate with qualified access
+let alice = Test.Mutation.createUser(input: Test.CreateUserInput(name: "Alice", email: "alice@example.com"))
+assert { alice.name == "Alice" }
+assert { Test.Mutation.deleteUser(id: alice.id) == true }

--- a/tests/testdata/ambiguous_mutation.golden
+++ b/tests/testdata/ambiguous_mutation.golden
@@ -1,0 +1,10 @@
+[1m[31mError:[0m ambiguous reference to "Mutation": provided by imports [Test Other]
+  [2m[34m--> errors/ambiguous_mutation.dang:7:15[0m
+ [2m    |[0m
+ [2m  5 | [0m
+ [2m  6 | # This should fail because both Test and Other provide Mutation[0m
+ [2m[34m[1m  7 | [0mlet deleted = Mutation.deleteUser(id: "99")
+[2m                     [31m^^^^^^^^[0m
+ [2m  8 | [0m
+ [2m    |[0m
+


### PR DESCRIPTION
Expose the `Mutation` root type as a module value so mutation fields are accessed via `Mutation.fieldName`, mirroring how you'd query against the Mutation type in GraphQL.

```dang
import Test

let alice = Mutation.createUser(input: CreateUserInput(name: "Alice", email: "alice@example.com"))
assert { alice.name == "Alice" }
assert { Mutation.deleteUser(id: alice.id) == true }
```

When multiple imports provide mutations, bare `Mutation` produces an ambiguous reference error, requiring qualified access (`Test.Mutation.createUser(...)`) to disambiguate.

## Changes

- **querybuilder**: Added `Mutation()` constructor and `isMutation` flag that propagates through the builder chain. `Execute()` sends `mutation Mutation { ... }` instead of `query Query { ... }` when set.
- **eval.go**: Added `IsMutation` to `GraphQLFunction`/`GraphQLValue`, propagated through `Call()` and `SelectField()`. Mutation fields are collected into a `ModuleValue` registered as `"Mutation"` with public visibility.
- **env.go**: Registered the Mutation type as a named value binding (not composed into lexical scope like Query), so fields are only accessible via `Mutation.fieldName`.
- **tests**: Added mutation tests and an error test for the multi-import ambiguity diagnostic.

Closes #30