### PR TITLE
feat(graphql): honor expectedType ID directives

### DIFF
--- a/pkg/dang/ast.go
+++ b/pkg/dang/ast.go
@@ -634,6 +634,10 @@ func (c *CompositeModule) NamedType(name string) (Env, bool) {
 	return c.lexical.NamedType(name)
 }
 
+func (c *CompositeModule) LocalNamedType(name string) (Env, bool) {
+	return c.primary.LocalNamedType(name)
+}
+
 func (c *CompositeModule) NamedTypes() iter.Seq2[string, Env] {
 	return func(yield func(string, Env) bool) {
 		seen := map[string]bool{}

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -1168,7 +1168,7 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 		if len(frag.Fields) == 0 {
 			// Lazy inline fragment: no field sub-selection, use the full concrete type.
 			// This allows chaining further calls on the result as a GraphQLValue.
-			narrowedUnion.AddMember(memberMod)
+			narrowedUnion.LinkMember(memberMod)
 			frag.Inferred = memberMod
 		} else {
 			// Create a narrowed module with only the selected fields.
@@ -1186,7 +1186,7 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 				narrowedMember.Add(field.Name, hm.NewScheme(nil, fieldType))
 			}
 
-			narrowedUnion.AddMember(narrowedMember)
+			narrowedUnion.LinkMember(narrowedMember)
 			frag.Inferred = narrowedMember
 		}
 	}

--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -16,6 +16,7 @@ type Env interface {
 	hm.Env
 	hm.Type
 	NamedType(string) (Env, bool)
+	LocalNamedType(string) (Env, bool)
 	AddClass(string, Env)
 	SetDocString(string, string)
 	GetDocString(string) (string, bool)
@@ -579,7 +580,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 				continue
 			}
 
-			unionMod.AddMember(memberType)
+			unionMod.LinkMember(memberType)
 			slog.Debug("linked union member", "union", t.Name, "member", member.Name)
 		}
 	}
@@ -720,7 +721,7 @@ func (e *Module) GetDirective(name string) (*DirectiveDecl, bool) {
 }
 
 func (e *Module) NamedType(name string) (Env, bool) {
-	t, ok := e.classes[name]
+	t, ok := e.LocalNamedType(name)
 	if ok {
 		return t, ok
 	}
@@ -728,6 +729,11 @@ func (e *Module) NamedType(name string) (Env, bool) {
 		return e.Parent.NamedType(name)
 	}
 	return nil, false
+}
+
+func (e *Module) LocalNamedType(name string) (Env, bool) {
+	t, ok := e.classes[name]
+	return t, ok
 }
 
 func (e *Module) Remove(name string) hm.Env {
@@ -955,10 +961,17 @@ func (m *Module) ImplementsInterface(iface Env) bool {
 	return slices.Contains(m.interfaces, iface)
 }
 
-// AddMember adds a member type to this union (for union modules)
+// AddMember adds a member type to this union (for union modules).
 func (m *Module) AddMember(member Env) {
 	m.members = append(m.members, member)
-	// Also track the reverse relationship on the member
+}
+
+// LinkMember adds a union member and records the reverse relationship on the
+// member. Only call this when the member module is owned by the same local
+// environment; Prelude modules are shared process-wide and must not record
+// per-module union declarations.
+func (m *Module) LinkMember(member Env) {
+	m.AddMember(member)
 	if memberMod, ok := member.(*Module); ok {
 		memberMod.unions = append(memberMod.unions, m)
 	}

--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -143,12 +143,16 @@ func NewModule(name string, kind ModuleKind) *Module {
 	return env
 }
 
-func gqlToTypeNode(mod Env, ref *introspection.TypeRef) (hm.Type, error) {
+func gqlFieldToTypeNode(mod Env, field *introspection.Field) (hm.Type, error) {
+	return gqlOutputTypeRefToTypeNode(mod, field.TypeRef, field.Directives.ExpectedType())
+}
+
+func gqlOutputTypeRefToTypeNode(mod Env, ref *introspection.TypeRef, expectedType string) (hm.Type, error) {
 	switch ref.Kind {
 	case introspection.TypeKindList:
-		inner, err := gqlToTypeNode(mod, ref.OfType)
+		inner, err := gqlOutputTypeRefToTypeNode(mod, ref.OfType, expectedType)
 		if err != nil {
-			return nil, fmt.Errorf("gqlToTypeNode List: %w", err)
+			return nil, fmt.Errorf("gqlOutputTypeRefToTypeNode List: %w", err)
 		}
 		// Lists of objects use GraphQLListType (not directly iterable)
 		// Lists of scalars use regular ListType (iterable)
@@ -157,23 +161,72 @@ func gqlToTypeNode(mod Env, ref *introspection.TypeRef) (hm.Type, error) {
 		}
 		return ListType{inner}, nil
 	case introspection.TypeKindNonNull:
-		inner, err := gqlToTypeNode(mod, ref.OfType)
+		inner, err := gqlOutputTypeRefToTypeNode(mod, ref.OfType, expectedType)
 		if err != nil {
-			return nil, fmt.Errorf("gqlToTypeNode NonNull: %w", err)
+			return nil, fmt.Errorf("gqlOutputTypeRefToTypeNode NonNull: %w", err)
 		}
 		return hm.NonNullType{Type: inner}, nil
 	case introspection.TypeKindScalar:
+		if ref.Name == "ID" && expectedType != "" {
+			t, found := mod.NamedType(expectedType)
+			if !found {
+				return nil, fmt.Errorf("gqlOutputTypeRefToTypeNode: expected type %q not found", expectedType)
+			}
+			return t, nil
+		}
 		if strings.HasSuffix(ref.Name, "ID") && ref.Name != "ID" {
-			return gqlToTypeNode(mod, &introspection.TypeRef{
+			return gqlOutputTypeRefToTypeNode(mod, &introspection.TypeRef{
 				Name: strings.TrimSuffix(ref.Name, "ID"),
 				Kind: introspection.TypeKindObject,
-			})
+			}, "")
 		}
 		fallthrough
 	default:
 		t, found := mod.NamedType(ref.Name)
 		if !found {
-			return nil, fmt.Errorf("gqlToTypeNode: %s %q not found", ref.Kind, ref.Name)
+			return nil, fmt.Errorf("gqlOutputTypeRefToTypeNode: %s %q not found", ref.Kind, ref.Name)
+		}
+		return t, nil
+	}
+}
+
+func gqlInputToTypeNode(mod Env, input introspection.InputValue) (hm.Type, error) {
+	return gqlInputTypeRefToTypeNode(mod, input.TypeRef, input.Directives.ExpectedType())
+}
+
+func gqlInputTypeRefToTypeNode(mod Env, ref *introspection.TypeRef, expectedType string) (hm.Type, error) {
+	switch ref.Kind {
+	case introspection.TypeKindList:
+		inner, err := gqlInputTypeRefToTypeNode(mod, ref.OfType, expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("gqlInputTypeRefToTypeNode List: %w", err)
+		}
+		return ListType{inner}, nil
+	case introspection.TypeKindNonNull:
+		inner, err := gqlInputTypeRefToTypeNode(mod, ref.OfType, expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("gqlInputTypeRefToTypeNode NonNull: %w", err)
+		}
+		return hm.NonNullType{Type: inner}, nil
+	case introspection.TypeKindScalar:
+		if ref.Name == "ID" && expectedType != "" {
+			t, found := mod.NamedType(expectedType)
+			if !found {
+				return nil, fmt.Errorf("gqlInputTypeRefToTypeNode: expected type %q not found", expectedType)
+			}
+			return t, nil
+		}
+		if strings.HasSuffix(ref.Name, "ID") && ref.Name != "ID" {
+			return gqlInputTypeRefToTypeNode(mod, &introspection.TypeRef{
+				Name: strings.TrimSuffix(ref.Name, "ID"),
+				Kind: introspection.TypeKindObject,
+			}, "")
+		}
+		fallthrough
+	default:
+		t, found := mod.NamedType(ref.Name)
+		if !found {
+			return nil, fmt.Errorf("gqlInputTypeRefToTypeNode: %s %q not found", ref.Kind, ref.Name)
 		}
 		return t, nil
 	}
@@ -342,7 +395,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 			if found {
 				args := NewRecordType("")
 				for _, f := range t.InputFields {
-					fieldType, err := gqlToTypeNode(env, f.TypeRef)
+					fieldType, err := gqlInputToTypeNode(env, f)
 					if err != nil {
 						continue
 					}
@@ -371,7 +424,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 		// Input objects: register their fields so they can be used as constructors
 		if t.Kind == introspection.TypeKindInputObject {
 			for _, f := range t.InputFields {
-				fieldType, err := gqlToTypeNode(env, f.TypeRef)
+				fieldType, err := gqlInputToTypeNode(env, f)
 				if err != nil {
 					panic(err)
 				}
@@ -409,14 +462,14 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 		}
 
 		for _, f := range t.Fields {
-			ret, err := gqlToTypeNode(env, f.TypeRef)
+			ret, err := gqlFieldToTypeNode(env, f)
 			if err != nil {
 				panic(err)
 			}
 
 			args := NewRecordType("")
 			for _, arg := range f.Args {
-				argType, err := gqlToTypeNode(env, arg.TypeRef)
+				argType, err := gqlInputToTypeNode(env, arg)
 				if err != nil {
 					panic(err)
 				}

--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -278,6 +278,18 @@ func NewPreludeEnv(name string) *CompositeModule {
 func NewEnv(name string, schema *introspection.Schema) Env {
 	env := NewPreludeEnv(name)
 
+	isBuiltinScalar := func(t *introspection.Type) bool {
+		if t.Kind != introspection.TypeKindScalar {
+			return false
+		}
+		switch t.Name {
+		case "ID", "String", "Int", "Float", "Boolean":
+			return true
+		default:
+			return false
+		}
+	}
+
 	for _, t := range schema.Directives {
 		var args []*SlotDecl
 		for _, arg := range t.Args {
@@ -302,20 +314,38 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 		env.AddDirective(t.Name, directive)
 	}
 
+	// Track schema-owned types separately from env.NamedType. env has Prelude as
+	// a lexical fallback, which is useful for resolving built-in scalars but must
+	// not participate in schema declaration ownership. A schema type named Error,
+	// Random, etc. is a new GraphQL type that shadows the Dang Prelude type.
+	schemaTypes := map[string]Env{}
+
 	for _, t := range schema.Types {
-		sub, found := env.NamedType(t.Name)
-		if !found {
-			kind, err := ModuleKindFromGraphQLKind(t.Kind)
-			if err != nil {
-				slog.Warn("skipping unsupported type", "type", t.Name, "kind", t.Kind, "error", err)
+		var sub Env
+		if isBuiltinScalar(t) {
+			var found bool
+			sub, found = env.lexical.NamedType(t.Name)
+			if !found {
+				slog.Warn("built-in scalar not found", "type", t.Name)
 				continue
 			}
-			sub = NewModule(t.Name, kind)
-			// Store type description as module documentation
-			if t.Description != "" {
-				sub.SetModuleDocString(t.Description)
+		} else {
+			var found bool
+			sub, found = schemaTypes[t.Name]
+			if !found {
+				kind, err := ModuleKindFromGraphQLKind(t.Kind)
+				if err != nil {
+					slog.Warn("skipping unsupported type", "type", t.Name, "kind", t.Kind, "error", err)
+					continue
+				}
+				sub = NewModule(t.Name, kind)
+				// Store type description as module documentation
+				if t.Description != "" {
+					sub.SetModuleDocString(t.Description)
+				}
+				schemaTypes[t.Name] = sub
+				env.AddClass(t.Name, sub)
 			}
-			env.AddClass(t.Name, sub)
 		}
 		if t.Name == schema.QueryType.Name {
 			// TODO: "lexical" is maybe not the right word anymore
@@ -332,7 +362,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 	// Make enum types available as values in the module
 	for _, t := range schema.Types {
 		if t.Kind == introspection.TypeKindEnum {
-			sub, found := env.NamedType(t.Name)
+			sub, found := schemaTypes[t.Name]
 			if found {
 				// Add the enum type as a scheme that represents the module itself
 				env.Add(t.Name, hm.NewScheme(nil, NonNull(sub)))
@@ -345,17 +375,12 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 	for _, t := range schema.Types {
 		if t.Kind == introspection.TypeKindScalar {
 			// Skip built-in scalars (String, Int, Float, Boolean, ID)
-			if t.Name == "String" || t.Name == "Int" || t.Name == "Float" || t.Name == "Boolean" || t.Name == "ID" {
+			if isBuiltinScalar(t) {
 				continue
 			}
-			sub, found := env.NamedType(t.Name)
+			sub, found := schemaTypes[t.Name]
 			if !found {
-				// Create a scalar type module
-				sub = NewModule(t.Name, ScalarKind)
-				if t.Description != "" {
-					sub.SetModuleDocString(t.Description)
-				}
-				env.AddClass(t.Name, sub)
+				continue
 			}
 			// Add the scalar type as a scheme
 			env.Add(t.Name, hm.NewScheme(nil, sub))
@@ -366,7 +391,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 	// Make interface types available as values in the module
 	for _, t := range schema.Types {
 		if t.Kind == introspection.TypeKindInterface {
-			sub, found := env.NamedType(t.Name)
+			sub, found := schemaTypes[t.Name]
 			if found {
 				// Add the interface type as a scheme that represents the module itself
 				env.Add(t.Name, hm.NewScheme(nil, sub))
@@ -378,7 +403,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 	// Make union types available as values in the module
 	for _, t := range schema.Types {
 		if t.Kind == introspection.TypeKindUnion {
-			sub, found := env.NamedType(t.Name)
+			sub, found := schemaTypes[t.Name]
 			if found {
 				// Add the union type as a scheme that represents the module itself
 				env.Add(t.Name, hm.NewScheme(nil, sub))
@@ -391,7 +416,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 	// UserSort(field: ..., direction: ...) creates a UserSort value
 	for _, t := range schema.Types {
 		if t.Kind == introspection.TypeKindInputObject {
-			sub, found := env.NamedType(t.Name)
+			sub, found := schemaTypes[t.Name]
 			if found {
 				args := NewRecordType("")
 				for _, f := range t.InputFields {
@@ -414,10 +439,10 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 	}
 
 	for _, t := range schema.Types {
-		install, found := env.NamedType(t.Name)
+		install, found := schemaTypes[t.Name]
 		if !found {
-			// we just set it above...
-			// This should never happen, but handle gracefully
+			// Built-in GraphQL scalars live in the shared Prelude and have no schema
+			// fields to install. All schema-owned types were recorded above.
 			continue
 		}
 
@@ -507,17 +532,14 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 			continue
 		}
 
-		// Get the implementing type module — only mutate locally owned types,
-		// not shared Prelude types.
-		implType, found := env.primary.NamedType(t.Name)
+		implType, found := schemaTypes[t.Name]
 		if !found {
 			continue
 		}
 
 		// For each interface this type implements
 		for _, iface := range t.Interfaces {
-			// Look up the interface module
-			ifaceModule, found := env.NamedType(iface.Name)
+			ifaceModule, found := schemaTypes[iface.Name]
 			if !found {
 				slog.Warn("interface not found", "interface", iface.Name, "implementer", t.Name)
 				continue
@@ -528,11 +550,8 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 				implMod.AddInterface(ifaceModule)
 				slog.Debug("linked interface implementation", "type", t.Name, "interface", iface.Name)
 			}
-			// Only add implementer to locally owned interfaces
-			if _, local := env.primary.NamedType(iface.Name); local {
-				if ifaceMod, ok := ifaceModule.(*Module); ok {
-					ifaceMod.AddImplementer(implType)
-				}
+			if ifaceMod, ok := ifaceModule.(*Module); ok {
+				ifaceMod.AddImplementer(implType)
 			}
 		}
 	}
@@ -543,8 +562,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 			continue
 		}
 
-		// Only mutate locally owned union types.
-		unionType, found := env.primary.NamedType(t.Name)
+		unionType, found := schemaTypes[t.Name]
 		if !found {
 			continue
 		}
@@ -555,7 +573,7 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 		}
 
 		for _, member := range t.PossibleTypes {
-			memberType, found := env.NamedType(member.Name)
+			memberType, found := schemaTypes[member.Name]
 			if !found {
 				slog.Warn("union member not found", "union", t.Name, "member", member.Name)
 				continue

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -1,0 +1,110 @@
+package dang
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vito/dang/pkg/introspection"
+)
+
+func TestNewEnvSchemaTypeShadowsPreludeType(t *testing.T) {
+	_, found := ErrorType.LocalSchemeOf("id")
+	require.False(t, found)
+
+	env := NewEnv("Dagger", schemaWithErrorObject())
+
+	schemaString, found := env.NamedType("String")
+	require.True(t, found)
+	require.Same(t, StringType, schemaString)
+
+	schemaError, found := env.NamedType("Error")
+	require.True(t, found)
+	require.NotSame(t, ErrorType, schemaError)
+
+	schemaErrorMod, ok := schemaError.(*Module)
+	require.True(t, ok)
+	require.Equal(t, ObjectKind, schemaErrorMod.Kind)
+
+	_, found = schemaError.LocalSchemeOf("id")
+	require.True(t, found)
+	_, found = schemaError.LocalSchemeOf("message")
+	require.True(t, found)
+
+	_, found = ErrorType.LocalSchemeOf("id")
+	require.False(t, found)
+}
+
+func TestConcurrentNewEnvWithPreludeTypeCollision(t *testing.T) {
+	schema := schemaWithErrorObject()
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan bool, 32)
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			env := NewEnv("Dagger", schema)
+			schemaError, found := env.NamedType("Error")
+			errs <- found && schemaError != ErrorType
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for ok := range errs {
+		require.True(t, ok)
+	}
+	_, found := ErrorType.LocalSchemeOf("id")
+	require.False(t, found)
+}
+
+func schemaWithErrorObject() *introspection.Schema {
+	schema := &introspection.Schema{
+		Types: introspection.Types{
+			{
+				Kind: introspection.TypeKindScalar,
+				Name: "ID",
+			},
+			{
+				Kind: introspection.TypeKindScalar,
+				Name: "String",
+			},
+			{
+				Kind: introspection.TypeKindObject,
+				Name: "Error",
+				Fields: []*introspection.Field{
+					{
+						Name: "id",
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "ID",
+							},
+						},
+					},
+					{
+						Name: "message",
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "String",
+							},
+						},
+					},
+				},
+			},
+			{
+				Kind: introspection.TypeKindObject,
+				Name: "Query",
+			},
+		},
+	}
+	schema.QueryType.Name = "Query"
+	return schema
+}

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -1,6 +1,9 @@
 package dang
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -60,6 +63,73 @@ func TestConcurrentNewEnvWithPreludeTypeCollision(t *testing.T) {
 	}
 	_, found := ErrorType.LocalSchemeOf("id")
 	require.False(t, found)
+}
+
+func TestRunDirDeclarationsShadowPreludeTypes(t *testing.T) {
+	env := runDangSnippet(t, `
+type Error {
+  pub id: String! = "x"
+}
+assert { Error.id == "x" }
+`)
+	classVal, found := env.Get("Error")
+	require.True(t, found)
+	classFn, ok := classVal.(*ConstructorFunction)
+	require.True(t, ok)
+	require.NotSame(t, ErrorType, classFn.ClassType)
+	_, found = ErrorType.LocalSchemeOf("id")
+	require.False(t, found)
+
+	env = runDangSnippet(t, `
+enum Error { FOO }
+assert { Error.FOO == Error.FOO }
+`)
+	enumVal, found := env.Get("Error")
+	require.True(t, found)
+	enumMod, ok := enumVal.(*ModuleValue)
+	require.True(t, ok)
+	require.NotSame(t, ErrorType, enumMod.Mod)
+	_, found = ErrorType.LocalSchemeOf("FOO")
+	require.False(t, found)
+
+	env = runDangSnippet(t, `
+scalar Error
+`)
+	scalarVal, found := env.Get("Error")
+	require.True(t, found)
+	scalarMod, ok := scalarVal.(*ModuleValue)
+	require.True(t, ok)
+	require.NotSame(t, ErrorType, scalarMod.Mod)
+	require.Equal(t, ScalarKind, scalarMod.Mod.(*Module).Kind)
+}
+
+func TestRunDirImplementingPreludeInterfaceDoesNotMutatePrelude(t *testing.T) {
+	before := len(ErrorType.GetImplementers())
+	runDangSnippet(t, `
+type MyError implements Error {
+  pub message: String! = "x"
+}
+assert { MyError.message == "x" }
+`)
+	require.Len(t, ErrorType.GetImplementers(), before)
+}
+
+func TestRunDirUnionWithPreludeMemberDoesNotMutatePrelude(t *testing.T) {
+	before := len(BasicErrorType.GetUnions())
+	runDangSnippet(t, `
+union MyUnion = BasicError
+assert { MyUnion != null }
+`)
+	require.Len(t, BasicErrorType.GetUnions(), before)
+}
+
+func runDangSnippet(t *testing.T, source string) EvalEnv {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.dang"), []byte(source), 0o600))
+	env, err := RunDir(context.Background(), dir, false)
+	require.NoError(t, err)
+	return env
 }
 
 func schemaWithErrorObject() *introspection.Schema {

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -293,14 +293,14 @@ func (g GraphQLValue) SelectField(ctx context.Context, fieldName string) (Value,
 	// Create a function type for this method call
 	args := NewRecordType("")
 	for _, arg := range field.Args {
-		argType, err := gqlToTypeNode(g.TypeEnv, arg.TypeRef)
+		argType, err := gqlInputToTypeNode(g.TypeEnv, arg)
 		if err != nil {
 			continue
 		}
 		args.Add(arg.Name, hm.NewScheme(nil, argType))
 	}
 
-	retType, err := gqlToTypeNode(g.TypeEnv, field.TypeRef)
+	retType, err := gqlFieldToTypeNode(g.TypeEnv, field)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert return type: %w", err)
 	}
@@ -497,7 +497,7 @@ func populateSchemaFunctions(env *ModuleValue, typeEnv Env, client graphql.Clien
 
 			args := NewRecordType("")
 			for _, f := range t.InputFields {
-				argType, err := gqlToTypeNode(typeEnv, f.TypeRef)
+				argType, err := gqlInputToTypeNode(typeEnv, f)
 				if err != nil {
 					continue
 				}
@@ -514,7 +514,7 @@ func populateSchemaFunctions(env *ModuleValue, typeEnv Env, client graphql.Clien
 		}
 
 		for _, f := range t.Fields {
-			ret, err := gqlToTypeNode(typeEnv, f.TypeRef)
+			ret, err := gqlFieldToTypeNode(typeEnv, f)
 			if err != nil {
 				continue
 			}
@@ -522,7 +522,7 @@ func populateSchemaFunctions(env *ModuleValue, typeEnv Env, client graphql.Clien
 			// This is a function - create a GraphQLFunction value
 			args := NewRecordType("")
 			for _, arg := range f.Args {
-				argType, err := gqlToTypeNode(typeEnv, arg.TypeRef)
+				argType, err := gqlInputToTypeNode(typeEnv, arg)
 				if err != nil {
 					continue
 				}
@@ -555,13 +555,13 @@ func populateSchemaFunctions(env *ModuleValue, typeEnv Env, client graphql.Clien
 			}
 			mutModule := NewModuleValue(mutTypeEnv)
 			for _, f := range t.Fields {
-				ret, err := gqlToTypeNode(typeEnv, f.TypeRef)
+				ret, err := gqlFieldToTypeNode(typeEnv, f)
 				if err != nil {
 					continue
 				}
 				args := NewRecordType("")
 				for _, arg := range f.Args {
-					argType, err := gqlToTypeNode(typeEnv, arg.TypeRef)
+					argType, err := gqlInputToTypeNode(typeEnv, arg)
 					if err != nil {
 						continue
 					}
@@ -714,6 +714,21 @@ func applyDefaults(args map[string]Value, def BuiltinDef) map[string]Value {
 	return result
 }
 
+func isObjectLikeType(typeRef *introspection.TypeRef, schema *introspection.Schema) bool {
+	currentType := typeRef
+	if currentType.Kind == "NON_NULL" {
+		currentType = currentType.OfType
+	}
+	if currentType.Kind == introspection.TypeKindObject || currentType.Kind == introspection.TypeKindInterface {
+		return true
+	}
+	if schema == nil {
+		return false
+	}
+	t := schema.Types.Get(currentType.Name)
+	return t != nil && (t.Kind == introspection.TypeKindObject || t.Kind == introspection.TypeKindInterface)
+}
+
 // Helper function to determine if a GraphQL type is scalar
 func isScalarType(typeRef *introspection.TypeRef, schema *introspection.Schema) bool {
 	// Unwrap NonNull and List wrappers
@@ -829,7 +844,7 @@ func dangValueToGo(val Value) (any, error) {
 		}
 		return result, nil
 	case GraphQLValue:
-		if v.Field.TypeRef.IsObject() {
+		if isObjectLikeType(v.Field.TypeRef, v.Schema) {
 			return gqlObjectMarshaller{val: v}, nil
 		}
 		return nil, fmt.Errorf("unsupported value type (%T): %s", val, pretty.Sprint(v))
@@ -858,7 +873,7 @@ func (m gqlObjectMarshaller) XXX_GraphQLType() string {
 }
 
 func (m gqlObjectMarshaller) XXX_GraphQLIDType() string {
-	return m.val.TypeName + "ID"
+	return "ID"
 }
 
 // XXX_GraphqlID is an internal function. It returns the underlying type ID

--- a/pkg/dang/expected_type_test.go
+++ b/pkg/dang/expected_type_test.go
@@ -1,0 +1,243 @@
+package dang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vito/dang/pkg/hm"
+	"github.com/vito/dang/pkg/introspection"
+)
+
+func TestExpectedTypeDirectiveMapsIDArgumentToObject(t *testing.T) {
+	env := NewEnv("Dagger", expectedTypeTestSchema())
+
+	useCacheScheme, found := env.SchemeOf("useCache")
+	require.True(t, found)
+	useCacheType, mono := useCacheScheme.Type()
+	require.True(t, mono)
+	useCacheFn, ok := useCacheType.(*hm.FunctionType)
+	require.True(t, ok)
+
+	cacheArgScheme, found := useCacheFn.Arg().(*RecordType).SchemeOf("cache")
+	require.True(t, found)
+	cacheArgType, mono := cacheArgScheme.Type()
+	require.True(t, mono)
+	cacheArgNonNull, ok := cacheArgType.(hm.NonNullType)
+	require.True(t, ok)
+	require.Equal(t, "CacheVolume", cacheArgNonNull.Type.Name())
+
+	cacheVolumeScheme, found := env.SchemeOf("cacheVolume")
+	require.True(t, found)
+	cacheVolumeType, mono := cacheVolumeScheme.Type()
+	require.True(t, mono)
+	cacheVolumeFn, ok := cacheVolumeType.(*hm.FunctionType)
+	require.True(t, ok)
+
+	_, err := hm.Assignable(cacheVolumeFn.Ret(false), cacheArgType)
+	require.NoError(t, err)
+}
+
+func TestExpectedTypeDirectiveMapsIDReturnToObject(t *testing.T) {
+	env := NewEnv("Dagger", expectedTypeTestSchema())
+
+	syncCacheScheme, found := env.SchemeOf("syncCache")
+	require.True(t, found)
+	syncCacheType, mono := syncCacheScheme.Type()
+	require.True(t, mono)
+	syncCacheFn, ok := syncCacheType.(*hm.FunctionType)
+	require.True(t, ok)
+
+	syncCacheRet := syncCacheFn.Ret(false)
+	syncCacheNonNull, ok := syncCacheRet.(hm.NonNullType)
+	require.True(t, ok)
+	require.Equal(t, "CacheVolume", syncCacheNonNull.Type.Name())
+
+	useCacheScheme, found := env.SchemeOf("useCache")
+	require.True(t, found)
+	useCacheType, mono := useCacheScheme.Type()
+	require.True(t, mono)
+	useCacheFn, ok := useCacheType.(*hm.FunctionType)
+	require.True(t, ok)
+
+	cacheArgScheme, found := useCacheFn.Arg().(*RecordType).SchemeOf("cache")
+	require.True(t, found)
+	cacheArgType, mono := cacheArgScheme.Type()
+	require.True(t, mono)
+
+	_, err := hm.Assignable(syncCacheRet, cacheArgType)
+	require.NoError(t, err)
+}
+
+func TestExpectedTypeDirectiveMapsIDListArgumentToPlainList(t *testing.T) {
+	env := NewEnv("Dagger", expectedTypeTestSchema())
+
+	useCachesScheme, found := env.SchemeOf("useCaches")
+	require.True(t, found)
+	useCachesType, mono := useCachesScheme.Type()
+	require.True(t, mono)
+	useCachesFn, ok := useCachesType.(*hm.FunctionType)
+	require.True(t, ok)
+
+	cachesArgScheme, found := useCachesFn.Arg().(*RecordType).SchemeOf("caches")
+	require.True(t, found)
+	cachesArgType, mono := cachesArgScheme.Type()
+	require.True(t, mono)
+	cachesArgNonNull, ok := cachesArgType.(hm.NonNullType)
+	require.True(t, ok)
+
+	_, isGraphQLList := cachesArgNonNull.Type.(GraphQLListType)
+	require.False(t, isGraphQLList)
+
+	cachesList, ok := cachesArgNonNull.Type.(ListType)
+	require.True(t, ok)
+	cacheElemNonNull, ok := cachesList.Type.(hm.NonNullType)
+	require.True(t, ok)
+	require.Equal(t, "CacheVolume", cacheElemNonNull.Type.Name())
+}
+
+func expectedTypeTestSchema() *introspection.Schema {
+	expectedTypeValue := `"CacheVolume"`
+	return &introspection.Schema{
+		QueryType: struct {
+			Name string `json:"name,omitempty"`
+		}{Name: "Query"},
+		Types: introspection.Types{
+			{
+				Kind: introspection.TypeKindScalar,
+				Name: "ID",
+			},
+			{
+				Kind: introspection.TypeKindScalar,
+				Name: "String",
+			},
+			{
+				Kind: introspection.TypeKindObject,
+				Name: "CacheVolume",
+				Fields: []*introspection.Field{
+					{
+						Name: "id",
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "ID",
+							},
+						},
+					},
+				},
+			},
+			{
+				Kind: introspection.TypeKindObject,
+				Name: "Query",
+				Fields: []*introspection.Field{
+					{
+						Name: "cacheVolume",
+						Args: introspection.InputValues{
+							{
+								Name: "key",
+								TypeRef: &introspection.TypeRef{
+									Kind: introspection.TypeKindNonNull,
+									OfType: &introspection.TypeRef{
+										Kind: introspection.TypeKindScalar,
+										Name: "String",
+									},
+								},
+							},
+						},
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindObject,
+								Name: "CacheVolume",
+							},
+						},
+					},
+					{
+						Name: "syncCache",
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "ID",
+							},
+						},
+						Directives: introspection.Directives{
+							{
+								Name: "expectedType",
+								Args: []*introspection.DirectiveArg{
+									{Name: "name", Value: &expectedTypeValue},
+								},
+							},
+						},
+					},
+					{
+						Name: "useCache",
+						Args: introspection.InputValues{
+							{
+								Name: "cache",
+								TypeRef: &introspection.TypeRef{
+									Kind: introspection.TypeKindNonNull,
+									OfType: &introspection.TypeRef{
+										Kind: introspection.TypeKindScalar,
+										Name: "ID",
+									},
+								},
+								Directives: introspection.Directives{
+									{
+										Name: "expectedType",
+										Args: []*introspection.DirectiveArg{
+											{Name: "name", Value: &expectedTypeValue},
+										},
+									},
+								},
+							},
+						},
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "String",
+							},
+						},
+					},
+					{
+						Name: "useCaches",
+						Args: introspection.InputValues{
+							{
+								Name: "caches",
+								TypeRef: &introspection.TypeRef{
+									Kind: introspection.TypeKindNonNull,
+									OfType: &introspection.TypeRef{
+										Kind: introspection.TypeKindList,
+										OfType: &introspection.TypeRef{
+											Kind: introspection.TypeKindNonNull,
+											OfType: &introspection.TypeRef{
+												Kind: introspection.TypeKindScalar,
+												Name: "ID",
+											},
+										},
+									},
+								},
+								Directives: introspection.Directives{
+									{
+										Name: "expectedType",
+										Args: []*introspection.DirectiveArg{
+											{Name: "name", Value: &expectedTypeValue},
+										},
+									},
+								},
+							},
+						},
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "String",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/dang/project.go
+++ b/pkg/dang/project.go
@@ -702,6 +702,7 @@ func astTypeToIntrospection(schema *ast.Schema, t *ast.Definition) *introspectio
 	it := &introspection.Type{
 		Name:        t.Name,
 		Description: t.Description,
+		Directives:  astDirectivesToIntrospection(t.Directives),
 	}
 
 	switch t.Kind {
@@ -714,7 +715,9 @@ func astTypeToIntrospection(schema *ast.Schema, t *ast.Definition) *introspectio
 			if strings.HasPrefix(f.Name, "__") {
 				continue
 			}
-			it.Fields = append(it.Fields, astFieldToIntrospection(schema, f))
+			field := astFieldToIntrospection(schema, f)
+			field.ParentObject = it
+			it.Fields = append(it.Fields, field)
 		}
 		for _, iface := range t.Interfaces {
 			it.Interfaces = append(it.Interfaces, &introspection.Type{
@@ -725,7 +728,9 @@ func astTypeToIntrospection(schema *ast.Schema, t *ast.Definition) *introspectio
 	case ast.Interface:
 		it.Kind = introspection.TypeKindInterface
 		for _, f := range t.Fields {
-			it.Fields = append(it.Fields, astFieldToIntrospection(schema, f))
+			field := astFieldToIntrospection(schema, f)
+			field.ParentObject = it
+			it.Fields = append(it.Fields, field)
 		}
 	case ast.Union:
 		it.Kind = introspection.TypeKindUnion
@@ -743,6 +748,7 @@ func astTypeToIntrospection(schema *ast.Schema, t *ast.Definition) *introspectio
 				Description:       v.Description,
 				IsDeprecated:      v.Directives.ForName("deprecated") != nil,
 				DeprecationReason: deprecationReason(v.Directives),
+				Directives:        astDirectivesToIntrospection(v.Directives),
 			})
 		}
 	case ast.InputObject:
@@ -762,6 +768,7 @@ func astFieldToIntrospection(schema *ast.Schema, f *ast.FieldDefinition) *intros
 		TypeRef:           astTypeRefToIntrospection(schema, f.Type),
 		IsDeprecated:      f.Directives.ForName("deprecated") != nil,
 		DeprecationReason: deprecationReason(f.Directives),
+		Directives:        astDirectivesToIntrospection(f.Directives),
 	}
 	for _, arg := range f.Arguments {
 		field.Args = append(field.Args, astInputValueToIntrospection(schema, arg))
@@ -774,6 +781,7 @@ func astInputValueToIntrospection(schema *ast.Schema, v *ast.ArgumentDefinition)
 		Name:        v.Name,
 		Description: v.Description,
 		TypeRef:     astTypeRefToIntrospection(schema, v.Type),
+		Directives:  astDirectivesToIntrospection(v.Directives),
 	}
 	if v.DefaultValue != nil {
 		s := v.DefaultValue.String()
@@ -787,6 +795,7 @@ func astInputValueFromField(schema *ast.Schema, f *ast.FieldDefinition) introspe
 		Name:        f.Name,
 		Description: f.Description,
 		TypeRef:     astTypeRefToIntrospection(schema, f.Type),
+		Directives:  astDirectivesToIntrospection(f.Directives),
 	}
 	if f.DefaultValue != nil {
 		s := f.DefaultValue.String()
@@ -838,6 +847,31 @@ func astDirectiveToIntrospection(schema *ast.Schema, d *ast.DirectiveDefinition)
 		dd.Args = append(dd.Args, astInputValueToIntrospection(schema, arg))
 	}
 	return dd
+}
+
+func astDirectivesToIntrospection(directives ast.DirectiveList) introspection.Directives {
+	if len(directives) == 0 {
+		return nil
+	}
+	converted := make(introspection.Directives, 0, len(directives))
+	for _, d := range directives {
+		directive := &introspection.Directive{
+			Name: d.Name,
+		}
+		for _, arg := range d.Arguments {
+			var value *string
+			if arg.Value != nil {
+				v := arg.Value.String()
+				value = &v
+			}
+			directive.Args = append(directive.Args, &introspection.DirectiveArg{
+				Name:  arg.Name,
+				Value: value,
+			})
+		}
+		converted = append(converted, directive)
+	}
+	return converted
 }
 
 func deprecationReason(directives ast.DirectiveList) string {

--- a/pkg/dang/project_test.go
+++ b/pkg/dang/project_test.go
@@ -29,6 +29,7 @@ type Query {
   hello(name: String!): String!
   users: [User!]!
   status: Status!
+  expectedUser(id: ID! @expectedType(name: "User")): ID! @expectedType(name: "User")
 }
 
 type User implements Node {
@@ -43,6 +44,7 @@ input CreateUserInput {
 }
 
 directive @custom(message: String) on FIELD_DEFINITION
+directive @expectedType(name: String!) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 `
 
 	schema, err := SchemaFromSDL(sdl, "test.graphqls")
@@ -72,6 +74,18 @@ directive @custom(message: String) on FIELD_DEFINITION
 	// arg type should be String! (NON_NULL -> String)
 	require.Equal(t, introspection.TypeKindNonNull, helloField.Args[0].TypeRef.Kind)
 	require.Equal(t, "String", helloField.Args[0].TypeRef.OfType.Name)
+
+	var expectedUserField *introspection.Field
+	for _, f := range queryType.Fields {
+		if f.Name == "expectedUser" {
+			expectedUserField = f
+			break
+		}
+	}
+	require.NotNil(t, expectedUserField)
+	require.Equal(t, "User", expectedUserField.Directives.ExpectedType())
+	require.Len(t, expectedUserField.Args, 1)
+	require.Equal(t, "User", expectedUserField.Args[0].Directives.ExpectedType())
 
 	// Enum type
 	statusType := schema.Types.Get("Status")

--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -348,7 +348,7 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 		return fmt.Errorf("ClassDecl.Hoist: environment does not support module operations")
 	}
 
-	class, found := mod.NamedType(c.Name.Name)
+	class, found := mod.LocalNamedType(c.Name.Name)
 	if !found {
 		class = NewModule(c.Name.Name, ObjectKind)
 		mod.AddClass(c.Name.Name, class)
@@ -398,9 +398,14 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 					)
 				}
 
-				// Add "blindly" initially, we'll validate later
+				// Add "blindly" initially, we'll validate later. The reverse
+				// implementer index is only maintained for locally owned interfaces;
+				// Prelude interfaces are shared process-wide and must not be mutated
+				// by per-module declarations.
 				classMod.AddInterface(ifaceType)
-				ifaceMod.AddImplementer(classMod)
+				if localIface, found := mod.LocalNamedType(ifaceSym.Name); found && localIface == ifaceType {
+					ifaceMod.AddImplementer(classMod)
+				}
 			}
 		}
 	}
@@ -434,7 +439,7 @@ func (c *ClassDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 		return nil, fmt.Errorf("ClassDecl.Infer: environment does not support module operations")
 	}
 
-	class, found := mod.NamedType(c.Name.Name)
+	class, found := mod.LocalNamedType(c.Name.Name)
 	if !found {
 		class = NewModule(c.Name.Name, ObjectKind)
 		mod.AddClass(c.Name.Name, class)
@@ -724,7 +729,7 @@ func (e *EnumDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 	}
 
 	// Create the enum type (module) if it doesn't exist
-	enumType, found := mod.NamedType(e.Name.Name)
+	enumType, found := mod.LocalNamedType(e.Name.Name)
 	if !found {
 		enumType = NewModule(e.Name.Name, EnumKind)
 		mod.AddClass(e.Name.Name, enumType)
@@ -766,7 +771,7 @@ func (e *EnumDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.
 		return nil, fmt.Errorf("EnumDecl.Infer: environment does not support module operations")
 	}
 
-	enumType, found := mod.NamedType(e.Name.Name)
+	enumType, found := mod.LocalNamedType(e.Name.Name)
 	if !found {
 		enumType = NewModule(e.Name.Name, EnumKind)
 		mod.AddClass(e.Name.Name, enumType)
@@ -858,7 +863,7 @@ func (s *ScalarDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pa
 	}
 
 	// Create the scalar type (module) if it doesn't exist
-	scalarType, found := mod.NamedType(s.Name.Name)
+	scalarType, found := mod.LocalNamedType(s.Name.Name)
 	if !found {
 		scalarType = NewModule(s.Name.Name, ScalarKind)
 		mod.AddClass(s.Name.Name, scalarType)
@@ -883,7 +888,7 @@ func (s *ScalarDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (h
 		return nil, fmt.Errorf("ScalarDecl.Infer: environment does not support module operations")
 	}
 
-	scalarType, found := mod.NamedType(s.Name.Name)
+	scalarType, found := mod.LocalNamedType(s.Name.Name)
 	if !found {
 		scalarType = NewModule(s.Name.Name, ScalarKind)
 		mod.AddClass(s.Name.Name, scalarType)
@@ -982,7 +987,7 @@ func (i *InterfaceDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher)
 			return nil, fmt.Errorf("InterfaceDecl.Infer: environment does not support module operations")
 		}
 
-		iface, found := mod.NamedType(i.Name.Name)
+		iface, found := mod.LocalNamedType(i.Name.Name)
 		if !found {
 			return nil, fmt.Errorf("interface %s not found", i.Name.Name)
 		}
@@ -1088,7 +1093,7 @@ func (u *UnionDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 			return nil, fmt.Errorf("UnionDecl.Infer: environment does not support module operations")
 		}
 
-		unionType, found := mod.NamedType(u.Name.Name)
+		unionType, found := mod.LocalNamedType(u.Name.Name)
 		if !found {
 			return nil, fmt.Errorf("union %s not found", u.Name.Name)
 		}
@@ -1120,7 +1125,11 @@ func (u *UnionDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 				)
 			}
 
-			unionMod.AddMember(memberType)
+			if localMember, found := mod.LocalNamedType(memberSym.Name); found && localMember == memberType {
+				unionMod.LinkMember(memberType)
+			} else {
+				unionMod.AddMember(memberType)
+			}
 		}
 
 		u.Inferred = unionMod

--- a/pkg/introspection/introspection.go
+++ b/pkg/introspection/introspection.go
@@ -322,6 +322,18 @@ func (t Directives) ExperimentalReason() string {
 	return fromJSON[string](*t.Directive("experimental").Arg("reason").Value)
 }
 
+func (t Directives) ExpectedType() string {
+	d := t.Directive("expectedType")
+	if d == nil {
+		return ""
+	}
+	arg := d.Arg("name")
+	if arg == nil || arg.Value == nil {
+		return ""
+	}
+	return fromJSON[string](*arg.Value)
+}
+
 type SourceMap struct {
 	Module   string
 	Filename string

--- a/pkg/introspection/introspection.graphql
+++ b/pkg/introspection/introspection.graphql
@@ -38,6 +38,9 @@ fragment FullType on __Type {
     }
     isDeprecated
     deprecationReason
+    directives {
+      ...DirectiveApplication
+    }
   }
   inputFields {
     ...InputValue
@@ -50,6 +53,9 @@ fragment FullType on __Type {
     description
     isDeprecated
     deprecationReason
+    directives {
+      ...DirectiveApplication
+    }
   }
   possibleTypes {
     ...TypeRef
@@ -63,6 +69,17 @@ fragment InputValue on __InputValue {
     ...TypeRef
   }
   defaultValue
+  directives {
+    ...DirectiveApplication
+  }
+}
+
+fragment DirectiveApplication on _DirectiveApplication {
+  name
+  args {
+    name
+    value
+  }
 }
 
 fragment TypeRef on __Type {

--- a/tests/expected_type_test.go
+++ b/tests/expected_type_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func (DangSuite) TestExpectedTypeDirectivesFromIntrospection(ctx context.Context, t *testctx.T) {
+	// Use a client-only import instead of tests/dang.toml's SDL-backed import so
+	// Dang has to introspect the live server. This exercises the test server's
+	// extended introspection path for applied directives such as @expectedType.
 	testGraphQLServer, err := gqlserver.StartServer()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = testGraphQLServer.Stop() })

--- a/tests/expected_type_test.go
+++ b/tests/expected_type_test.go
@@ -1,0 +1,27 @@
+package tests
+
+import (
+	"context"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+	"github.com/vito/dang/pkg/dang"
+	"github.com/vito/dang/pkg/ioctx"
+	"github.com/vito/dang/tests/gqlserver"
+)
+
+func (DangSuite) TestExpectedTypeDirectivesFromIntrospection(ctx context.Context, t *testctx.T) {
+	testGraphQLServer, err := gqlserver.StartServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testGraphQLServer.Stop() })
+
+	client := graphql.NewClient(testGraphQLServer.QueryURL(), nil)
+	ctx = ioctx.StdoutToContext(ctx, NewTWriter(t))
+	ctx = dang.ContextWithImportConfigs(ctx, dang.ImportConfig{
+		Name:   "Test",
+		Client: client,
+	})
+
+	require.NoError(t, dang.RunFile(ctx, "test_expected_type.dang", false))
+}

--- a/tests/gqlserver/generated.go
+++ b/tests/gqlserver/generated.go
@@ -77,6 +77,9 @@ type ComplexityRoot struct {
 
 	Query struct {
 		AddBigInt         func(childComplexity int, a string, b string) int
+		FavoriteNodeID    func(childComplexity int) int
+		FavoriteUserID    func(childComplexity int) int
+		FavoriteUserIDs   func(childComplexity int) int
 		FetchMultipleURLs func(childComplexity int, urls []string) int
 		FetchURL          func(childComplexity int, url string) int
 		FetchURLNullable  func(childComplexity int, url *string) int
@@ -84,18 +87,23 @@ type ComplexityRoot struct {
 		Hello             func(childComplexity int, name string) int
 		Homepage          func(childComplexity int) int
 		Node              func(childComplexity int, id string) int
+		NodeLabel         func(childComplexity int, node string) int
 		Nodes             func(childComplexity int) int
 		Now               func(childComplexity int) int
 		ParseJSON         func(childComplexity int, data string) int
 		PostTitles        func(childComplexity int) int
 		Posts             func(childComplexity int, authorID *string, limit *int) int
+		PrimaryUser       func(childComplexity int) int
 		Search            func(childComplexity int, query string) int
 		SearchConnection  func(childComplexity int, query string) int
+		SecondaryUser     func(childComplexity int) int
 		ServerInfo        func(childComplexity int) int
 		SortedUsers       func(childComplexity int, sort UserSort) int
 		Status            func(childComplexity int) int
 		Timestamped       func(childComplexity int) int
 		User              func(childComplexity int, id string) int
+		UserName          func(childComplexity int, user string) int
+		UserNames         func(childComplexity int, users []string) int
 		UserProfile       func(childComplexity int, userID *string, includeStats *bool) int
 		Users             func(childComplexity int) int
 		UsersByStatus     func(childComplexity int, status Status) int
@@ -125,6 +133,7 @@ type ComplexityRoot struct {
 		Name   func(childComplexity int) int
 		Posts  func(childComplexity int, first *int, after *string, last *int, before *string) int
 		Status func(childComplexity int) int
+		Sync   func(childComplexity int) int
 	}
 
 	UserProfile struct {
@@ -146,6 +155,14 @@ type QueryResolver interface {
 	Hello(ctx context.Context, name string) (string, error)
 	Users(ctx context.Context) ([]*User, error)
 	User(ctx context.Context, id string) (*User, error)
+	PrimaryUser(ctx context.Context) (*User, error)
+	SecondaryUser(ctx context.Context) (*User, error)
+	UserName(ctx context.Context, user string) (string, error)
+	UserNames(ctx context.Context, users []string) ([]string, error)
+	NodeLabel(ctx context.Context, node string) (string, error)
+	FavoriteUserID(ctx context.Context) (string, error)
+	FavoriteUserIDs(ctx context.Context) ([]string, error)
+	FavoriteNodeID(ctx context.Context) (string, error)
 	ServerInfo(ctx context.Context) (*ServerInfo, error)
 	Posts(ctx context.Context, authorID *string, limit *int) ([]*Post, error)
 	UserProfile(ctx context.Context, userID *string, includeStats *bool) (*UserProfile, error)
@@ -169,6 +186,7 @@ type QueryResolver interface {
 }
 type UserResolver interface {
 	Posts(ctx context.Context, obj *User, first *int, after *string, last *int, before *string) (*PostConnection, error)
+	Sync(ctx context.Context, obj *User) (string, error)
 }
 
 type executableSchema struct {
@@ -304,6 +322,24 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.AddBigInt(childComplexity, args["a"].(string), args["b"].(string)), true
+	case "Query.favoriteNodeID":
+		if e.complexity.Query.FavoriteNodeID == nil {
+			break
+		}
+
+		return e.complexity.Query.FavoriteNodeID(childComplexity), true
+	case "Query.favoriteUserID":
+		if e.complexity.Query.FavoriteUserID == nil {
+			break
+		}
+
+		return e.complexity.Query.FavoriteUserID(childComplexity), true
+	case "Query.favoriteUserIDs":
+		if e.complexity.Query.FavoriteUserIDs == nil {
+			break
+		}
+
+		return e.complexity.Query.FavoriteUserIDs(childComplexity), true
 	case "Query.fetchMultipleURLs":
 		if e.complexity.Query.FetchMultipleURLs == nil {
 			break
@@ -376,6 +412,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Node(childComplexity, args["id"].(string)), true
+	case "Query.nodeLabel":
+		if e.complexity.Query.NodeLabel == nil {
+			break
+		}
+
+		args, err := ec.field_Query_nodeLabel_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.NodeLabel(childComplexity, args["node"].(string)), true
 	case "Query.nodes":
 		if e.complexity.Query.Nodes == nil {
 			break
@@ -416,6 +463,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Posts(childComplexity, args["authorId"].(*string), args["limit"].(*int)), true
+	case "Query.primaryUser":
+		if e.complexity.Query.PrimaryUser == nil {
+			break
+		}
+
+		return e.complexity.Query.PrimaryUser(childComplexity), true
 	case "Query.search":
 		if e.complexity.Query.Search == nil {
 			break
@@ -438,6 +491,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.SearchConnection(childComplexity, args["query"].(string)), true
+	case "Query.secondaryUser":
+		if e.complexity.Query.SecondaryUser == nil {
+			break
+		}
+
+		return e.complexity.Query.SecondaryUser(childComplexity), true
 	case "Query.serverInfo":
 		if e.complexity.Query.ServerInfo == nil {
 			break
@@ -478,6 +537,28 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.User(childComplexity, args["id"].(string)), true
+	case "Query.userName":
+		if e.complexity.Query.UserName == nil {
+			break
+		}
+
+		args, err := ec.field_Query_userName_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.UserName(childComplexity, args["user"].(string)), true
+	case "Query.userNames":
+		if e.complexity.Query.UserNames == nil {
+			break
+		}
+
+		args, err := ec.field_Query_userNames_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.UserNames(childComplexity, args["users"].([]string)), true
 	case "Query.userProfile":
 		if e.complexity.Query.UserProfile == nil {
 			break
@@ -599,6 +680,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.User.Status(childComplexity), true
+	case "User.sync":
+		if e.complexity.User.Sync == nil {
+			break
+		}
+
+		return e.complexity.User.Sync(childComplexity), true
 
 	case "UserProfile.averagePostLength":
 		if e.complexity.UserProfile.AveragePostLength == nil {
@@ -895,6 +982,17 @@ func (ec *executionContext) field_Query_hello_args(ctx context.Context, rawArgs 
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_nodeLabel_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "node", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["node"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_node_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -963,6 +1061,28 @@ func (ec *executionContext) field_Query_sortedUsers_args(ctx context.Context, ra
 		return nil, err
 	}
 	args["sort"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_userName_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "user", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["user"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_userNames_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "users", ec.unmarshalNID2ᚕstringᚄ)
+	if err != nil {
+		return nil, err
+	}
+	args["users"] = arg0
 	return args, nil
 }
 
@@ -1119,6 +1239,8 @@ func (ec *executionContext) fieldContext_Mutation_createUser(ctx context.Context
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1174,6 +1296,8 @@ func (ec *executionContext) fieldContext_Mutation_updateUser(ctx context.Context
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1472,6 +1596,8 @@ func (ec *executionContext) fieldContext_Post_author(_ context.Context, field gr
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1665,6 +1791,8 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1709,6 +1837,8 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1723,6 +1853,306 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 	if fc.Args, err = ec.field_Query_user_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_primaryUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_primaryUser,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().PrimaryUser(ctx)
+		},
+		nil,
+		ec.marshalNUser2ᚖgithubᚗcomᚋvitoᚋdangᚋtestsᚋgqlserverᚐUser,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_primaryUser(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "emails":
+				return ec.fieldContext_User_emails(ctx, field)
+			case "age":
+				return ec.fieldContext_User_age(ctx, field)
+			case "status":
+				return ec.fieldContext_User_status(ctx, field)
+			case "posts":
+				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_secondaryUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_secondaryUser,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().SecondaryUser(ctx)
+		},
+		nil,
+		ec.marshalNUser2ᚖgithubᚗcomᚋvitoᚋdangᚋtestsᚋgqlserverᚐUser,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_secondaryUser(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "emails":
+				return ec.fieldContext_User_emails(ctx, field)
+			case "age":
+				return ec.fieldContext_User_age(ctx, field)
+			case "status":
+				return ec.fieldContext_User_status(ctx, field)
+			case "posts":
+				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_userName(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_userName,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().UserName(ctx, fc.Args["user"].(string))
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_userName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_userName_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_userNames(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_userNames,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().UserNames(ctx, fc.Args["users"].([]string))
+		},
+		nil,
+		ec.marshalNString2ᚕstringᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_userNames(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_userNames_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_nodeLabel(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_nodeLabel,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().NodeLabel(ctx, fc.Args["node"].(string))
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_nodeLabel(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_nodeLabel_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_favoriteUserID(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_favoriteUserID,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().FavoriteUserID(ctx)
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_favoriteUserID(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_favoriteUserIDs(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_favoriteUserIDs,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().FavoriteUserIDs(ctx)
+		},
+		nil,
+		ec.marshalNID2ᚕstringᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_favoriteUserIDs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_favoriteNodeID(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_favoriteNodeID,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().FavoriteNodeID(ctx)
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_favoriteNodeID(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
 	}
 	return fc, nil
 }
@@ -2462,6 +2892,8 @@ func (ec *executionContext) fieldContext_Query_usersByStatus(ctx context.Context
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -2517,6 +2949,8 @@ func (ec *executionContext) fieldContext_Query_sortedUsers(ctx context.Context, 
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -3071,6 +3505,35 @@ func (ec *executionContext) fieldContext_User_posts(ctx context.Context, field g
 	return fc, nil
 }
 
+func (ec *executionContext) _User_sync(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_sync,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.User().Sync(ctx, obj)
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_sync(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserProfile_user(ctx context.Context, field graphql.CollectedField, obj *UserProfile) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3107,6 +3570,8 @@ func (ec *executionContext) fieldContext_UserProfile_user(_ context.Context, fie
 				return ec.fieldContext_User_status(ctx, field)
 			case "posts":
 				return ec.fieldContext_User_posts(ctx, field)
+			case "sync":
+				return ec.fieldContext_User_sync(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -5184,6 +5649,182 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "primaryUser":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_primaryUser(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "secondaryUser":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_secondaryUser(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "userName":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_userName(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "userNames":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_userNames(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "nodeLabel":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_nodeLabel(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "favoriteUserID":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_favoriteUserID(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "favoriteUserIDs":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_favoriteUserIDs(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "favoriteNodeID":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_favoriteNodeID(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "serverInfo":
 			field := field
 
@@ -5857,6 +6498,42 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "sync":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_sync(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6305,6 +6982,52 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 func (ec *executionContext) unmarshalNCreateUserInput2githubᚗcomᚋvitoᚋdangᚋtestsᚋgqlserverᚐCreateUserInput(ctx context.Context, v any) (CreateUserInput, error) {
 	res, err := ec.unmarshalInputCreateUserInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNID2string(ctx context.Context, v any) (string, error) {
+	res, err := graphql.UnmarshalID(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalID(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNID2ᚕstringᚄ(ctx context.Context, v any) ([]string, error) {
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNID2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNID2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNID2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v any) (int, error) {

--- a/tests/gqlserver/gqlgen.yml
+++ b/tests/gqlserver/gqlgen.yml
@@ -14,3 +14,7 @@ resolver:
   package: gqlserver
   layout: single-file
   filename: resolvers.go
+
+directives:
+  expectedType:
+    skip_runtime: true

--- a/tests/gqlserver/models_gen.go
+++ b/tests/gqlserver/models_gen.go
@@ -93,6 +93,7 @@ type User struct {
 	Age    *int            `json:"age,omitempty"`
 	Status Status          `json:"status"`
 	Posts  *PostConnection `json:"posts"`
+	Sync   string          `json:"sync"`
 }
 
 func (User) IsNode()            {}

--- a/tests/gqlserver/resolvers.go
+++ b/tests/gqlserver/resolvers.go
@@ -76,6 +76,82 @@ func (r *queryResolver) User(ctx context.Context, id string) (*User, error) {
 	return nil, fmt.Errorf("user not found")
 }
 
+// PrimaryUser is the resolver for the primaryUser field.
+func (r *queryResolver) PrimaryUser(ctx context.Context) (*User, error) {
+	if len(users) == 0 {
+		return nil, fmt.Errorf("no users available")
+	}
+	return users[0], nil
+}
+
+// SecondaryUser is the resolver for the secondaryUser field.
+func (r *queryResolver) SecondaryUser(ctx context.Context) (*User, error) {
+	if len(users) < 2 {
+		return nil, fmt.Errorf("secondary user not available")
+	}
+	return users[1], nil
+}
+
+// UserName is the resolver for the userName field.
+func (r *queryResolver) UserName(ctx context.Context, user string) (string, error) {
+	found, err := findUserByID(user)
+	if err != nil {
+		return "", err
+	}
+	return found.Name, nil
+}
+
+// UserNames is the resolver for the userNames field.
+func (r *queryResolver) UserNames(ctx context.Context, users []string) ([]string, error) {
+	names := make([]string, 0, len(users))
+	for _, id := range users {
+		user, err := findUserByID(id)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, user.Name)
+	}
+	return names, nil
+}
+
+// NodeLabel is the resolver for the nodeLabel field.
+func (r *queryResolver) NodeLabel(ctx context.Context, node string) (string, error) {
+	found, err := r.findNodeByID(node)
+	if err != nil {
+		return "", err
+	}
+	switch n := found.(type) {
+	case *User:
+		return "User:" + n.Name, nil
+	case *Post:
+		return "Post:" + n.Title, nil
+	default:
+		return "", fmt.Errorf("node not found")
+	}
+}
+
+// FavoriteUserID is the resolver for the favoriteUserID field.
+func (r *queryResolver) FavoriteUserID(ctx context.Context) (string, error) {
+	if len(users) == 0 {
+		return "", fmt.Errorf("no users available")
+	}
+	return users[0].ID, nil
+}
+
+// FavoriteUserIDs is the resolver for the favoriteUserIDs field.
+func (r *queryResolver) FavoriteUserIDs(ctx context.Context) ([]string, error) {
+	ids := make([]string, 0, len(users))
+	for _, user := range users {
+		ids = append(ids, user.ID)
+	}
+	return ids, nil
+}
+
+// FavoriteNodeID is the resolver for the favoriteNodeID field.
+func (r *queryResolver) FavoriteNodeID(ctx context.Context) (string, error) {
+	return r.FavoriteUserID(ctx)
+}
+
 // ServerInfo is the resolver for the serverInfo field.
 func (r *queryResolver) ServerInfo(ctx context.Context) (*ServerInfo, error) {
 	uptime := time.Since(serverStartTime)
@@ -309,6 +385,11 @@ func (r *userResolver) Posts(ctx context.Context, obj *User, first *int, after *
 
 	// Implement cursor-based pagination
 	return paginatePosts(userPosts, first, after, last, before)
+}
+
+// Sync is the resolver for the sync field.
+func (r *userResolver) Sync(ctx context.Context, obj *User) (string, error) {
+	return obj.ID, nil
 }
 
 // Mutation returns MutationResolver implementation.

--- a/tests/gqlserver/resolvers.helpers.go
+++ b/tests/gqlserver/resolvers.helpers.go
@@ -1,6 +1,9 @@
 package gqlserver
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // paginatePosts implements cursor-based pagination for posts using Post ID as cursor
 func paginatePosts(posts []*Post, first *int, after *string, last *int, before *string) (*PostConnection, error) {
@@ -95,6 +98,15 @@ func paginatePosts(posts []*Post, first *int, after *string, last *int, before *
 			EndCursor:       endCursor,
 		},
 	}, nil
+}
+
+func findUserByID(id string) (*User, error) {
+	for _, user := range users {
+		if user.ID == id {
+			return user, nil
+		}
+	}
+	return nil, fmt.Errorf("user not found")
 }
 
 // findNodeByID finds a node (User or Post) by ID

--- a/tests/gqlserver/schema.graphqls
+++ b/tests/gqlserver/schema.graphqls
@@ -1,3 +1,8 @@
+directive @expectedType(
+  """The name of the expected object or interface type."""
+  name: String!
+) on ARGUMENT_DEFINITION | FIELD_DEFINITION
+
 enum Status {
   ACTIVE
   INACTIVE
@@ -22,6 +27,14 @@ type Query {
   hello(name: String!): String!
   users: [User!]!
   user(id: String!): User
+  primaryUser: User!
+  secondaryUser: User!
+  userName(user: ID! @expectedType(name: "User")): String!
+  userNames(users: [ID!]! @expectedType(name: "User")): [String!]!
+  nodeLabel(node: ID! @expectedType(name: "Node")): String!
+  favoriteUserID: ID! @expectedType(name: "User")
+  favoriteUserIDs: [ID!]! @expectedType(name: "User")
+  favoriteNodeID: ID! @expectedType(name: "Node")
   serverInfo: ServerInfo!
   posts(authorId: String, limit: Int): [Post!]!
   userProfile(userId: String, includeStats: Boolean): UserProfile
@@ -73,6 +86,7 @@ type User implements Node {
   age: Int
   status: Status!
   posts(first: Int, after: String, last: Int, before: String): PostConnection! @goField(forceResolver: true)
+  sync: ID! @expectedType(name: "User") @goField(forceResolver: true)
 }
 
 type Post implements Node & Timestamped {

--- a/tests/gqlserver/server.go
+++ b/tests/gqlserver/server.go
@@ -3,13 +3,21 @@ package gqlserver
 //go:generate go run github.com/99designs/gqlgen generate
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
+	"github.com/vito/dang/pkg/dang"
+	"github.com/vito/dang/pkg/introspection"
 )
 
 type Server struct {
@@ -31,10 +39,15 @@ func StartServer() (*Server, error) {
 	// Create GraphQL handler
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
 
+	introspectionSchema, err := loadIntrospectionSchema()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create HTTP mux
 	mux := http.NewServeMux()
 	mux.Handle("/", playground.Handler("GraphQL playground", "/query"))
-	mux.Handle("/query", srv)
+	mux.Handle("/query", introspectionHandler(srv, introspectionSchema))
 
 	// Create HTTP server
 	httpServer := &http.Server{
@@ -55,6 +68,56 @@ func StartServer() (*Server, error) {
 	}()
 
 	return server, nil
+}
+
+func loadIntrospectionSchema() (*introspection.Schema, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("failed to locate gqlserver source")
+	}
+	schemaPath := filepath.Join(filepath.Dir(filename), "schema.graphqls")
+	schema, err := dang.SchemaFromSDLFile(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading GraphQL test schema for introspection: %w", err)
+	}
+	return schema, nil
+}
+
+func introspectionHandler(next http.Handler, schema *introspection.Schema) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_ = r.Body.Close()
+
+		var req struct {
+			Query string `json:"query"`
+		}
+		if err := json.Unmarshal(body, &req); err == nil && isExtendedIntrospectionQuery(req.Query) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(struct {
+				Data struct {
+					Schema *introspection.Schema `json:"__schema"`
+				} `json:"data"`
+			}{
+				Data: struct {
+					Schema *introspection.Schema `json:"__schema"`
+				}{
+					Schema: schema,
+				},
+			})
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isExtendedIntrospectionQuery(query string) bool {
+	return strings.Contains(query, "_DirectiveApplication")
 }
 
 // Stop gracefully stops the server

--- a/tests/gqlserver/server.go
+++ b/tests/gqlserver/server.go
@@ -39,6 +39,10 @@ func StartServer() (*Server, error) {
 	// Create GraphQL handler
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
 
+	// Dang asks GraphQL servers for applied directive metadata using Dagger's
+	// "extended introspection" fields. gqlgen only implements the standard
+	// introspection schema, so keep a Dang-friendly schema handy and intercept
+	// just those extended introspection requests below.
 	introspectionSchema, err := loadIntrospectionSchema()
 	if err != nil {
 		return nil, err
@@ -70,6 +74,9 @@ func StartServer() (*Server, error) {
 	return server, nil
 }
 
+// loadIntrospectionSchema converts this test server's SDL into Dang's
+// introspection shape. This preserves applied directives from schema.graphqls
+// without maintaining a large handwritten introspection JSON fixture.
 func loadIntrospectionSchema() (*introspection.Schema, error) {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -83,6 +90,14 @@ func loadIntrospectionSchema() (*introspection.Schema, error) {
 	return schema, nil
 }
 
+// introspectionHandler serves Dagger-style extended introspection for Dang's
+// schema loader while delegating ordinary GraphQL operations to gqlgen.
+//
+// The non-standard part is the `_DirectiveApplication` type plus `directives`
+// fields on introspection objects such as __Field and __InputValue. Dang uses
+// these to discover applied directives like @expectedType. Since gqlgen rejects
+// those fields during validation, tests intercept that specific query and return
+// the equivalent schema converted from SDL.
 func introspectionHandler(next http.Handler, schema *introspection.Schema) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -117,6 +132,8 @@ func introspectionHandler(next http.Handler, schema *introspection.Schema) http.
 }
 
 func isExtendedIntrospectionQuery(query string) bool {
+	// Standard introspection queries should continue through gqlgen. Dang's
+	// extended query is identifiable by the Dagger-only fragment type.
 	return strings.Contains(query, "_DirectiveApplication")
 }
 

--- a/tests/test_expected_type.dang
+++ b/tests/test_expected_type.dang
@@ -1,0 +1,39 @@
+# Test @expectedType directives on GraphQL ID arguments and return values.
+# The GraphQL test server exposes ID-typed fields/arguments annotated with
+# @expectedType so Dang can treat those IDs as object/interface handles.
+
+import Test
+
+pub john = primaryUser
+pub jane = secondaryUser
+
+# ID arguments annotated with @expectedType(name: "User") accept User objects.
+assert { userName(user: john) == "John Doe" }
+assert { userName(user: jane) == "Jane Smith" }
+
+# Lists of ID arguments preserve the expected object type for each element.
+pub selectedNames = userNames(users: [john, jane])
+assert { selectedNames[0] == "John Doe" }
+assert { selectedNames[1] == "Jane Smith" }
+
+# Interface expectations accept concrete implementers.
+assert { nodeLabel(node: john) == "User:John Doe" }
+
+# ID return values annotated with @expectedType(name: "User") infer as the
+# expected object type and can flow into arguments expecting that object type.
+pub returnedUser: User! = favoriteUserID
+pub syncedUser: User! = john.sync
+assert { userName(user: returnedUser) == "John Doe" }
+assert { userName(user: syncedUser) == "John Doe" }
+
+# Lists of ID return values preserve the expected object type for downstream args.
+pub returnedUsers: [User!]! = favoriteUserIDs
+pub favoriteNames = userNames(users: returnedUsers)
+assert { favoriteNames[0] == "John Doe" }
+assert { favoriteNames[1] == "Jane Smith" }
+
+# Return values can also carry interface expectations.
+pub returnedNode: Node! = favoriteNodeID
+assert { nodeLabel(node: returnedNode) == "User:John Doe" }
+
+print("expectedType directive tests passed!")


### PR DESCRIPTION
## Summary
- extend the GraphQL test server with @expectedType on ID arguments and return fields
- preserve SDL-applied directives when building Dang introspection schemas
- add integration coverage for object and interface expected ID flows

## Tests
- go test ./pkg/dang ./tests/...
