### PR TITLE
feat: add String.replaceRegex method

### DIFF
--- a/pkg/dang/stdlib.go
+++ b/pkg/dang/stdlib.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/vito/dang/pkg/hm"
@@ -230,6 +231,39 @@ func registerStdlib() {
 			count := args.GetInt("count")
 
 			result := strings.Replace(str, old, new, count)
+			return ToValue(result)
+		})
+
+	// String.replaceRegex method: replaceRegex(pattern: String!, new: String!, count: Int = -1) -> String!
+	Method(StringType, "replaceRegex").
+		Doc("replaces regex matches with new in the string. The count parameter controls how many replacements to make: -1 (default) replaces all occurrences, 1 replaces only the first, etc.").
+		Params(
+			"pattern", NonNull(StringType),
+			"new", NonNull(StringType),
+			"count", IntType, IntValue{Val: -1},
+		).
+		Returns(NonNull(StringType)).
+		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
+			str := self.(StringValue).Val
+			pattern := args.GetString("pattern")
+			new := args.GetString("new")
+			count := args.GetInt("count")
+
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("replaceRegex: invalid pattern: %w", err)
+			}
+			if count < 0 {
+				return ToValue(re.ReplaceAllString(str, new))
+			}
+			n := 0
+			result := re.ReplaceAllStringFunc(str, func(match string) string {
+				if n >= count {
+					return match
+				}
+				n++
+				return re.ReplaceAllString(match, new)
+			})
 			return ToValue(result)
 		})
 

--- a/tests/test_string_replace_regex.dang
+++ b/tests/test_string_replace_regex.dang
@@ -1,0 +1,39 @@
+# Test String.replaceRegex method
+
+# Test default behavior (replace all occurrences with count=-1)
+pub replace_all = "hello world hello".replaceRegex(pattern: "hel+o", new: "hi")
+assert { replace_all == "hi world hi" }
+
+# Test with count=1 to replace only first occurrence
+pub first_only = "hello world hello".replaceRegex(pattern: "hel+o", new: "hi", count: 1)
+assert { first_only == "hi world hello" }
+
+# Test with count=2 to replace first two occurrences
+pub first_two = "abc abc abc abc".replaceRegex(pattern: "a[bc]+", new: "xyz", count: 2)
+assert { first_two == "xyz xyz abc abc" }
+
+# Test with no matches
+pub no_match = "hello world".replaceRegex(pattern: "goodbye", new: "hi")
+assert { no_match == "hello world" }
+
+# Test replacing with empty string (all)
+pub remove_all = "foo123 bar foo456".replaceRegex(pattern: "[0-9]+", new: "")
+assert { remove_all == "foo bar foo" }
+
+# Test replacing with empty string (first only)
+pub remove_first = "foo123 bar foo456".replaceRegex(pattern: "[0-9]+", new: "", count: 1)
+assert { remove_first == "foo bar foo456" }
+
+# Test full string replacement
+pub full = "hello".replaceRegex(pattern: "h.*o", new: "goodbye")
+assert { full == "goodbye" }
+
+# Test capture group substitution
+pub capture = "2024-04-17".replaceRegex(pattern: "([0-9]{4})-([0-9]{2})-([0-9]{2})", new: "$3/$2/$1")
+assert { capture == "17/04/2024" }
+
+# Test multiple different patterns (all)
+pub multiple_all = "abc ABC def abc".replaceRegex(pattern: "(?i)abc", new: "xyz")
+assert { multiple_all == "xyz xyz def xyz" }
+
+print("String.replaceRegex() tests passed!")


### PR DESCRIPTION
Adds replaceRegex(pattern, new, count) to the String stdlib, similar to String.replace but accepts a RE2 regular expression as the search pattern. Supports capture group substitution ($1, $2, ...) and the same count parameter as replace (-1 replaces all, n >= 0 limits replacements). Also adds tests/test_string_replace_regex.dang covering replace-all, count-limited, capture groups, and case-insensitive patterns.

I found this method is useful when we want to replace a complex string with a new one, for example, replace an image in sdk/elixir/runtime/main.go to match with the image defined in the elixir-sdk toolchain.