### PR TITLE
fix(dang): make class hoisting order-independent

### DIFF
--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -354,6 +354,14 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 		mod.AddClass(c.Name.Name, class)
 	}
 
+	// Pass 0 must only register the type name. Other top-level types may refer
+	// to this class before its file is reached, so anything that resolves field
+	// annotations, constructor params, or implemented interfaces has to wait
+	// until every type has had this registration pass.
+	if pass == 0 {
+		return nil
+	}
+
 	inferEnv := &CompositeModule{
 		primary: class,
 		lexical: env.(Env),
@@ -377,55 +385,52 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 	constructorScheme := hm.NewScheme(nil, constructorType)
 	env.Add(c.Name.Name, constructorScheme)
 
-	if pass == 0 {
-		// Link the implementation
-		if len(c.Implements) > 0 {
-			classMod := class.(*Module)
-			for _, ifaceSym := range c.Implements {
-				ifaceType, found := mod.NamedType(ifaceSym.Name)
-				if !found {
-					return WrapInferError(
-						fmt.Errorf("interface %s not found", ifaceSym.Name),
-						ifaceSym,
-					)
-				}
+	// Link the implementation after all interface type names have been
+	// registered by pass 0.
+	if len(c.Implements) > 0 {
+		classMod := class.(*Module)
+		for _, ifaceSym := range c.Implements {
+			ifaceType, found := mod.NamedType(ifaceSym.Name)
+			if !found {
+				return WrapInferError(
+					fmt.Errorf("interface %s not found", ifaceSym.Name),
+					ifaceSym,
+				)
+			}
 
-				ifaceMod, ok := ifaceType.(*Module)
-				if !ok || ifaceMod.Kind != InterfaceKind {
-					return WrapInferError(
-						fmt.Errorf("%s is not an interface", ifaceSym.Name),
-						ifaceSym,
-					)
-				}
+			ifaceMod, ok := ifaceType.(*Module)
+			if !ok || ifaceMod.Kind != InterfaceKind {
+				return WrapInferError(
+					fmt.Errorf("%s is not an interface", ifaceSym.Name),
+					ifaceSym,
+				)
+			}
 
-				// Add "blindly" initially, we'll validate later. The reverse
-				// implementer index is only maintained for locally owned interfaces;
-				// Prelude interfaces are shared process-wide and must not be mutated
-				// by per-module declarations.
-				classMod.AddInterface(ifaceType)
-				if localIface, found := mod.LocalNamedType(ifaceSym.Name); found && localIface == ifaceType {
-					ifaceMod.AddImplementer(classMod)
-				}
+			// Add "blindly" initially, we'll validate later. The reverse
+			// implementer index is only maintained for locally owned interfaces;
+			// Prelude interfaces are shared process-wide and must not be mutated
+			// by per-module declarations.
+			classMod.AddInterface(ifaceType)
+			if localIface, found := mod.LocalNamedType(ifaceSym.Name); found && localIface == ifaceType {
+				ifaceMod.AddImplementer(classMod)
 			}
 		}
 	}
 
-	if pass > 0 {
-		// Set dynamic scope type to the class type
-		selfType := hm.NonNullType{Type: class}
-		class.SetDynamicScopeType(selfType)
+	// Set dynamic scope type to the class type
+	selfType := hm.NonNullType{Type: class}
+	class.SetDynamicScopeType(selfType)
 
-		// Hoist body forms directly (not via Block.Hoist which clones the env)
-		// to register method signatures on the class module. This enables
-		// forward references between types defined in any order. We hoist at
-		// pass 0 so that FunDecl.Hoist registers signatures and
-		// SlotDecl.Hoist registers typed field declarations.
-		bodyForms := c.bodyFormsWithoutNew()
-		for _, form := range bodyForms {
-			if hoister, ok := form.(Hoister); ok {
-				if err := hoister.Hoist(ctx, inferEnv, fresh, 0); err != nil {
-					return err
-				}
+	// Hoist body forms directly (not via Block.Hoist which clones the env)
+	// to register method signatures on the class module. This enables
+	// forward references between types defined in any order. We hoist at
+	// pass 0 so that FunDecl.Hoist registers signatures and
+	// SlotDecl.Hoist registers typed field declarations.
+	bodyForms := c.bodyFormsWithoutNew()
+	for _, form := range bodyForms {
+		if hoister, ok := form.(Hoister); ok {
+			if err := hoister.Hoist(ctx, inferEnv, fresh, 0); err != nil {
+				return err
 			}
 		}
 	}

--- a/tests/test_dir_order_independent/a_consumer.dang
+++ b/tests/test_dir_order_independent/a_consumer.dang
@@ -1,0 +1,13 @@
+# These declarations intentionally refer to types in z_types.dang.
+
+type UsesLater {
+  let later: Later!
+
+  pub label: String! {
+    later.name
+  }
+}
+
+type ImplementsLater implements LaterInterface {
+  pub name: String!
+}

--- a/tests/test_dir_order_independent/m_main.dang
+++ b/tests/test_dir_order_independent/m_main.dang
@@ -1,0 +1,8 @@
+let later = Later("Ada")
+let uses = UsesLater(later)
+let impl = ImplementsLater("Grace")
+
+assert { uses.label == "Ada" }
+assert { impl.name == "Grace" }
+
+print("Order-independent directory loading works!")

--- a/tests/test_dir_order_independent/z_types.dang
+++ b/tests/test_dir_order_independent/z_types.dang
@@ -1,0 +1,7 @@
+type Later {
+  pub name: String!
+}
+
+interface LaterInterface {
+  pub name: String!
+}

--- a/tests/testdata/ambiguous_directive.golden
+++ b/tests/testdata/ambiguous_directive.golden
@@ -1,4 +1,4 @@
-3 inference errors:
+2 inference errors:
 
 Error 1:
 [1m[31mError:[0m ambiguous reference to directive @experimental: provided by imports [Other Test]
@@ -14,19 +14,6 @@ Error 1:
 
 
 Error 2:
-[1m[31mError:[0m ambiguous reference to directive @experimental: provided by imports [Other Test]
-  [2m[34m--> errors/ambiguous_directive.dang:9:21[0m
- [2m    |[0m
- [2m  7 | # Using unqualified @experimental should fail[0m
- [2m  8 | type MyType {[0m
- [2m[34m[1m  9 | [0m  pub field: String! @experimental
-[2m                           [31m^^^^^^^^^^^^^^[0m
- [2m 10 | }[0m
- [2m 11 | [0m
- [2m    |[0m
-
-
-Error 3:
 [1m[31mError:[0m ambiguous reference to directive @experimental: provided by imports [Other Test]
   [2m[34m--> errors/ambiguous_directive.dang:9:21[0m
  [2m    |[0m

--- a/tests/testdata/directive_positional_after_named.golden
+++ b/tests/testdata/directive_positional_after_named.golden
@@ -1,4 +1,4 @@
-3 inference errors:
+2 inference errors:
 
 Error 1:
 [1m[31mError:[0m DirectiveApplication.Infer: positional arguments must come before named arguments
@@ -14,19 +14,6 @@ Error 1:
 
 
 Error 2:
-[1m[31mError:[0m DirectiveApplication.Infer: positional arguments must come before named arguments
-  [2m[34m--> errors/directive_positional_after_named.dang:7:21[0m
- [2m    |[0m
- [2m  5 | type Test {[0m
- [2m  6 |   # This should fail: positional arg after named arg[0m
- [2m[34m[1m  7 | [0m  pub field: String! @example(a: "named", "positional")
-[2m                           [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
- [2m  8 | }[0m
- [2m  9 | [0m
- [2m    |[0m
-
-
-Error 3:
 [1m[31mError:[0m DirectiveApplication.Infer: positional arguments must come before named arguments
   [2m[34m--> errors/directive_positional_after_named.dang:7:21[0m
  [2m    |[0m


### PR DESCRIPTION
https://github.com/shykes/dagger-go-sdk @ [`a8308261be03ee8878c048629f7f91e73ec84b40`](https://github.com/shykes/dagger-go-sdk/tree/a8308261be03ee8878c048629f7f91e73ec84b40) has to resort to `00-` filename prefixes to control ordering that files are loaded. This PR fixes that. We already had the code infra as Dang already implements Go-style directory-level modularity. Just needed a small tweak for class declarations to register their names and do nothing else for the first pass.