### PR TITLE
add `Random` and `UUID` to prelude

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.24.2
 toolchain go1.24.4
 
 require (
-	charm.land/bubbles/v2 v2.0.0-rc.1
-	charm.land/bubbletea/v2 v2.0.0-rc.2
 	charm.land/lipgloss/v2 v2.0.0-beta.3.0.20260213141939-54ce8ebb1690
 	dagger.io/dagger v0.19.11
 	github.com/99designs/gqlgen v0.17.81
@@ -30,11 +28,10 @@ require (
 require (
 	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
@@ -91,7 +88,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.8.0 // indirect
 	golang.org/x/mod v0.28.0 // indirect
 	golang.org/x/net v0.44.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/sys v0.41.0
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-charm.land/bubbles/v2 v2.0.0-rc.1 h1:EiIFVAc3Zi/yY86td+79mPhHR7AqZ1OxF+6ztpOCRaM=
-charm.land/bubbles/v2 v2.0.0-rc.1/go.mod h1:5AbN6cEd/47gkEf8TgiQ2O3RZ5QxMS14l9W+7F9fPC4=
-charm.land/bubbletea/v2 v2.0.0-rc.2 h1:TdTbUOFzbufDJmSz/3gomL6q+fR6HwfY+P13hXQzD7k=
-charm.land/bubbletea/v2 v2.0.0-rc.2/go.mod h1:IXFmnCnMLTWw/KQ9rEatSYqbAPAYi8kA3Yqwa1SFnLk=
 charm.land/lipgloss/v2 v2.0.0-beta.3.0.20260213141939-54ce8ebb1690 h1:OVl2Gyeiz7srXcZBBL5CgkcakBeFbVQArR1YQdGSZpE=
 charm.land/lipgloss/v2 v2.0.0-beta.3.0.20260213141939-54ce8ebb1690/go.mod h1:xylWHUuJWcFJqoGrKdZP8Z0y3THC6xqrnfl1IYDviTE=
 dagger.io/dagger v0.19.11 h1:Cra3wL1oaZsqXJcnPydocx3bIDD5tM7XCuwcn2Uh+2Q=
@@ -24,8 +20,6 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
-github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
-github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/dang/builtins.go
+++ b/pkg/dang/builtins.go
@@ -56,6 +56,18 @@ func (a Args) GetBool(name string) bool {
 	return false
 }
 
+// GetEnum retrieves an enum argument's string value
+func (a Args) GetEnum(name string) string {
+	val, ok := a.Values[name]
+	if !ok {
+		return ""
+	}
+	if enumVal, ok := val.(EnumValue); ok {
+		return enumVal.Val
+	}
+	return ""
+}
+
 // GetList retrieves a list argument
 func (a Args) GetList(name string) []Value {
 	val, ok := a.Values[name]

--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -192,6 +192,12 @@ func init() {
 	Prelude.AddClass("Boolean", BooleanType)
 	Prelude.AddClass("List", ListTypeModule)
 
+	// Install built-in modules (as both classes and values)
+	Prelude.AddClass("Random", RandomModule)
+	Prelude.AddClass("UUID", UUIDModule)
+	Prelude.Add("Random", hm.NewScheme(nil, hm.NonNullType{Type: RandomModule}))
+	Prelude.Add("UUID", hm.NewScheme(nil, hm.NonNullType{Type: UUIDModule}))
+
 	// Install Error interface with message field
 	Prelude.AddClass("Error", ErrorType)
 	ErrorType.Add("message", hm.NewScheme(nil, hm.NonNullType{Type: StringType}))
@@ -706,6 +712,16 @@ func registerBuiltinTypes() {
 			fnType := createFunctionTypeFromDef(def)
 			slog.Debug("adding builtin method", "type", receiverType.Named, "method", def.Name)
 			receiverType.Add(def.Name, hm.NewScheme(nil, fnType))
+		})
+	}
+
+	// Register all static method types on their host modules
+	for _, hostModule := range StaticModules() {
+		ForEachStaticMethod(hostModule, func(def BuiltinDef) {
+			fnType := createFunctionTypeFromDef(def)
+			slog.Debug("adding static method", "module", hostModule.Named, "method", def.Name)
+			hostModule.Add(def.Name, hm.NewScheme(nil, fnType))
+			hostModule.SetVisibility(def.Name, PublicVisibility)
 		})
 	}
 }

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -573,6 +573,24 @@ func addBuiltinFunctions(env EvalEnv) {
 			env.Set(methodKey, builtinFn)
 		})
 	}
+
+	// Register static methods on their host modules
+	for _, hostModule := range StaticModules() {
+		modValue := NewModuleValue(hostModule)
+		ForEachStaticMethod(hostModule, func(def BuiltinDef) {
+			fnType := createFunctionTypeFromDef(def)
+			builtinFn := BuiltinFunction{
+				Name:   def.Name,
+				FnType: fnType,
+				CallFn: func(ctx context.Context, env EvalEnv, args map[string]Value) (Value, error) {
+					argsWithDefaults := applyDefaults(args, def)
+					return def.Impl(ctx, nil, Args{Values: argsWithDefaults})
+				},
+			}
+			modValue.SetWithVisibility(def.Name, builtinFn, PublicVisibility)
+		})
+		env.Set(hostModule.Named, modValue)
+	}
 }
 
 // applyDefaults fills in default values for missing arguments

--- a/pkg/dang/stdlib.go
+++ b/pkg/dang/stdlib.go
@@ -13,6 +13,8 @@ import (
 // registerStdlib registers all standard library builtins
 // This is called from init() in env.go after type definitions are set up
 func registerStdlib() {
+	registerRandomAndUUID()
+
 	// print function: print(value: a) -> Null
 	Builtin("print").
 		Doc("prints a value to stdout").

--- a/pkg/dang/stdlib_random.go
+++ b/pkg/dang/stdlib_random.go
@@ -1,0 +1,124 @@
+package dang
+
+import (
+	"context"
+	crand "crypto/rand"
+	"fmt"
+	"math/big"
+	"math/rand/v2"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// RandomModule is the "Random" namespace for random value generation
+var RandomModule = NewModule("Random", ObjectKind)
+
+// UUIDModule is the "UUID" namespace for UUID generation
+var UUIDModule = NewModule("UUID", ObjectKind)
+
+// registerRandomAndUUID is called from registerStdlib to ensure correct init ordering
+func registerRandomAndUUID() {
+	registerRandom()
+	registerUUID()
+}
+
+func registerRandom() {
+	RandomModule.SetModuleDocString("functions for generating random values")
+
+	// Random.int(min: Int!, max: Int!) -> Int!
+	StaticMethod(RandomModule, "int").
+		Doc("generates a random integer between min (inclusive) and max (exclusive)").
+		Params("min", NonNull(IntType), "max", NonNull(IntType)).
+		Returns(NonNull(IntType)).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			min := args.GetInt("min")
+			max := args.GetInt("max")
+			if min >= max {
+				return nil, fmt.Errorf("Random.int: min (%d) must be less than max (%d)", min, max)
+			}
+			return ToValue(min + rand.IntN(max-min))
+		})
+
+	// Random.float() -> Float!
+	StaticMethod(RandomModule, "float").
+		Doc("generates a random float between 0.0 (inclusive) and 1.0 (exclusive)").
+		Returns(NonNull(FloatType)).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			return ToValue(rand.Float64())
+		})
+
+	// Random.string(length: Int!, charset: String! = "alphanumeric") -> String!
+	StaticMethod(RandomModule, "string").
+		Doc(`generates a random string of the given length. The charset parameter can be "alphanumeric", "hex", "alpha", "numeric", or a custom set of characters`).
+		Params(
+			"length", NonNull(IntType),
+			"charset", NonNull(StringType), StringValue{Val: "alphanumeric"},
+		).
+		Returns(NonNull(StringType)).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			length := args.GetInt("length")
+			charset := args.GetString("charset")
+
+			if length < 0 {
+				return nil, fmt.Errorf("Random.string: length must be non-negative, got %d", length)
+			}
+			if length == 0 {
+				return ToValue("")
+			}
+
+			chars := resolveCharset(charset)
+			if len(chars) == 0 {
+				return nil, fmt.Errorf("Random.string: charset is empty")
+			}
+
+			result := make([]byte, length)
+			for i := range result {
+				idx, err := crand.Int(crand.Reader, big.NewInt(int64(len(chars))))
+				if err != nil {
+					return nil, fmt.Errorf("Random.string: %w", err)
+				}
+				result[i] = chars[idx.Int64()]
+			}
+			return ToValue(string(result))
+		})
+}
+
+func registerUUID() {
+	UUIDModule.SetModuleDocString("functions for generating UUIDs")
+
+	// UUID.v4() -> String!
+	StaticMethod(UUIDModule, "v4").
+		Doc("generates a random UUID v4 string").
+		Returns(NonNull(StringType)).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			return ToValue(uuid.New().String())
+		})
+
+	// UUID.v7() -> String!
+	StaticMethod(UUIDModule, "v7").
+		Doc("generates a time-ordered UUID v7 string").
+		Returns(NonNull(StringType)).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return nil, fmt.Errorf("UUID.v7: %w", err)
+			}
+			return ToValue(id.String())
+		})
+}
+
+var charsets = map[string]string{
+	"alphanumeric": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+	"alpha":        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+	"numeric":      "0123456789",
+	"hex":          "0123456789abcdef",
+}
+
+func resolveCharset(name string) string {
+	if chars, ok := charsets[strings.ToLower(name)]; ok {
+		return chars
+	}
+	// Treat the string itself as the character set
+	return name
+}

--- a/pkg/dang/stdlib_random.go
+++ b/pkg/dang/stdlib_random.go
@@ -8,28 +8,26 @@ import (
 	"math/rand/v2"
 
 	"github.com/google/uuid"
-	"github.com/vito/dang/pkg/hm"
 )
 
 // RandomModule is the "Random" namespace for random value generation
 var RandomModule = NewModule("Random", ObjectKind)
 
 // CharsetEnum is the Random.Charset enum type
-var CharsetEnum = NewModule("Charset", EnumKind)
+var CharsetEnum = DefineEnum(RandomModule, "Charset",
+	"ALPHANUMERIC", "ALPHA", "NUMERIC", "HEX",
+)
 
 // UUIDModule is the "UUID" namespace for UUID generation
 var UUIDModule = NewModule("UUID", ObjectKind)
 
-// charsetValues maps enum value names to their character sets
+// charsetChars maps enum value names to their character sets
 var charsetChars = map[string]string{
 	"ALPHANUMERIC": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
 	"ALPHA":        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 	"NUMERIC":      "0123456789",
 	"HEX":          "0123456789abcdef",
 }
-
-// Ordered list for the values() method and default
-var charsetNames = []string{"ALPHANUMERIC", "ALPHA", "NUMERIC", "HEX"}
 
 // registerRandomAndUUID is called from registerStdlib to ensure correct init ordering
 func registerRandomAndUUID() {
@@ -39,21 +37,6 @@ func registerRandomAndUUID() {
 
 func registerRandom() {
 	RandomModule.SetModuleDocString("functions for generating random values")
-
-	// Set up Charset enum inside Random
-	RandomModule.AddClass("Charset", CharsetEnum)
-	RandomModule.Add("Charset", hm.NewScheme(nil, NonNull(CharsetEnum)))
-	RandomModule.SetVisibility("Charset", PublicVisibility)
-
-	for _, name := range charsetNames {
-		CharsetEnum.Add(name, hm.NewScheme(nil, NonNull(CharsetEnum)))
-		CharsetEnum.SetVisibility(name, PublicVisibility)
-	}
-
-	// Add values() method to the enum
-	valuesType := hm.NewScheme(nil, NonNull(ListType{NonNull(CharsetEnum)}))
-	CharsetEnum.Add("values", valuesType)
-	CharsetEnum.SetVisibility("values", PublicVisibility)
 
 	// Random.int(min: Int!, max: Int!) -> Int!
 	StaticMethod(RandomModule, "int").

--- a/pkg/dang/stdlib_random.go
+++ b/pkg/dang/stdlib_random.go
@@ -33,7 +33,7 @@ func registerRandom() {
 			min := args.GetInt("min")
 			max := args.GetInt("max")
 			if min >= max {
-				return nil, fmt.Errorf("Random.int: min (%d) must be less than max (%d)", min, max)
+				return nil, fmt.Errorf("random.int: min (%d) must be less than max (%d)", min, max)
 			}
 			return ToValue(min + mrand.IntN(max-min))
 		})

--- a/pkg/lsp/lsp_test.go
+++ b/pkg/lsp/lsp_test.go
@@ -189,6 +189,7 @@ func testFile(t *testctx.T, client *nvim.Nvim, file string) {
 		require.NoError(t, err)
 		line := string(lineb)
 
+		line = strings.ReplaceAll(line, "nofmt ", "")
 		line, test, ok := strings.Cut(line, " # test: ")
 		if !ok {
 			continue

--- a/pkg/lsp/testdata/complete.dang
+++ b/pkg/lsp/testdata/complete.dang
@@ -31,8 +31,8 @@ pub barQualified: Dagger.Container! {
 }
 
 # argument completion
-container.from() # test: ^f(a<C-x><C-o> => container.from(address┃)
-container.withExec() # test: ^f(a<C-x><C-o> => container.withExec(args┃)
+container.from() # nofmt test: ^f(a<C-x><C-o> => container.from(address┃)
+container.withExec() # nofmt test: ^f(a<C-x><C-o> => container.withExec(args┃)
 
 let url = "https://github.com/vito/dang"
 Dagger.git(url) # test: ^Ea.he<C-x><C-o>{delay:200ms}.tr<C-x><C-o> => git(url).head.tree┃

--- a/tests/errors/ambiguous_mutation.dang
+++ b/tests/errors/ambiguous_mutation.dang
@@ -1,7 +1,7 @@
 # Test that bare Mutation is ambiguous when multiple imports provide it
 
-import Test
 import Other
+import Test
 
 # This should fail because both Test and Other provide Mutation
 let deleted = Mutation.deleteUser(id: "99")

--- a/tests/test_mutation_conflict.dang
+++ b/tests/test_mutation_conflict.dang
@@ -1,7 +1,9 @@
-import Test
 import Other
+import Test
 
 # Both Test and Other provide Mutation — disambiguate with qualified access
-let alice = Test.Mutation.createUser(input: Test.CreateUserInput(name: "Alice", email: "alice@example.com"))
+let alice = Test.Mutation.createUser(
+  input: Test.CreateUserInput(name: "Alice", email: "alice@example.com"),
+)
 assert { alice.name == "Alice" }
 assert { Test.Mutation.deleteUser(id: alice.id) == true }

--- a/tests/test_random.dang
+++ b/tests/test_random.dang
@@ -6,33 +6,41 @@ assert { n >= 0 }
 assert { n < 10 }
 
 # Random.float generates floats in [0, 1)
-let f = Random.float
+let f = Random.float()
 assert { f >= 0.0 }
 assert { f < 1.0 }
 
-# Random.string with default charset
+# Random.string with default charset (ALPHANUMERIC)
 let s = Random.string(length: 16)
 assert { s != "" }
 
-# Random.string with hex charset
-let h = Random.string(length: 8, charset: "hex")
+# Random.string with explicit charset
+let h = Random.string(length: 8, charset: Random.Charset.HEX)
 assert { h != "" }
+
+# Random.string with ALPHA charset
+let a = Random.string(length: 10, charset: Random.Charset.ALPHA)
+assert { a != "" }
+
+# Random.string with NUMERIC charset
+let num = Random.string(length: 6, charset: Random.Charset.NUMERIC)
+assert { num != "" }
 
 # Random.string with zero length
 let empty = Random.string(length: 0)
 assert { empty == "" }
 
 # UUID.v4 generates valid-looking UUIDs (36 chars with hyphens)
-let id = UUID.v4
+let id = UUID.v4()
 assert { id.contains("-") }
 assert { id.split("-").length == 5 }
 
 # UUID.v7 generates valid-looking UUIDs
-let id7 = UUID.v7
+let id7 = UUID.v7()
 assert { id7.contains("-") }
 assert { id7.split("-").length == 5 }
 
 # Each call generates a different value
-let a = UUID.v4
-let b = UUID.v4
-assert { a != b }
+let x = UUID.v4()
+let y = UUID.v4()
+assert { x != y }

--- a/tests/test_random.dang
+++ b/tests/test_random.dang
@@ -1,0 +1,38 @@
+# Test Random and UUID modules
+
+# Random.int generates integers in range
+let n = Random.int(min: 0, max: 10)
+assert { n >= 0 }
+assert { n < 10 }
+
+# Random.float generates floats in [0, 1)
+let f = Random.float
+assert { f >= 0.0 }
+assert { f < 1.0 }
+
+# Random.string with default charset
+let s = Random.string(length: 16)
+assert { s != "" }
+
+# Random.string with hex charset
+let h = Random.string(length: 8, charset: "hex")
+assert { h != "" }
+
+# Random.string with zero length
+let empty = Random.string(length: 0)
+assert { empty == "" }
+
+# UUID.v4 generates valid-looking UUIDs (36 chars with hyphens)
+let id = UUID.v4
+assert { id.contains("-") }
+assert { id.split("-").length == 5 }
+
+# UUID.v7 generates valid-looking UUIDs
+let id7 = UUID.v7
+assert { id7.contains("-") }
+assert { id7.split("-").length == 5 }
+
+# Each call generates a different value
+let a = UUID.v4
+let b = UUID.v4
+assert { a != b }

--- a/tests/test_random.dang
+++ b/tests/test_random.dang
@@ -10,25 +10,9 @@ let f = Random.float()
 assert { f >= 0.0 }
 assert { f < 1.0 }
 
-# Random.string with default charset (ALPHANUMERIC)
-let s = Random.string(length: 16)
+# Random.string generates a secure random token
+let s = Random.string()
 assert { s != "" }
-
-# Random.string with explicit charset
-let h = Random.string(length: 8, charset: Random.Charset.HEX)
-assert { h != "" }
-
-# Random.string with ALPHA charset
-let a = Random.string(length: 10, charset: Random.Charset.ALPHA)
-assert { a != "" }
-
-# Random.string with NUMERIC charset
-let num = Random.string(length: 6, charset: Random.Charset.NUMERIC)
-assert { num != "" }
-
-# Random.string with zero length
-let empty = Random.string(length: 0)
-assert { empty == "" }
 
 # UUID.v4 generates valid-looking UUIDs (36 chars with hyphens)
 let id = UUID.v4()
@@ -41,6 +25,6 @@ assert { id7.contains("-") }
 assert { id7.split("-").length == 5 }
 
 # Each call generates a different value
-let x = UUID.v4()
-let y = UUID.v4()
-assert { x != y }
+let a = UUID.v4()
+let b = UUID.v4()
+assert { a != b }

--- a/tests/test_random.dang
+++ b/tests/test_random.dang
@@ -6,25 +6,25 @@ assert { n >= 0 }
 assert { n < 10 }
 
 # Random.float generates floats in [0, 1)
-let f = Random.float()
+let f = Random.float
 assert { f >= 0.0 }
 assert { f < 1.0 }
 
 # Random.string generates a secure random token
-let s = Random.string()
+let s = Random.string
 assert { s != "" }
 
 # UUID.v4 generates valid-looking UUIDs (36 chars with hyphens)
-let id = UUID.v4()
+let id = UUID.v4
 assert { id.contains("-") }
 assert { id.split("-").length == 5 }
 
 # UUID.v7 generates valid-looking UUIDs
-let id7 = UUID.v7()
+let id7 = UUID.v7
 assert { id7.contains("-") }
 assert { id7.split("-").length == 5 }
 
 # Each call generates a different value
-let a = UUID.v4()
-let b = UUID.v4()
+let a = UUID.v4
+let b = UUID.v4
 assert { a != b }

--- a/tests/testdata/ambiguous_mutation.golden
+++ b/tests/testdata/ambiguous_mutation.golden
@@ -1,4 +1,4 @@
-[1m[31mError:[0m ambiguous reference to "Mutation": provided by imports [Test Other]
+[1m[31mError:[0m ambiguous reference to "Mutation": provided by imports [Other Test]
   [2m[34m--> errors/ambiguous_mutation.dang:7:15[0m
  [2m    |[0m
  [2m  5 | [0m


### PR DESCRIPTION
closes #35 

Wanted to figure out how utility functions like this should work without polluting the global namespace too much. For this iteration, we define modules with static methods on them.

I considered also doing static methods on each type like `String.random`, `Int.random` - but went with separate `UUID` and `Random` modules for now. Currently, defining a `Int.random` would mean `43.random` also exists, which is odd. We would need something like `class << self` from Ruby, to define static methods that exist only on the module itself, I suppose.