### PR TITLE
Failing test for graphql list selection

### DIFF
--- a/tests/test_graphql_multiselect_index.dang
+++ b/tests/test_graphql_multiselect_index.dang
@@ -1,0 +1,10 @@
+# Regression test for indexing a GraphQL list after a multiselect containing
+# a field call with a positional argument and no nested selection.
+
+import Test
+
+pub first_user = users.{posts(1)}[0]
+
+assert { first_user.posts != null }
+
+print("GraphQL multiselect indexing tests passed!")


### PR DESCRIPTION
The actual thing I'm trying to do:

```graphql
let file = Dagger.http("https://www.php.net/releases/index.php?json&version=8")
let metadata = file.asJSON

metadata.field(["source"]).asArray.{field("filename")}[0].field
```

Related #46