### PR TITLE
support shadowing imported types

### DIFF
--- a/pkg/dang/ast.go
+++ b/pkg/dang/ast.go
@@ -549,6 +549,14 @@ func (c *CompositeModule) Add(name string, scheme *hm.Scheme) hm.Env {
 	return c
 }
 
+func (c *CompositeModule) SetValueOrigin(name string, origin BindingOrigin) {
+	c.primary.SetValueOrigin(name, origin)
+}
+
+func (c *CompositeModule) LocalValueOrigin(name string) (BindingOrigin, bool) {
+	return c.primary.LocalValueOrigin(name)
+}
+
 func (c *CompositeModule) SetVisibility(name string, visibility Visibility) {
 	c.primary.SetVisibility(name, visibility)
 }
@@ -662,20 +670,12 @@ func (c *CompositeModule) AddClass(name string, class Env) {
 	c.primary.AddClass(name, class)
 }
 
-// TrackUnqualifiedTypeImport delegates to the primary module
-func (c *CompositeModule) TrackUnqualifiedTypeImport(symbolName, importName string) bool {
-	if mod, ok := c.primary.(*Module); ok {
-		return mod.TrackUnqualifiedTypeImport(symbolName, importName)
-	}
-	return false
+func (c *CompositeModule) SetTypeOrigin(name string, origin BindingOrigin) {
+	c.primary.SetTypeOrigin(name, origin)
 }
 
-// TrackUnqualifiedValueImport delegates to the primary module
-func (c *CompositeModule) TrackUnqualifiedValueImport(symbolName, importName string) bool {
-	if mod, ok := c.primary.(*Module); ok {
-		return mod.TrackUnqualifiedValueImport(symbolName, importName)
-	}
-	return false
+func (c *CompositeModule) LocalTypeOrigin(name string) (BindingOrigin, bool) {
+	return c.primary.LocalTypeOrigin(name)
 }
 
 // CheckTypeConflict delegates to the primary module
@@ -702,14 +702,6 @@ func (c *CompositeModule) CheckValueConflict(symbolName string) []string {
 	return imports
 }
 
-// TrackUnqualifiedDirectiveImport delegates to the primary module
-func (c *CompositeModule) TrackUnqualifiedDirectiveImport(directiveName, importName string) bool {
-	if mod, ok := c.primary.(*Module); ok {
-		return mod.TrackUnqualifiedDirectiveImport(directiveName, importName)
-	}
-	return false
-}
-
 // CheckDirectiveConflict delegates to the primary module
 func (c *CompositeModule) CheckDirectiveConflict(directiveName string) []string {
 	imports := c.primary.CheckDirectiveConflict(directiveName)
@@ -725,6 +717,14 @@ func (c *CompositeModule) CheckDirectiveConflict(directiveName string) []string 
 // AddDirective adds a directive to the primary environment
 func (c *CompositeModule) AddDirective(name string, directive *DirectiveDecl) {
 	c.primary.AddDirective(name, directive)
+}
+
+func (c *CompositeModule) SetDirectiveOrigin(name string, origin BindingOrigin) {
+	c.primary.SetDirectiveOrigin(name, origin)
+}
+
+func (c *CompositeModule) LocalDirectiveOrigin(name string) (BindingOrigin, bool) {
+	return c.primary.LocalDirectiveOrigin(name)
 }
 
 // GetDirective gets a directive from either environment

--- a/pkg/dang/ast_declarations.go
+++ b/pkg/dang/ast_declarations.go
@@ -1184,17 +1184,7 @@ func (i *ImportDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (h
 			i.client = client
 			i.schema = schema
 
-			// Register type for the module
-			// TOOD: is this useful? i guess it means we can pass GH around which is
-			// kinda neat?
-			dangEnv.AddClass(i.Name.Name, schemaModule)
-
-			// Also add as a scheme so the type checker can find it
-			dangEnv.Add(i.Name.Name, hm.NewScheme(nil, NonNull(schemaModule)))
-
-			// Import all symbols from the schema module as unqualified names
-			// unless they conflict with existing symbols
-			i.importUnqualifiedSymbols(dangEnv, schemaModule, i.Name.Name)
+			installImportedTypeEnvironment(dangEnv, i.Name.Name, schemaModule)
 
 			i.inferred = schemaModule
 		}
@@ -1211,11 +1201,7 @@ func (i *ImportDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	// Create evaluation environment for the imported schema
 	moduleEnv := NewEvalEnvWithSchema(i.inferred, i.client, i.schema)
 
-	// Set the module in the evaluation environment
-	env.Set(i.Name.Name, moduleEnv)
-
-	// Import all runtime values as unqualified symbols (unless they conflict)
-	i.importUnqualifiedValues(env, moduleEnv, i.Name.Name)
+	installImportedEvalEnvironment(env, i.Name.Name, moduleEnv)
 
 	return moduleEnv, nil
 }
@@ -1265,161 +1251,4 @@ func (i *ImportDecl) checkAliasConflicts(env Env, alias string) error {
 	}
 
 	return nil
-}
-
-// importUnqualifiedSymbols imports all symbols from an imported module into
-// the parent environment, unless they conflict with existing symbols or
-// symbols from other imports.
-func (i *ImportDecl) importUnqualifiedSymbols(parentEnv Env, schemaModule Env, importName string) {
-	// Import all value bindings (functions, etc.) from the schema module
-	for name, scheme := range schemaModule.Bindings(PublicVisibility) {
-		// Skip the import name itself (e.g., don't import "Test" as unqualified)
-		if name == importName {
-			continue
-		}
-
-		// Check if this name already exists in the parent environment
-		if existing, exists := parentEnv.LocalSchemeOf(name); exists {
-			// Symbol already exists - check if it's from another import or locally defined
-			// For now, we simply skip adding it (qualified access will still work)
-			_ = existing
-			// Track the conflict
-			parentEnv.TrackUnqualifiedTypeImport(name, importName)
-			continue
-		}
-
-		// Add the symbol to the parent environment
-		parentEnv.Add(name, scheme)
-		// Track that this import provides this symbol
-		parentEnv.TrackUnqualifiedTypeImport(name, importName)
-	}
-
-	// Import all type bindings (classes) from the schema module
-	// We need to iterate through all types in the module
-	if mod, ok := schemaModule.(*CompositeModule); ok {
-		// For CompositeModule, get the primary module and import from it
-		if primaryMod, ok := mod.primary.(*Module); ok {
-			i.importTypesFromModule(parentEnv, primaryMod, importName)
-			i.importDirectivesFromModule(parentEnv, primaryMod, importName)
-		}
-	} else if mod, ok := schemaModule.(*Module); ok {
-		// For regular Module
-		i.importTypesFromModule(parentEnv, mod, importName)
-		i.importDirectivesFromModule(parentEnv, mod, importName)
-	}
-}
-
-func (i *ImportDecl) importTypesFromModule(parentEnv Env, mod *Module, importName string) {
-	// Import all classes (types) from the module
-	for name, class := range mod.classes {
-		// Skip the import name itself
-		if name == importName {
-			continue
-		}
-
-		// Check if this type already exists in the parent environment
-		if _, exists := parentEnv.NamedType(name); exists {
-			// Type already exists - track the conflict
-			parentEnv.TrackUnqualifiedTypeImport(name, importName)
-			continue
-		}
-
-		// Add the type to the parent environment
-		parentEnv.AddClass(name, class)
-		// Track that this import provides this type
-		parentEnv.TrackUnqualifiedTypeImport(name, importName)
-
-		// For enum types, also import their values as unqualified symbols
-		if enumMod, ok := class.(*Module); ok && enumMod.Kind == EnumKind {
-			for enumValName, enumValScheme := range enumMod.Bindings(PublicVisibility) {
-				// Check if this enum value name conflicts with existing symbols
-				if _, exists := parentEnv.LocalSchemeOf(enumValName); exists {
-					// Conflict - track it
-					parentEnv.TrackUnqualifiedTypeImport(enumValName, importName)
-					continue
-				}
-
-				// Add the enum value to the parent environment
-				parentEnv.Add(enumValName, enumValScheme)
-				// Track that this import provides this enum value
-				parentEnv.TrackUnqualifiedTypeImport(enumValName, importName)
-			}
-		}
-	}
-}
-
-func (i *ImportDecl) importDirectivesFromModule(parentEnv Env, mod *Module, importName string) {
-	// Import all directives from the module
-	for directiveName, directive := range mod.directives {
-		// Check if this directive already exists in the parent environment
-		if _, exists := parentEnv.GetDirective(directiveName); exists {
-			// Directive already exists - track the conflict
-			parentEnv.TrackUnqualifiedDirectiveImport(directiveName, importName)
-			continue
-		}
-
-		// Add the directive to the parent environment
-		parentEnv.AddDirective(directiveName, directive)
-		// Track that this import provides this directive
-		parentEnv.TrackUnqualifiedDirectiveImport(directiveName, importName)
-	}
-}
-
-// importUnqualifiedValues imports all runtime values from an imported module
-// into the parent environment, unless they conflict with existing values.
-func (i *ImportDecl) importUnqualifiedValues(parentEnv EvalEnv, moduleEnv EvalEnv, importName string) {
-	// Iterate through all bindings in the module environment
-	for _, binding := range moduleEnv.Bindings(PublicVisibility) {
-		name := binding.Key
-		value := binding.Value
-
-		// Skip the import name itself
-		if name == importName {
-			continue
-		}
-
-		// Check if this name already exists in the parent environment
-		if _, exists := parentEnv.GetLocal(name); exists {
-			// Value already exists - track the conflict
-			if mod, ok := parentEnv.(*ModuleValue); ok {
-				mod.Mod.TrackUnqualifiedValueImport(name, importName)
-			}
-			continue
-		}
-
-		// Add the value to the parent environment
-		parentEnv.Set(name, value)
-		// Track that this import provides this value
-		if mod, ok := parentEnv.(*ModuleValue); ok {
-			mod.Mod.TrackUnqualifiedValueImport(name, importName)
-		}
-
-		// If this is an enum module, also import its enum values as unqualified symbols
-		if enumModuleVal, ok := value.(*ModuleValue); ok {
-			// Check if this is an enum type by looking at the module kind
-			if mod, ok := enumModuleVal.Mod.(*Module); ok && mod.Kind == EnumKind {
-				// Import all enum values
-				for _, enumBinding := range enumModuleVal.Bindings(PublicVisibility) {
-					enumValName := enumBinding.Key
-					enumVal := enumBinding.Value
-
-					// Check if this enum value name conflicts with existing symbols
-					if _, exists := parentEnv.GetLocal(enumValName); exists {
-						// Conflict - track it
-						if parentMod, ok := parentEnv.(*ModuleValue); ok {
-							parentMod.Mod.TrackUnqualifiedValueImport(enumValName, importName)
-						}
-						continue
-					}
-
-					// Add the enum value to the parent environment
-					parentEnv.Set(enumValName, enumVal)
-					// Track that this import provides this enum value
-					if parentMod, ok := parentEnv.(*ModuleValue); ok {
-						parentMod.Mod.TrackUnqualifiedValueImport(enumValName, importName)
-					}
-				}
-			}
-		}
-	}
 }

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -563,6 +563,9 @@ func (s *Symbol) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.Ty
 	return WithInferErrorHandling(s, func() (hm.Type, error) {
 		// Check for import conflicts before resolving
 		if dangEnv, ok := env.(Env); ok {
+			if conflicts := dangEnv.CheckValueConflict(s.Name); len(conflicts) > 0 {
+				return nil, fmt.Errorf("ambiguous reference to %q: provided by imports %v", s.Name, conflicts)
+			}
 			if conflicts := dangEnv.CheckTypeConflict(s.Name); len(conflicts) > 0 {
 				return nil, fmt.Errorf("ambiguous reference to %q: provided by imports %v", s.Name, conflicts)
 			}

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -1170,7 +1170,7 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 		return nil, NewInferError(fmt.Errorf("inline fragments require a union or interface type, got %s", unwrapped), o.Receiver)
 	}
 	if unionOrIface.Kind != UnionKind && unionOrIface.Kind != InterfaceKind {
-		return nil, NewInferError(fmt.Errorf("inline fragments require a union or interface type, got %s type %s", unionOrIface.Kind, unionOrIface.Name()), o.Receiver)
+		return nil, NewInferError(fmt.Errorf("inline fragments require a union or interface type, got %s type %s", unionOrIface.Kind, unionOrIface), o.Receiver)
 	}
 
 	// Create a narrowed union whose members only have the selected fields.
@@ -1194,7 +1194,7 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 		// Check membership
 		if unionOrIface.Kind == UnionKind {
 			if !unionOrIface.HasMember(memberMod) {
-				return nil, NewInferError(fmt.Errorf("type %s is not a member of union %s", frag.TypeName.Name, unionOrIface.Name()), frag.TypeName)
+				return nil, NewInferError(fmt.Errorf("type %s is not a member of union %s", frag.TypeName.Name, unionOrIface), frag.TypeName)
 			}
 		}
 
@@ -1474,7 +1474,7 @@ func (o *ObjectSelection) evalInlineFragmentOnValue(val Value, ctx context.Conte
 			for _, field := range frag.Fields {
 				fieldVal, exists := modVal.Get(field.Name)
 				if !exists {
-					return nil, fmt.Errorf("field %s not found on %s", field.Name, mod.Name())
+					return nil, fmt.Errorf("field %s not found on %s", field.Name, mod)
 				}
 				resultModuleValue.Set(field.Name, fieldVal)
 			}
@@ -1486,7 +1486,7 @@ func (o *ObjectSelection) evalInlineFragmentOnValue(val Value, ctx context.Conte
 	for _, frag := range o.InlineFragments {
 		if frag.NonNull {
 			return nil, fmt.Errorf("inline fragment type assertion failed: expected one of %s, got %s",
-				o.inlineFragmentTypeNames(), mod.Name())
+				o.inlineFragmentTypeNames(), mod)
 		}
 	}
 

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -1184,21 +1184,9 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 
 	// Validate each fragment
 	for _, frag := range o.InlineFragments {
-		memberType, found := modEnv.NamedType(frag.TypeName.Name)
-		if !found {
-			return nil, NewInferError(fmt.Errorf("unknown type %s in inline fragment", frag.TypeName.Name), frag.TypeName)
-		}
-
-		memberMod, ok := memberType.(*Module)
-		if !ok {
-			return nil, NewInferError(fmt.Errorf("type %s in inline fragment is not an object type", frag.TypeName.Name), frag.TypeName)
-		}
-
-		// Check membership
-		if unionOrIface.Kind == UnionKind {
-			if !unionOrIface.HasMember(memberMod) {
-				return nil, NewInferError(fmt.Errorf("type %s is not a member of union %s", frag.TypeName.Name, unionOrIface), frag.TypeName)
-			}
+		memberMod, err := resolveInlineFragmentMemberType(unionOrIface, frag.TypeName.Name)
+		if err != nil {
+			return nil, NewInferError(err, frag.TypeName)
 		}
 
 		if len(frag.Fields) == 0 {
@@ -1209,16 +1197,16 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 		} else {
 			// Create a narrowed module with only the selected fields.
 			// Link back to the canonical type for runtime matching.
-			narrowedMember := NewModule(frag.TypeName.Name, ObjectKind)
+			narrowedMember := NewModule(memberMod.Name(), ObjectKind)
 			narrowedMember.Qualifier = memberMod.Qualifier
 			narrowedMember.Canonical = memberMod
 
 			// Validate each field in the fragment exists on the concrete type
 			// and add it to the narrowed module (including nested selections)
 			for _, field := range frag.Fields {
-				fieldType, err := o.inferFieldType(ctx, field, memberMod, env, fresh)
+				fieldType, err := o.inferFieldType(ctx, field, memberMod, modEnv, fresh)
 				if err != nil {
-					return nil, NewInferError(fmt.Errorf("field %s not found on type %s", field.Name, frag.TypeName.Name), field)
+					return nil, NewInferError(fmt.Errorf("field %s not found on type %s", field.Name, memberMod), field)
 				}
 				narrowedMember.Add(field.Name, hm.NewScheme(nil, fieldType))
 			}
@@ -1263,6 +1251,37 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 
 	o.SetInferredType(resultType)
 	return resultType, nil
+}
+
+func resolveInlineFragmentMemberType(receiver *Module, typeName string) (*Module, error) {
+	switch receiver.Kind {
+	case UnionKind:
+		if member, found := findMemberModuleByName(receiver.GetMembers(), typeName); found {
+			return member, nil
+		}
+		return nil, fmt.Errorf("type %s is not a member of union %s", typeName, receiver)
+	case InterfaceKind:
+		if implementer, found := findMemberModuleByName(receiver.GetImplementers(), typeName); found {
+			return implementer, nil
+		}
+		return nil, fmt.Errorf("type %s does not implement interface %s", typeName, receiver)
+	default:
+		return nil, fmt.Errorf("inline fragments require a union or interface type, got %s type %s", receiver.Kind, receiver)
+	}
+}
+
+func findMemberModuleByName(members []Env, typeName string) (*Module, bool) {
+	for _, member := range members {
+		if member.Name() != typeName {
+			continue
+		}
+		memberMod, ok := member.(*Module)
+		if !ok {
+			return nil, false
+		}
+		return memberMod, true
+	}
+	return nil, false
 }
 
 func (o *ObjectSelection) inferSelectionType(ctx context.Context, receiverType hm.Type, env hm.Env, fresh hm.Fresher) (*Module, error) {

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -1177,6 +1177,7 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 	// This ensures downstream code (e.g. case type patterns) can only access
 	// fields that were actually selected in the inline fragment.
 	narrowedUnion := NewModule(unionOrIface.Name(), UnionKind)
+	narrowedUnion.Qualifier = unionOrIface.Qualifier
 
 	// Validate each fragment
 	for _, frag := range o.InlineFragments {
@@ -1206,6 +1207,7 @@ func (o *ObjectSelection) inferInlineFragments(ctx context.Context, receiverType
 			// Create a narrowed module with only the selected fields.
 			// Link back to the canonical type for runtime matching.
 			narrowedMember := NewModule(frag.TypeName.Name, ObjectKind)
+			narrowedMember.Qualifier = memberMod.Qualifier
 			narrowedMember.Canonical = memberMod
 
 			// Validate each field in the fragment exists on the concrete type

--- a/pkg/dang/ast_patterns.go
+++ b/pkg/dang/ast_patterns.go
@@ -131,7 +131,7 @@ func (c *Case) inferTypePatternClause(ctx context.Context, env hm.Env, fresh hm.
 	var memberMod *Module
 	if operandMod, ok := unwrapped.(*Module); ok {
 		if operandMod.Kind != UnionKind && operandMod.Kind != InterfaceKind {
-			return NewInferError(fmt.Errorf("type pattern requires a union or interface operand, got %s type %s", operandMod.Kind, operandMod.Name()), c.Expr)
+			return NewInferError(fmt.Errorf("type pattern requires a union or interface operand, got %s type %s", operandMod.Kind, operandMod), c.Expr)
 		}
 
 		if operandMod.Kind == UnionKind {
@@ -142,7 +142,7 @@ func (c *Case) inferTypePatternClause(ctx context.Context, env hm.Env, fresh hm.
 				}
 			}
 			if memberMod == nil {
-				return NewInferError(fmt.Errorf("type %s is not a member of union %s", clause.TypePattern.Name, operandMod.Name()), clause.TypePattern)
+				return NewInferError(fmt.Errorf("type %s is not a member of union %s", clause.TypePattern.Name, operandMod), clause.TypePattern)
 			}
 		} else if operandMod.Kind == InterfaceKind {
 			var err error
@@ -188,7 +188,7 @@ func resolveInterfaceTypePattern(env Env, iface *Module, patternName string) (*M
 			return memberMod, nil
 		}
 	}
-	return nil, fmt.Errorf("type %s does not implement interface %s", patternName, iface.Name())
+	return nil, fmt.Errorf("type %s does not implement interface %s", patternName, iface)
 }
 
 func resolveInlineUnionTypePattern(env Env, union *hm.UnionType, patternName string) (*Module, error) {

--- a/pkg/dang/block.go
+++ b/pkg/dang/block.go
@@ -237,10 +237,12 @@ func classifyForms(forms []Node) ClassifiedForms {
 // InferFormsWithPhases implements phased compilation:
 // 1. Parse all files (already done)
 // 2. Build dependency graph of all declarations
-// 3. Typecheck constants and types (which can reference each other)
-// 4. Declare function signatures (without bodies)
-// 5. Typecheck variables in dependency order (can now reference function signatures)
-// 6. Typecheck function bodies last (can reference all package-level declarations)
+// 3. Import external schemas
+// 4. Hoist local type names so annotations shadow imported types immediately
+// 5. Typecheck constants and types (which can reference each other)
+// 6. Declare function signatures (without bodies)
+// 7. Typecheck variables in dependency order (can now reference function signatures)
+// 8. Typecheck function bodies last (can reference all package-level declarations)
 //
 // This function collects all errors instead of failing fast, allowing partial inference
 // to succeed and providing better error messages showing all problems at once.
@@ -254,6 +256,9 @@ func InferFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh h
 	}{
 		{"imports", func(errs *InferenceErrors) (hm.Type, error) {
 			return inferImportsPhaseResilient(ctx, classified.Imports, env, fresh, errs)
+		}},
+		{"type names", func(errs *InferenceErrors) (hm.Type, error) {
+			return inferTypeNamesPhaseResilient(ctx, classified.Types, env, fresh, errs)
 		}},
 		{"directives", func(errs *InferenceErrors) (hm.Type, error) {
 			return inferDirectivesPhaseResilient(ctx, classified.Directives, env, fresh, errs)
@@ -585,8 +590,10 @@ func inferConstantsPhaseResilient(ctx context.Context, constants []Node, env hm.
 	return lastT, nil
 }
 
-func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
-	// Pass 0: Create class types
+func inferTypeNamesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+	// Pass 0 only registers local type names. Running it before any phase that
+	// resolves annotations ensures a local type shadows an unqualified import as
+	// soon as imports are installed.
 	for _, form := range types {
 		if hoister, ok := form.(Hoister); ok {
 			if err := hoister.Hoist(ctx, env, fresh, 0); err != nil {
@@ -595,7 +602,10 @@ func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fre
 			}
 		}
 	}
+	return nil, nil
+}
 
+func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
 	// Pass 1: Infer class bodies
 	for _, form := range types {
 		if hoister, ok := form.(Hoister); ok {

--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -12,12 +12,58 @@ import (
 	"github.com/vito/dang/pkg/introspection"
 )
 
+type BindingOriginKind int
+
+const (
+	BindingOriginUnknown BindingOriginKind = iota
+	BindingOriginLocal
+	BindingOriginImport
+)
+
+type BindingOrigin struct {
+	Kind        BindingOriginKind
+	ImportNames []string
+	Qualified   bool
+}
+
+func LocalBindingOrigin() BindingOrigin {
+	return BindingOrigin{Kind: BindingOriginLocal}
+}
+
+func ImportedBindingOrigin(importName string, qualified bool) BindingOrigin {
+	return BindingOrigin{Kind: BindingOriginImport, ImportNames: []string{importName}, Qualified: qualified}
+}
+
+func (o BindingOrigin) IsUnqualifiedImport() bool {
+	return o.Kind == BindingOriginImport && !o.Qualified
+}
+
+func (o BindingOrigin) AddImportProvider(importName string) BindingOrigin {
+	if o.Kind != BindingOriginImport {
+		return ImportedBindingOrigin(importName, false)
+	}
+	if slices.Contains(o.ImportNames, importName) {
+		return o
+	}
+	o.ImportNames = append(o.ImportNames, importName)
+	return o
+}
+
+func (o BindingOrigin) ConflictingImports() []string {
+	if !o.IsUnqualifiedImport() || len(o.ImportNames) < 2 {
+		return nil
+	}
+	return o.ImportNames
+}
+
 type Env interface {
 	hm.Env
 	hm.Type
 	NamedType(string) (Env, bool)
 	LocalNamedType(string) (Env, bool)
 	AddClass(string, Env)
+	SetTypeOrigin(string, BindingOrigin)
+	LocalTypeOrigin(string) (BindingOrigin, bool)
 	SetDocString(string, string)
 	GetDocString(string) (string, bool)
 	SetDirectives(string, []*DirectiveApplication)
@@ -26,12 +72,13 @@ type Env interface {
 	GetModuleDocString() string
 	SetVisibility(string, Visibility)
 	LocalSchemeOf(string) (*hm.Scheme, bool)
+	SetValueOrigin(string, BindingOrigin)
+	LocalValueOrigin(string) (BindingOrigin, bool)
 	AddDirective(string, *DirectiveDecl)
 	GetDirective(string) (*DirectiveDecl, bool)
+	SetDirectiveOrigin(string, BindingOrigin)
+	LocalDirectiveOrigin(string) (BindingOrigin, bool)
 	Bindings(visibility Visibility) iter.Seq2[string, *hm.Scheme]
-	TrackUnqualifiedTypeImport(symbolName, importName string) bool
-	TrackUnqualifiedValueImport(symbolName, importName string) bool
-	TrackUnqualifiedDirectiveImport(directiveName, importName string) bool
 	CheckTypeConflict(symbolName string) []string
 	CheckValueConflict(symbolName string) []string
 	CheckDirectiveConflict(directiveName string) []string
@@ -98,13 +145,16 @@ type Module struct {
 
 	Parent Env
 
-	classes         map[string]Env
-	vars            map[string]*hm.Scheme
-	visibility      map[string]Visibility
-	directives      map[string]*DirectiveDecl
-	slotDirectives  map[string][]*DirectiveApplication
-	docStrings      map[string]string
-	moduleDocString string
+	classes          map[string]Env
+	vars             map[string]*hm.Scheme
+	visibility       map[string]Visibility
+	directives       map[string]*DirectiveDecl
+	typeOrigins      map[string]BindingOrigin
+	valueOrigins     map[string]BindingOrigin
+	directiveOrigins map[string]BindingOrigin
+	slotDirectives   map[string][]*DirectiveApplication
+	docStrings       map[string]string
+	moduleDocString  string
 
 	// Type-level dynamic scope type
 	dynamicScopeType hm.Type
@@ -122,27 +172,22 @@ type Module struct {
 	members []Env // Member types of this union (for union modules)
 	unions  []Env // Unions this type is a member of
 
-	// Import conflict tracking for unqualified imports
-	// Maps symbol name -> list of import names that provide it
-	unqualifiedTypeImports      map[string][]string // For type-level symbols
-	unqualifiedValueImports     map[string][]string // For value-level symbols
-	unqualifiedDirectiveImports map[string][]string // For directives
 }
 
 func NewModule(name string, kind ModuleKind) *Module {
 	env := &Module{
-		Named:                       name,
-		Kind:                        kind,
-		classes:                     make(map[string]Env),
-		vars:                        make(map[string]*hm.Scheme),
-		visibility:                  make(map[string]Visibility),
-		directives:                  make(map[string]*DirectiveDecl),
-		slotDirectives:              make(map[string][]*DirectiveApplication),
-		docStrings:                  make(map[string]string),
-		moduleDocString:             "",
-		unqualifiedTypeImports:      make(map[string][]string),
-		unqualifiedValueImports:     make(map[string][]string),
-		unqualifiedDirectiveImports: make(map[string][]string),
+		Named:            name,
+		Kind:             kind,
+		classes:          make(map[string]Env),
+		vars:             make(map[string]*hm.Scheme),
+		visibility:       make(map[string]Visibility),
+		directives:       make(map[string]*DirectiveDecl),
+		typeOrigins:      make(map[string]BindingOrigin),
+		valueOrigins:     make(map[string]BindingOrigin),
+		directiveOrigins: make(map[string]BindingOrigin),
+		slotDirectives:   make(map[string][]*DirectiveApplication),
+		docStrings:       make(map[string]string),
+		moduleDocString:  "",
 	}
 	return env
 }
@@ -656,10 +701,20 @@ func (e *Module) FreeTypeVar() hm.TypeVarSet {
 
 func (e *Module) Add(name string, s *hm.Scheme) hm.Env {
 	e.vars[name] = s
+	e.valueOrigins[name] = LocalBindingOrigin()
 	if _, ok := e.visibility[name]; !ok {
 		e.visibility[name] = PrivateVisibility
 	}
 	return e
+}
+
+func (e *Module) SetValueOrigin(name string, origin BindingOrigin) {
+	e.valueOrigins[name] = origin
+}
+
+func (e *Module) LocalValueOrigin(name string) (BindingOrigin, bool) {
+	origin, ok := e.valueOrigins[name]
+	return origin, ok
 }
 
 func (e *Module) SetVisibility(name string, visibility Visibility) {
@@ -716,10 +771,30 @@ func (e *Module) NamedTypes() iter.Seq2[string, Env] {
 
 func (e *Module) AddClass(name string, c Env) {
 	e.classes[name] = c
+	e.typeOrigins[name] = LocalBindingOrigin()
+}
+
+func (e *Module) SetTypeOrigin(name string, origin BindingOrigin) {
+	e.typeOrigins[name] = origin
+}
+
+func (e *Module) LocalTypeOrigin(name string) (BindingOrigin, bool) {
+	origin, ok := e.typeOrigins[name]
+	return origin, ok
 }
 
 func (e *Module) AddDirective(name string, directive *DirectiveDecl) {
 	e.directives[name] = directive
+	e.directiveOrigins[name] = LocalBindingOrigin()
+}
+
+func (e *Module) SetDirectiveOrigin(name string, origin BindingOrigin) {
+	e.directiveOrigins[name] = origin
+}
+
+func (e *Module) LocalDirectiveOrigin(name string) (BindingOrigin, bool) {
+	origin, ok := e.directiveOrigins[name]
+	return origin, ok
 }
 
 func (e *Module) GetDirective(name string) (*DirectiveDecl, bool) {
@@ -1008,83 +1083,38 @@ func (m *Module) GetUnions() []Env {
 	return m.unions
 }
 
-// TrackUnqualifiedTypeImport records that an import provides a type-level symbol
-// Returns true if this creates a conflict (symbol already provided by a different import)
-func (m *Module) TrackUnqualifiedTypeImport(symbolName, importName string) bool {
-	existing := m.unqualifiedTypeImports[symbolName]
-	if slices.Contains(existing, importName) {
-		// Already tracked from this import
-		return len(existing) > 1
-	}
-	m.unqualifiedTypeImports[symbolName] = append(existing, importName)
-	return len(m.unqualifiedTypeImports[symbolName]) > 1
-}
-
-// TrackUnqualifiedValueImport records that an import provides a value-level symbol
-// Returns true if this creates a conflict (symbol already provided by a different import)
-func (m *Module) TrackUnqualifiedValueImport(symbolName, importName string) bool {
-	existing := m.unqualifiedValueImports[symbolName]
-	if slices.Contains(existing, importName) {
-		// Already tracked from this import
-		return len(existing) > 1
-	}
-	m.unqualifiedValueImports[symbolName] = append(existing, importName)
-	return len(m.unqualifiedValueImports[symbolName]) > 1
-}
-
-// CheckTypeConflict checks if a type-level symbol has import conflicts
-// Returns the list of imports that provide it (empty if no conflict or not tracked)
+// CheckTypeConflict checks if a type-level symbol has import conflicts.
+// Returns the list of imports that provide it (empty if no conflict or not tracked).
 func (m *Module) CheckTypeConflict(symbolName string) []string {
-	imports := m.unqualifiedTypeImports[symbolName]
-	if len(imports) > 1 {
-		return imports
+	if origin, found := m.LocalTypeOrigin(symbolName); found {
+		return origin.ConflictingImports()
 	}
 	if m.Parent != nil {
-		if parent, ok := m.Parent.(*Module); ok {
-			return parent.CheckTypeConflict(symbolName)
-		}
+		return m.Parent.CheckTypeConflict(symbolName)
 	}
 	return nil
 }
 
-// CheckValueConflict checks if a value-level symbol has import conflicts
-// Returns the list of imports that provide it (empty if no conflict or not tracked)
+// CheckValueConflict checks if a value-level symbol has import conflicts.
+// Returns the list of imports that provide it (empty if no conflict or not tracked).
 func (m *Module) CheckValueConflict(symbolName string) []string {
-	imports := m.unqualifiedValueImports[symbolName]
-	if len(imports) > 1 {
-		return imports
+	if origin, found := m.LocalValueOrigin(symbolName); found {
+		return origin.ConflictingImports()
 	}
 	if m.Parent != nil {
-		if parent, ok := m.Parent.(*Module); ok {
-			return parent.CheckValueConflict(symbolName)
-		}
+		return m.Parent.CheckValueConflict(symbolName)
 	}
 	return nil
 }
 
-// TrackUnqualifiedDirectiveImport records that an import provides a directive
-// Returns true if this creates a conflict (directive already provided by a different import)
-func (m *Module) TrackUnqualifiedDirectiveImport(directiveName, importName string) bool {
-	existing := m.unqualifiedDirectiveImports[directiveName]
-	if slices.Contains(existing, importName) {
-		// Already tracked from this import
-		return len(existing) > 1
-	}
-	m.unqualifiedDirectiveImports[directiveName] = append(existing, importName)
-	return len(m.unqualifiedDirectiveImports[directiveName]) > 1
-}
-
-// CheckDirectiveConflict checks if a directive has import conflicts
-// Returns the list of imports that provide it (empty if no conflict or not tracked)
+// CheckDirectiveConflict checks if a directive has import conflicts.
+// Returns the list of imports that provide it (empty if no conflict or not tracked).
 func (m *Module) CheckDirectiveConflict(directiveName string) []string {
-	imports := m.unqualifiedDirectiveImports[directiveName]
-	if len(imports) > 1 {
-		return imports
+	if origin, found := m.LocalDirectiveOrigin(directiveName); found {
+		return origin.ConflictingImports()
 	}
 	if m.Parent != nil {
-		if parent, ok := m.Parent.(*Module); ok {
-			return parent.CheckDirectiveConflict(directiveName)
-		}
+		return m.Parent.CheckDirectiveConflict(directiveName)
 	}
 	return nil
 }

--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -93,6 +93,9 @@ type Module struct {
 	Named string
 	Kind  ModuleKind
 
+	// Qualifier is the import/module alias used for display-only type names.
+	Qualifier string
+
 	Parent Env
 
 	classes         map[string]Env
@@ -346,6 +349,9 @@ func NewEnv(name string, schema *introspection.Schema) Env {
 					continue
 				}
 				sub = NewModule(t.Name, kind)
+				if subMod, ok := sub.(*Module); ok {
+					subMod.Qualifier = name
+				}
 				// Store type description as module documentation
 				if t.Description != "" {
 					sub.SetModuleDocString(t.Description)
@@ -678,6 +684,7 @@ func (e *Module) LocalSchemeOf(name string) (*hm.Scheme, bool) {
 
 func (e *Module) Clone() hm.Env {
 	mod := NewModule(e.Named, e.Kind)
+	mod.Qualifier = e.Qualifier
 	mod.Parent = e
 	mod.dynamicScopeType = e.dynamicScopeType
 	return mod
@@ -874,6 +881,9 @@ func (t *Module) Types() hm.Types                            { return nil }
 
 func (t *Module) String() string {
 	if t.Named != "" {
+		if t.Qualifier != "" {
+			return t.Qualifier + "." + t.Named
+		}
 		return t.Named
 	}
 	return t.AsRecord().String()

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -104,6 +104,30 @@ scalar Error
 	require.Equal(t, ScalarKind, scalarMod.Mod.(*Module).Kind)
 }
 
+func TestImportedTypeDisplayNamesAreQualified(t *testing.T) {
+	env := NewEnv("Dagger", schemaWithCoreShadowTypes())
+
+	container, found := env.NamedType("Container")
+	require.True(t, found)
+	require.Equal(t, "Container", container.Name())
+	require.Equal(t, "Dagger.Container", container.String())
+	require.Equal(t, "Dagger.Container", container.Clone().(Env).String())
+
+	nonNullContainer := hm.NonNullType{Type: container}
+	require.Equal(t, "Dagger.Container!", nonNullContainer.String())
+	require.Equal(t, "Dagger.Container!", nonNullContainer.Name())
+
+	containerList := ListType{nonNullContainer}
+	require.Equal(t, "[Dagger.Container!]", containerList.String())
+	require.Equal(t, "[Dagger.Container!]", containerList.Name())
+
+	fn := hm.NewFnType(
+		NewRecordType("", Keyed[*hm.Scheme]{Key: "input", Value: hm.NewScheme(nil, nonNullContainer)}),
+		nonNullContainer,
+	)
+	require.Equal(t, "(input: Dagger.Container!): Dagger.Container!", fn.String())
+}
+
 func TestRunDirDeclarationsShadowImportedTypes(t *testing.T) {
 	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
 		Name:       "Dagger",

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vito/dang/pkg/hm"
 	"github.com/vito/dang/pkg/introspection"
 )
 
@@ -103,6 +104,67 @@ scalar Error
 	require.Equal(t, ScalarKind, scalarMod.Mod.(*Module).Kind)
 }
 
+func TestRunDirDeclarationsShadowImportedTypes(t *testing.T) {
+	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+		Name:       "Dagger",
+		Schema:     schemaWithCoreShadowTypes(),
+		AutoImport: true,
+	})
+	env := runDangSnippetContext(t, ctx, `
+type TestShadowing {
+  pub makeLocal: Container! {
+    Container("local")
+  }
+
+  pub makeCore: Dagger.Container! {
+    Dagger.container
+  }
+}
+
+type Container {
+  pub value: String!
+}
+
+type Directory {
+  pub value: String!
+}
+`)
+
+	daggerVal, found := env.Get("Dagger")
+	require.True(t, found)
+	daggerMod, ok := daggerVal.(*ModuleValue)
+	require.True(t, ok)
+	importedContainer, found := daggerMod.Mod.NamedType("Container")
+	require.True(t, found)
+	importedDirectory, found := daggerMod.Mod.NamedType("Directory")
+	require.True(t, found)
+
+	containerVal, found := env.Get("Container")
+	require.True(t, found)
+	containerCtor, ok := containerVal.(*ConstructorFunction)
+	require.True(t, ok)
+	require.NotSame(t, importedContainer, containerCtor.ClassType)
+
+	directoryVal, found := env.Get("Directory")
+	require.True(t, found)
+	directoryCtor, ok := directoryVal.(*ConstructorFunction)
+	require.True(t, ok)
+	require.NotSame(t, importedDirectory, directoryCtor.ClassType)
+
+	testVal, found := env.Get("TestShadowing")
+	require.True(t, found)
+	testCtor, ok := testVal.(*ConstructorFunction)
+	require.True(t, ok)
+
+	localScheme, found := testCtor.ClassType.LocalSchemeOf("makeLocal")
+	require.True(t, found)
+	require.Same(t, containerCtor.ClassType, functionReturnType(t, localScheme))
+
+	coreScheme, found := testCtor.ClassType.LocalSchemeOf("makeCore")
+	require.True(t, found)
+	require.Same(t, importedContainer, functionReturnType(t, coreScheme))
+}
+
 func TestRunDirImplementingPreludeInterfaceDoesNotMutatePrelude(t *testing.T) {
 	before := len(ErrorType.GetImplementers())
 	runDangSnippet(t, `
@@ -125,11 +187,94 @@ assert { MyUnion != null }
 
 func runDangSnippet(t *testing.T, source string) EvalEnv {
 	t.Helper()
+	return runDangSnippetContext(t, context.Background(), source)
+}
+
+func runDangSnippetContext(t *testing.T, ctx context.Context, source string) EvalEnv {
+	t.Helper()
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.dang"), []byte(source), 0o600))
-	env, err := RunDir(context.Background(), dir, false)
+	env, err := RunDir(ctx, dir, false)
 	require.NoError(t, err)
 	return env
+}
+
+func functionReturnType(t *testing.T, scheme *hm.Scheme) hm.Type {
+	t.Helper()
+	typ, mono := scheme.Type()
+	require.True(t, mono)
+	fn, ok := typ.(*hm.FunctionType)
+	require.True(t, ok)
+	ret := fn.Ret(false)
+	if nn, ok := ret.(hm.NonNullType); ok {
+		ret = nn.Type
+	}
+	return ret
+}
+
+func schemaWithCoreShadowTypes() *introspection.Schema {
+	schema := &introspection.Schema{
+		Types: introspection.Types{
+			{
+				Kind: introspection.TypeKindScalar,
+				Name: "ID",
+			},
+			{
+				Kind: introspection.TypeKindScalar,
+				Name: "String",
+			},
+			{
+				Kind: introspection.TypeKindObject,
+				Name: "Container",
+				Fields: []*introspection.Field{
+					{
+						Name: "id",
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "ID",
+							},
+						},
+					},
+				},
+			},
+			{
+				Kind: introspection.TypeKindObject,
+				Name: "Directory",
+				Fields: []*introspection.Field{
+					{
+						Name: "id",
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindScalar,
+								Name: "ID",
+							},
+						},
+					},
+				},
+			},
+			{
+				Kind: introspection.TypeKindObject,
+				Name: "Query",
+				Fields: []*introspection.Field{
+					{
+						Name: "container",
+						TypeRef: &introspection.TypeRef{
+							Kind: introspection.TypeKindNonNull,
+							OfType: &introspection.TypeRef{
+								Kind: introspection.TypeKindObject,
+								Name: "Container",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	schema.QueryType.Name = "Query"
+	return schema
 }
 
 func schemaWithErrorObject() *introspection.Schema {

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -147,6 +147,37 @@ func TestBuildEnvFromImportsTracksImportedTypeOrigins(t *testing.T) {
 	require.Same(t, importedContainer, qualifiedContainer)
 }
 
+func TestBuildEnvFromImportsKeepsImportedBindingsPrivate(t *testing.T) {
+	typeEnv, evalEnv := BuildEnvFromImports("", []ImportConfig{{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	}})
+
+	publicTypeBindings := map[string]bool{}
+	for name := range typeEnv.Bindings(PublicVisibility) {
+		publicTypeBindings[name] = true
+	}
+	require.NotContains(t, publicTypeBindings, "Dagger")
+	require.NotContains(t, publicTypeBindings, "container")
+
+	_, found := typeEnv.SchemeOf("Dagger")
+	require.True(t, found)
+	_, found = typeEnv.SchemeOf("container")
+	require.True(t, found)
+
+	publicEvalBindings := map[string]bool{}
+	for _, binding := range evalEnv.Bindings(PublicVisibility) {
+		publicEvalBindings[binding.Key] = true
+	}
+	require.NotContains(t, publicEvalBindings, "Dagger")
+	require.NotContains(t, publicEvalBindings, "container")
+
+	_, found = evalEnv.Get("Dagger")
+	require.True(t, found)
+	_, found = evalEnv.Get("container")
+	require.True(t, found)
+}
+
 func TestRunDirDeclarationsShadowImportedTypes(t *testing.T) {
 	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
 		Name:       "Dagger",

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -137,7 +137,8 @@ func TestBuildEnvFromImportsTracksImportedTypeOrigins(t *testing.T) {
 	importedContainer, found := typeEnv.NamedType("Container")
 	require.True(t, found)
 
-	localContainer := declareLocalType(typeEnv, "Container", ObjectKind)
+	localContainer, err := declareLocalType(typeEnv, "Container", ObjectKind)
+	require.NoError(t, err)
 	require.NotSame(t, importedContainer, localContainer)
 
 	daggerType, found := typeEnv.NamedType("Dagger")
@@ -176,6 +177,49 @@ func TestBuildEnvFromImportsKeepsImportedBindingsPrivate(t *testing.T) {
 	require.True(t, found)
 	_, found = evalEnv.Get("container")
 	require.True(t, found)
+}
+
+func TestDeclareLocalTypeRejectsQualifiedImportAlias(t *testing.T) {
+	typeEnv, _ := BuildEnvFromImports("", []ImportConfig{{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	}})
+
+	importAlias, found := typeEnv.NamedType("Dagger")
+	require.True(t, found)
+	importedContainer, found := importAlias.NamedType("Container")
+	require.True(t, found)
+
+	localDagger, err := declareLocalType(typeEnv, "Dagger", ObjectKind)
+	require.ErrorContains(t, err, `type "Dagger" conflicts with import alias`)
+	require.Nil(t, localDagger)
+
+	aliasAfter, found := typeEnv.NamedType("Dagger")
+	require.True(t, found)
+	require.Same(t, importAlias, aliasAfter)
+	qualifiedContainer, found := aliasAfter.NamedType("Container")
+	require.True(t, found)
+	require.Same(t, importedContainer, qualifiedContainer)
+}
+
+func TestRunDirDeclarationCannotShadowImportAlias(t *testing.T) {
+	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	})
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.dang"), []byte(`
+import Dagger
+
+type Dagger {
+  pub value: String!
+}
+
+pub core: Dagger.Container! = Dagger.container
+`), 0o600))
+
+	_, err := RunDir(ctx, dir, false)
+	require.ErrorContains(t, err, `type "Dagger" conflicts with import alias`)
 }
 
 func TestRunDirDeclarationsShadowImportedTypes(t *testing.T) {

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -229,6 +229,8 @@ func TestRunDirDeclarationsShadowImportedTypes(t *testing.T) {
 		AutoImport: true,
 	})
 	env := runDangSnippetContext(t, ctx, `
+pub maybe: Container = null
+
 type TestShadowing {
   pub makeLocal: Container! {
     Container("local")
@@ -262,6 +264,15 @@ type Directory {
 	containerCtor, ok := containerVal.(*ConstructorFunction)
 	require.True(t, ok)
 	require.NotSame(t, importedContainer, containerCtor.ClassType)
+
+	moduleVal, ok := env.(*ModuleValue)
+	require.True(t, ok)
+	maybeScheme, found := moduleVal.Mod.SchemeOf("maybe")
+	require.True(t, found)
+	maybeType, mono := maybeScheme.Type()
+	require.True(t, mono)
+	require.Same(t, containerCtor.ClassType, maybeType)
+	require.NotSame(t, importedContainer, maybeType)
 
 	directoryVal, found := env.Get("Directory")
 	require.True(t, found)

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -128,6 +128,25 @@ func TestImportedTypeDisplayNamesAreQualified(t *testing.T) {
 	require.Equal(t, "(input: Dagger.Container!): Dagger.Container!", fn.String())
 }
 
+func TestBuildEnvFromImportsTracksImportedTypeOrigins(t *testing.T) {
+	typeEnv, _ := BuildEnvFromImports("", []ImportConfig{{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	}})
+
+	importedContainer, found := typeEnv.NamedType("Container")
+	require.True(t, found)
+
+	localContainer := declareLocalType(typeEnv, "Container", ObjectKind)
+	require.NotSame(t, importedContainer, localContainer)
+
+	daggerType, found := typeEnv.NamedType("Dagger")
+	require.True(t, found)
+	qualifiedContainer, found := daggerType.NamedType("Container")
+	require.True(t, found)
+	require.Same(t, importedContainer, qualifiedContainer)
+}
+
 func TestRunDirDeclarationsShadowImportedTypes(t *testing.T) {
 	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
 		Name:       "Dagger",

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -355,32 +355,8 @@ func BuildEnvFromImports(name string, configs []ImportConfig) (Env, EvalEnv) {
 		if config.Schema == nil {
 			continue
 		}
-
 		schemaModule := NewEnv(config.Name, config.Schema)
-		typeEnv.AddClass(config.Name, schemaModule)
-		typeEnv.Add(config.Name, hm.NewScheme(nil, NonNull(schemaModule)))
-		typeEnv.SetVisibility(config.Name, PublicVisibility)
-
-		for name, scheme := range schemaModule.Bindings(PublicVisibility) {
-			if name == config.Name {
-				continue
-			}
-			if _, exists := typeEnv.LocalSchemeOf(name); exists {
-				continue
-			}
-			typeEnv.Add(name, scheme)
-			typeEnv.SetVisibility(name, PublicVisibility)
-		}
-
-		for name, namedEnv := range schemaModule.NamedTypes() {
-			if name == config.Name {
-				continue
-			}
-			if _, exists := typeEnv.NamedType(name); exists {
-				continue
-			}
-			typeEnv.AddClass(name, namedEnv)
-		}
+		installImportedTypeEnvironment(typeEnv, config.Name, schemaModule)
 	}
 
 	evalEnv := NewEvalEnv(typeEnv)
@@ -389,18 +365,12 @@ func BuildEnvFromImports(name string, configs []ImportConfig) (Env, EvalEnv) {
 		if config.Schema == nil {
 			continue
 		}
-		schemaModule := NewEnv(config.Name, config.Schema)
-		moduleEnv := NewEvalEnvWithSchema(schemaModule, config.Client, config.Schema)
-		evalEnv.Set(config.Name, moduleEnv)
-		for _, binding := range moduleEnv.Bindings(PublicVisibility) {
-			if binding.Key == config.Name {
-				continue
-			}
-			if _, exists := evalEnv.GetLocal(binding.Key); exists {
-				continue
-			}
-			evalEnv.Set(binding.Key, binding.Value)
+		schemaModule, found := typeEnv.NamedType(config.Name)
+		if !found {
+			continue
 		}
+		moduleEnv := NewEvalEnvWithSchema(schemaModule, config.Client, config.Schema)
+		installImportedEvalEnvironment(evalEnv, config.Name, moduleEnv)
 	}
 
 	return typeEnv, evalEnv
@@ -1268,6 +1238,7 @@ func (m *ModuleValue) Set(name string, value Value) EvalEnv {
 	// TODO: check the type, set it if not present?
 	m.Values[name] = value
 	m.Visibilities[name] = m.Visibility(name)
+	m.Mod.SetValueOrigin(name, LocalBindingOrigin())
 	return m
 }
 
@@ -1338,6 +1309,7 @@ func (m *ModuleValue) Fork() EvalEnv {
 func (m *ModuleValue) SetWithVisibility(name string, value Value, visibility Visibility) {
 	m.Values[name] = value
 	m.Visibilities[name] = visibility
+	m.Mod.SetValueOrigin(name, LocalBindingOrigin())
 }
 
 // Reassign reassigns a value following proper scoping rules:
@@ -1349,6 +1321,7 @@ func (m *ModuleValue) Reassign(name string, value Value) {
 		// Variable exists locally, update it locally
 		m.Values[name] = value
 		m.Visibilities[name] = m.Visibility(name)
+		m.Mod.SetValueOrigin(name, LocalBindingOrigin())
 	} else if m.Parent != nil && !m.IsForked {
 		if _, existsInParent := m.Parent.Get(name); existsInParent {
 			// Variable exists in parent, update parent (only if not forked)
@@ -1357,11 +1330,13 @@ func (m *ModuleValue) Reassign(name string, value Value) {
 			// Variable doesn't exist anywhere, set it locally
 			m.Values[name] = value
 			m.Visibilities[name] = m.Visibility(name)
+			m.Mod.SetValueOrigin(name, LocalBindingOrigin())
 		}
 	} else {
 		// No parent or forked boundary, set it locally
 		m.Values[name] = value
 		m.Visibilities[name] = m.Visibility(name)
+		m.Mod.SetValueOrigin(name, LocalBindingOrigin())
 	}
 }
 

--- a/pkg/dang/import_install.go
+++ b/pkg/dang/import_install.go
@@ -2,13 +2,15 @@ package dang
 
 import "github.com/vito/dang/pkg/hm"
 
+const importedBindingVisibility = PrivateVisibility
+
 func installImportedTypeEnvironment(parentEnv Env, importName string, schemaModule Env) {
 	qualifiedOrigin := ImportedBindingOrigin(importName, true)
 
 	parentEnv.AddClass(importName, schemaModule)
 	parentEnv.SetTypeOrigin(importName, qualifiedOrigin)
 	parentEnv.Add(importName, hm.NewScheme(nil, NonNull(schemaModule)))
-	parentEnv.SetVisibility(importName, PublicVisibility)
+	parentEnv.SetVisibility(importName, importedBindingVisibility)
 	parentEnv.SetValueOrigin(importName, qualifiedOrigin)
 
 	installUnqualifiedImportSymbols(parentEnv, schemaModule, importName)
@@ -45,7 +47,7 @@ func installUnqualifiedImportValuesForInference(parentEnv Env, schemaModule Env,
 		}
 
 		parentEnv.Add(name, scheme)
-		parentEnv.SetVisibility(name, PublicVisibility)
+		parentEnv.SetVisibility(name, importedBindingVisibility)
 		parentEnv.SetValueOrigin(name, origin)
 	}
 }
@@ -84,7 +86,7 @@ func installUnqualifiedImportEnumValuesForInference(parentEnv Env, enumMod *Modu
 		}
 
 		parentEnv.Add(enumValName, enumValScheme)
-		parentEnv.SetVisibility(enumValName, PublicVisibility)
+		parentEnv.SetVisibility(enumValName, importedBindingVisibility)
 		parentEnv.SetValueOrigin(enumValName, origin)
 	}
 }
@@ -106,7 +108,7 @@ func installUnqualifiedImportDirectivesFromModule(parentEnv Env, mod *Module, im
 
 func installImportedEvalEnvironment(parentEnv EvalEnv, importName string, moduleEnv EvalEnv) {
 	qualifiedOrigin := ImportedBindingOrigin(importName, true)
-	parentEnv.SetWithVisibility(importName, moduleEnv, PublicVisibility)
+	parentEnv.SetWithVisibility(importName, moduleEnv, importedBindingVisibility)
 	setEvalValueOrigin(parentEnv, importName, qualifiedOrigin)
 
 	installUnqualifiedImportValues(parentEnv, moduleEnv, importName)
@@ -128,7 +130,7 @@ func installUnqualifiedImportValues(parentEnv EvalEnv, moduleEnv EvalEnv, import
 			continue
 		}
 
-		parentEnv.SetWithVisibility(name, value, PublicVisibility)
+		parentEnv.SetWithVisibility(name, value, importedBindingVisibility)
 		setEvalValueOrigin(parentEnv, name, origin)
 
 		if enumModuleVal, ok := value.(*ModuleValue); ok {
@@ -152,7 +154,7 @@ func installUnqualifiedImportEnumValues(parentEnv EvalEnv, enumModuleVal *Module
 			continue
 		}
 
-		parentEnv.SetWithVisibility(enumValName, enumVal, PublicVisibility)
+		parentEnv.SetWithVisibility(enumValName, enumVal, importedBindingVisibility)
 		setEvalValueOrigin(parentEnv, enumValName, origin)
 	}
 }

--- a/pkg/dang/import_install.go
+++ b/pkg/dang/import_install.go
@@ -1,0 +1,221 @@
+package dang
+
+import "github.com/vito/dang/pkg/hm"
+
+func installImportedTypeEnvironment(parentEnv Env, importName string, schemaModule Env) {
+	qualifiedOrigin := ImportedBindingOrigin(importName, true)
+
+	parentEnv.AddClass(importName, schemaModule)
+	parentEnv.SetTypeOrigin(importName, qualifiedOrigin)
+	parentEnv.Add(importName, hm.NewScheme(nil, NonNull(schemaModule)))
+	parentEnv.SetVisibility(importName, PublicVisibility)
+	parentEnv.SetValueOrigin(importName, qualifiedOrigin)
+
+	installUnqualifiedImportSymbols(parentEnv, schemaModule, importName)
+}
+
+func installUnqualifiedImportSymbols(parentEnv Env, schemaModule Env, importName string) {
+	installUnqualifiedImportValuesForInference(parentEnv, schemaModule, importName)
+
+	if mod, ok := schemaModule.(*CompositeModule); ok {
+		if primaryMod, ok := mod.primary.(*Module); ok {
+			installUnqualifiedImportTypesFromModule(parentEnv, primaryMod, importName)
+			installUnqualifiedImportDirectivesFromModule(parentEnv, primaryMod, importName)
+		}
+		return
+	}
+	if mod, ok := schemaModule.(*Module); ok {
+		installUnqualifiedImportTypesFromModule(parentEnv, mod, importName)
+		installUnqualifiedImportDirectivesFromModule(parentEnv, mod, importName)
+	}
+}
+
+func installUnqualifiedImportValuesForInference(parentEnv Env, schemaModule Env, importName string) {
+	origin := ImportedBindingOrigin(importName, false)
+	for name, scheme := range schemaModule.Bindings(PublicVisibility) {
+		if name == importName {
+			continue
+		}
+
+		if _, exists := parentEnv.LocalSchemeOf(name); exists {
+			if localValueBindingIsUnqualifiedImport(parentEnv, name) {
+				addValueImportProvider(parentEnv, name, importName)
+			}
+			continue
+		}
+
+		parentEnv.Add(name, scheme)
+		parentEnv.SetVisibility(name, PublicVisibility)
+		parentEnv.SetValueOrigin(name, origin)
+	}
+}
+
+func installUnqualifiedImportTypesFromModule(parentEnv Env, mod *Module, importName string) {
+	origin := ImportedBindingOrigin(importName, false)
+	for name, class := range mod.classes {
+		if name == importName {
+			continue
+		}
+
+		if _, exists := parentEnv.NamedType(name); exists {
+			if localTypeBindingIsUnqualifiedImport(parentEnv, name) {
+				addTypeImportProvider(parentEnv, name, importName)
+			}
+			continue
+		}
+
+		parentEnv.AddClass(name, class)
+		parentEnv.SetTypeOrigin(name, origin)
+
+		if enumMod, ok := class.(*Module); ok && enumMod.Kind == EnumKind {
+			installUnqualifiedImportEnumValuesForInference(parentEnv, enumMod, importName)
+		}
+	}
+}
+
+func installUnqualifiedImportEnumValuesForInference(parentEnv Env, enumMod *Module, importName string) {
+	origin := ImportedBindingOrigin(importName, false)
+	for enumValName, enumValScheme := range enumMod.Bindings(PublicVisibility) {
+		if _, exists := parentEnv.LocalSchemeOf(enumValName); exists {
+			if localValueBindingIsUnqualifiedImport(parentEnv, enumValName) {
+				addValueImportProvider(parentEnv, enumValName, importName)
+			}
+			continue
+		}
+
+		parentEnv.Add(enumValName, enumValScheme)
+		parentEnv.SetVisibility(enumValName, PublicVisibility)
+		parentEnv.SetValueOrigin(enumValName, origin)
+	}
+}
+
+func installUnqualifiedImportDirectivesFromModule(parentEnv Env, mod *Module, importName string) {
+	origin := ImportedBindingOrigin(importName, false)
+	for directiveName, directive := range mod.directives {
+		if _, exists := parentEnv.GetDirective(directiveName); exists {
+			if localDirectiveBindingIsUnqualifiedImport(parentEnv, directiveName) {
+				addDirectiveImportProvider(parentEnv, directiveName, importName)
+			}
+			continue
+		}
+
+		parentEnv.AddDirective(directiveName, directive)
+		parentEnv.SetDirectiveOrigin(directiveName, origin)
+	}
+}
+
+func installImportedEvalEnvironment(parentEnv EvalEnv, importName string, moduleEnv EvalEnv) {
+	qualifiedOrigin := ImportedBindingOrigin(importName, true)
+	parentEnv.SetWithVisibility(importName, moduleEnv, PublicVisibility)
+	setEvalValueOrigin(parentEnv, importName, qualifiedOrigin)
+
+	installUnqualifiedImportValues(parentEnv, moduleEnv, importName)
+}
+
+func installUnqualifiedImportValues(parentEnv EvalEnv, moduleEnv EvalEnv, importName string) {
+	origin := ImportedBindingOrigin(importName, false)
+	for _, binding := range moduleEnv.Bindings(PublicVisibility) {
+		name := binding.Key
+		value := binding.Value
+		if name == importName {
+			continue
+		}
+
+		if _, exists := parentEnv.GetLocal(name); exists {
+			if evalValueBindingIsUnqualifiedImport(parentEnv, name) {
+				addEvalValueImportProvider(parentEnv, name, importName)
+			}
+			continue
+		}
+
+		parentEnv.SetWithVisibility(name, value, PublicVisibility)
+		setEvalValueOrigin(parentEnv, name, origin)
+
+		if enumModuleVal, ok := value.(*ModuleValue); ok {
+			if mod, ok := enumModuleVal.Mod.(*Module); ok && mod.Kind == EnumKind {
+				installUnqualifiedImportEnumValues(parentEnv, enumModuleVal, importName)
+			}
+		}
+	}
+}
+
+func installUnqualifiedImportEnumValues(parentEnv EvalEnv, enumModuleVal *ModuleValue, importName string) {
+	origin := ImportedBindingOrigin(importName, false)
+	for _, enumBinding := range enumModuleVal.Bindings(PublicVisibility) {
+		enumValName := enumBinding.Key
+		enumVal := enumBinding.Value
+
+		if _, exists := parentEnv.GetLocal(enumValName); exists {
+			if evalValueBindingIsUnqualifiedImport(parentEnv, enumValName) {
+				addEvalValueImportProvider(parentEnv, enumValName, importName)
+			}
+			continue
+		}
+
+		parentEnv.SetWithVisibility(enumValName, enumVal, PublicVisibility)
+		setEvalValueOrigin(parentEnv, enumValName, origin)
+	}
+}
+
+func localTypeBindingIsUnqualifiedImport(env Env, name string) bool {
+	origin, found := env.LocalTypeOrigin(name)
+	return found && origin.IsUnqualifiedImport()
+}
+
+func localValueBindingIsUnqualifiedImport(env Env, name string) bool {
+	origin, found := env.LocalValueOrigin(name)
+	return found && origin.IsUnqualifiedImport()
+}
+
+func localDirectiveBindingIsUnqualifiedImport(env Env, name string) bool {
+	origin, found := env.LocalDirectiveOrigin(name)
+	return found && origin.IsUnqualifiedImport()
+}
+
+func addTypeImportProvider(env Env, name, importName string) {
+	if origin, found := env.LocalTypeOrigin(name); found {
+		env.SetTypeOrigin(name, origin.AddImportProvider(importName))
+	}
+}
+
+func addValueImportProvider(env Env, name, importName string) {
+	if origin, found := env.LocalValueOrigin(name); found {
+		env.SetValueOrigin(name, origin.AddImportProvider(importName))
+	}
+}
+
+func addDirectiveImportProvider(env Env, name, importName string) {
+	if origin, found := env.LocalDirectiveOrigin(name); found {
+		env.SetDirectiveOrigin(name, origin.AddImportProvider(importName))
+	}
+}
+
+func evalValueBindingIsUnqualifiedImport(env EvalEnv, name string) bool {
+	if modVal, ok := evalEnvModuleValue(env); ok {
+		return localValueBindingIsUnqualifiedImport(modVal.Mod, name)
+	}
+	return false
+}
+
+func addEvalValueImportProvider(env EvalEnv, name, importName string) {
+	if modVal, ok := evalEnvModuleValue(env); ok {
+		addValueImportProvider(modVal.Mod, name, importName)
+	}
+}
+
+func setEvalValueOrigin(env EvalEnv, name string, origin BindingOrigin) {
+	if modVal, ok := evalEnvModuleValue(env); ok {
+		modVal.Mod.SetValueOrigin(name, origin)
+	}
+}
+
+func evalEnvModuleValue(env EvalEnv) (*ModuleValue, bool) {
+	switch e := env.(type) {
+	case *ModuleValue:
+		return e, true
+	case CompositeEnv:
+		return evalEnvModuleValue(e.primary)
+	default:
+		return nil, false
+	}
+}

--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -323,23 +323,35 @@ var _ Hoister = &ClassDecl{}
 
 // Imported schema types are installed into the local type map so they can be
 // referenced unqualified. A real type declaration with the same name must
-// replace that imported alias, not mutate the imported schema type; qualified
-// references like Dagger.Container still resolve through the import module.
+// replace an unqualified imported alias, not mutate the imported schema type.
+// Qualified import aliases like Dagger are protected so Dagger.Container keeps
+// resolving through the imported module.
 func localTypeShadowsImport(env Env, name string) bool {
 	origin, found := env.LocalTypeOrigin(name)
 	return found && origin.IsUnqualifiedImport()
 }
 
-func declareLocalType(env Env, name string, kind ModuleKind) *Module {
-	if existing, found := env.LocalNamedType(name); found && !localTypeShadowsImport(env, name) {
-		if mod, ok := existing.(*Module); ok {
-			return mod
+func localTypeIsQualifiedImport(env Env, name string) bool {
+	origin, found := env.LocalTypeOrigin(name)
+	return found && origin.Kind == BindingOriginImport && origin.Qualified
+}
+
+func declareLocalType(env Env, name string, kind ModuleKind) (*Module, error) {
+	if existing, found := env.LocalNamedType(name); found {
+		if localTypeShadowsImport(env, name) {
+			// Local declarations intentionally shadow unqualified imports.
+		} else if localTypeIsQualifiedImport(env, name) {
+			return nil, fmt.Errorf("type %q conflicts with import alias", name)
+		} else if mod, ok := existing.(*Module); ok {
+			return mod, nil
+		} else {
+			return nil, fmt.Errorf("type %q conflicts with existing type", name)
 		}
 	}
 
 	mod := NewModule(name, kind)
 	env.AddClass(name, mod)
-	return mod
+	return mod, nil
 }
 
 // findNewConstructor returns the NewConstructorDecl from the class body, if any
@@ -369,7 +381,10 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 		return fmt.Errorf("ClassDecl.Hoist: environment does not support module operations")
 	}
 
-	class := declareLocalType(mod, c.Name.Name, ObjectKind)
+	class, declareErr := declareLocalType(mod, c.Name.Name, ObjectKind)
+	if declareErr != nil {
+		return WrapInferError(declareErr, c.Name)
+	}
 
 	// Pass 0 must only register the type name. Other top-level types may refer
 	// to this class before its file is reached, so anything that resolves field
@@ -461,7 +476,10 @@ func (c *ClassDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 		return nil, fmt.Errorf("ClassDecl.Infer: environment does not support module operations")
 	}
 
-	class := declareLocalType(mod, c.Name.Name, ObjectKind)
+	class, declareErr := declareLocalType(mod, c.Name.Name, ObjectKind)
+	if declareErr != nil {
+		return nil, WrapInferError(declareErr, c.Name)
+	}
 
 	// Store doc string for the class name in the environment
 	if c.DocString != "" {
@@ -764,7 +782,10 @@ func (e *EnumDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 		return fmt.Errorf("EnumDecl.Hoist: environment does not support module operations")
 	}
 
-	enumType := declareLocalType(mod, e.Name.Name, EnumKind)
+	enumType, declareErr := declareLocalType(mod, e.Name.Name, EnumKind)
+	if declareErr != nil {
+		return WrapInferError(declareErr, e.Name)
+	}
 
 	e.Inferred = enumType
 
@@ -802,7 +823,10 @@ func (e *EnumDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.
 		return nil, fmt.Errorf("EnumDecl.Infer: environment does not support module operations")
 	}
 
-	enumType := declareLocalType(mod, e.Name.Name, EnumKind)
+	enumType, declareErr := declareLocalType(mod, e.Name.Name, EnumKind)
+	if declareErr != nil {
+		return nil, WrapInferError(declareErr, e.Name)
+	}
 	if e.DocString != "" {
 		mod.SetDocString(e.Name.Name, e.DocString)
 	}
@@ -888,7 +912,10 @@ func (s *ScalarDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pa
 		return fmt.Errorf("ScalarDecl.Hoist: environment does not support module operations")
 	}
 
-	scalarType := declareLocalType(mod, s.Name.Name, ScalarKind)
+	scalarType, declareErr := declareLocalType(mod, s.Name.Name, ScalarKind)
+	if declareErr != nil {
+		return WrapInferError(declareErr, s.Name)
+	}
 
 	s.Inferred = scalarType
 
@@ -909,7 +936,10 @@ func (s *ScalarDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (h
 		return nil, fmt.Errorf("ScalarDecl.Infer: environment does not support module operations")
 	}
 
-	scalarType := declareLocalType(mod, s.Name.Name, ScalarKind)
+	scalarType, declareErr := declareLocalType(mod, s.Name.Name, ScalarKind)
+	if declareErr != nil {
+		return nil, WrapInferError(declareErr, s.Name)
+	}
 	if s.DocString != "" {
 		mod.SetDocString(s.Name.Name, s.DocString)
 	}
@@ -984,7 +1014,10 @@ func (i *InterfaceDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher,
 
 	// Pass 0: Register the interface type
 	if pass == 0 {
-		iface := declareLocalType(mod, i.Name.Name, InterfaceKind)
+		iface, declareErr := declareLocalType(mod, i.Name.Name, InterfaceKind)
+		if declareErr != nil {
+			return WrapInferError(declareErr, i.Name)
+		}
 
 		// Add the interface type to the environment so it can be referenced
 		interfaceScheme := hm.NewScheme(nil, iface)
@@ -1091,7 +1124,10 @@ func (u *UnionDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 
 	if pass == 0 {
 		// Pass 0: Register the union type
-		unionMod := declareLocalType(mod, u.Name.Name, UnionKind)
+		unionMod, declareErr := declareLocalType(mod, u.Name.Name, UnionKind)
+		if declareErr != nil {
+			return WrapInferError(declareErr, u.Name)
+		}
 
 		// Add the union type to the environment so it can be referenced
 		env.Add(u.Name.Name, hm.NewScheme(nil, unionMod))

--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -326,24 +326,8 @@ var _ Hoister = &ClassDecl{}
 // replace that imported alias, not mutate the imported schema type; qualified
 // references like Dagger.Container still resolve through the import module.
 func localTypeShadowsImport(env Env, name string) bool {
-	switch e := env.(type) {
-	case *Module:
-		return len(e.unqualifiedTypeImports[name]) > 0
-	case *CompositeModule:
-		return localTypeShadowsImport(e.primary, name)
-	default:
-		return false
-	}
-}
-
-func clearShadowedUnqualifiedImports(env Env, name string) {
-	switch e := env.(type) {
-	case *Module:
-		delete(e.unqualifiedTypeImports, name)
-		delete(e.unqualifiedValueImports, name)
-	case *CompositeModule:
-		clearShadowedUnqualifiedImports(e.primary, name)
-	}
+	origin, found := env.LocalTypeOrigin(name)
+	return found && origin.IsUnqualifiedImport()
 }
 
 func declareLocalType(env Env, name string, kind ModuleKind) *Module {
@@ -355,14 +339,7 @@ func declareLocalType(env Env, name string, kind ModuleKind) *Module {
 
 	mod := NewModule(name, kind)
 	env.AddClass(name, mod)
-	clearShadowedUnqualifiedImports(env, name)
 	return mod
-}
-
-func clearEvalShadowedUnqualifiedImports(env EvalEnv, name string) {
-	if modVal, ok := env.(*ModuleValue); ok {
-		clearShadowedUnqualifiedImports(modVal.Mod, name)
-	}
 }
 
 // findNewConstructor returns the NewConstructorDecl from the class body, if any
@@ -732,7 +709,6 @@ func (c *ClassDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 		}
 
 		// Add the constructor to the evaluation environment
-		clearEvalShadowedUnqualifiedImports(env, c.Name.Name)
 		env.SetWithVisibility(c.Name.Name, constructor, c.Visibility)
 
 		return constructor, nil
@@ -859,7 +835,6 @@ func (e *EnumDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	}
 
 	// Register the enum module in the environment
-	clearEvalShadowedUnqualifiedImports(env, e.Name.Name)
 	env.SetWithVisibility(e.Name.Name, enumModule, e.Visibility)
 
 	return enumModule, nil
@@ -951,7 +926,6 @@ func (s *ScalarDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	scalarModule := NewModuleValue(s.Inferred)
 
 	// Register the scalar type in the environment
-	clearEvalShadowedUnqualifiedImports(env, s.Name.Name)
 	env.SetWithVisibility(s.Name.Name, scalarModule, s.Visibility)
 
 	return scalarModule, nil
@@ -1060,7 +1034,6 @@ func (i *InterfaceDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	// Interfaces are pure type declarations - they don't have runtime values
 	// Just register the interface module in the environment
 	interfaceModule := NewModuleValue(i.Inferred)
-	clearEvalShadowedUnqualifiedImports(env, i.Name.Name)
 	env.SetWithVisibility(i.Name.Name, interfaceModule, i.Visibility)
 	return interfaceModule, nil
 }
@@ -1188,7 +1161,6 @@ func (u *UnionDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 func (u *UnionDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	// Unions are pure type declarations - register the union module
 	unionModule := NewModuleValue(u.Inferred)
-	clearEvalShadowedUnqualifiedImports(env, u.Name.Name)
 	env.SetWithVisibility(u.Name.Name, unionModule, u.Visibility)
 	return unionModule, nil
 }

--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -188,7 +188,7 @@ func (s *SlotDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 			// This is a runtime error - required types must have values
 			if inferredType := s.GetInferredType(); inferredType != nil {
 				if _, isNonNull := inferredType.(hm.NonNullType); isNonNull {
-					return nil, fmt.Errorf("required slot %q (type %s) has no value", s.Name.Name, inferredType.Name())
+					return nil, fmt.Errorf("required slot %q (type %s) has no value", s.Name.Name, inferredType)
 				}
 			}
 
@@ -581,7 +581,7 @@ func (c *ClassDecl) validateInterfaceImplementations(classMod *Module, env Env, 
 		classFieldType, _ := classFieldScheme.Type()
 
 		// Validate field type compatibility
-		if err := validateFieldImplementation(field, ifaceFieldType, classFieldType, ifaceSym.Name, c.Name.Name); err != nil {
+		if err := validateFieldImplementation(field, ifaceFieldType, classFieldType, ifaceMod.String(), classMod.String()); err != nil {
 			return WrapInferError(err, ifaceSym)
 		}
 	}
@@ -592,7 +592,7 @@ func (c *ClassDecl) validateInterfaceImplementations(classMod *Module, env Env, 
 		for _, field := range missingFields {
 			fieldScheme, _ := ifaceMod.SchemeOf(field)
 			errs.Add(WrapInferError(
-				fmt.Errorf("class %s is missing `%s%s`, required by interface %s", c.Name.Name, field, fieldScheme, ifaceSym.Name),
+				fmt.Errorf("class %s is missing `%s%s`, required by interface %s", classMod, field, fieldScheme, ifaceMod),
 				ifaceSym,
 			))
 		}
@@ -677,7 +677,7 @@ func (c *ClassDecl) inferNewConstructor(ctx context.Context, newDecl *NewConstru
 	if _, err := hm.Assignable(bodyType, expectedType); err != nil {
 		lastForm := newDecl.BodyBlock.Forms[len(newDecl.BodyBlock.Forms)-1]
 		return NewInferError(
-			fmt.Errorf("new() must return %s, got %s", expectedType.Name(), bodyType.Name()),
+			fmt.Errorf("new() must return %s, got %s", expectedType, bodyType),
 			lastForm,
 		)
 	}
@@ -689,7 +689,7 @@ func (c *ClassDecl) inferNewConstructor(ctx context.Context, newDecl *NewConstru
 		}
 		if _, err := hm.Assignable(retType, expectedType); err != nil {
 			return NewInferError(
-				fmt.Errorf("new() must return %s, got %s", expectedType.Name(), retType.Name()),
+				fmt.Errorf("new() must return %s, got %s", expectedType, retType),
 				ret.Value,
 			)
 		}

--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -321,6 +321,50 @@ func (c *ClassDecl) GetSourceLocation() *SourceLocation { return c.Loc }
 
 var _ Hoister = &ClassDecl{}
 
+// Imported schema types are installed into the local type map so they can be
+// referenced unqualified. A real type declaration with the same name must
+// replace that imported alias, not mutate the imported schema type; qualified
+// references like Dagger.Container still resolve through the import module.
+func localTypeShadowsImport(env Env, name string) bool {
+	switch e := env.(type) {
+	case *Module:
+		return len(e.unqualifiedTypeImports[name]) > 0
+	case *CompositeModule:
+		return localTypeShadowsImport(e.primary, name)
+	default:
+		return false
+	}
+}
+
+func clearShadowedUnqualifiedImports(env Env, name string) {
+	switch e := env.(type) {
+	case *Module:
+		delete(e.unqualifiedTypeImports, name)
+		delete(e.unqualifiedValueImports, name)
+	case *CompositeModule:
+		clearShadowedUnqualifiedImports(e.primary, name)
+	}
+}
+
+func declareLocalType(env Env, name string, kind ModuleKind) *Module {
+	if existing, found := env.LocalNamedType(name); found && !localTypeShadowsImport(env, name) {
+		if mod, ok := existing.(*Module); ok {
+			return mod
+		}
+	}
+
+	mod := NewModule(name, kind)
+	env.AddClass(name, mod)
+	clearShadowedUnqualifiedImports(env, name)
+	return mod
+}
+
+func clearEvalShadowedUnqualifiedImports(env EvalEnv, name string) {
+	if modVal, ok := env.(*ModuleValue); ok {
+		clearShadowedUnqualifiedImports(modVal.Mod, name)
+	}
+}
+
 // findNewConstructor returns the NewConstructorDecl from the class body, if any
 func (c *ClassDecl) findNewConstructor() *NewConstructorDecl {
 	for _, form := range c.Value.Forms {
@@ -348,11 +392,7 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 		return fmt.Errorf("ClassDecl.Hoist: environment does not support module operations")
 	}
 
-	class, found := mod.LocalNamedType(c.Name.Name)
-	if !found {
-		class = NewModule(c.Name.Name, ObjectKind)
-		mod.AddClass(c.Name.Name, class)
-	}
+	class := declareLocalType(mod, c.Name.Name, ObjectKind)
 
 	// Pass 0 must only register the type name. Other top-level types may refer
 	// to this class before its file is reached, so anything that resolves field
@@ -375,7 +415,7 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 	} else {
 		constructorParams = c.extractConstructorParameters()
 	}
-	constructorType, err := c.buildConstructorType(ctx, inferEnv, constructorParams, class.(*Module), fresh)
+	constructorType, err := c.buildConstructorType(ctx, inferEnv, constructorParams, class, fresh)
 	if err != nil {
 		return err
 	}
@@ -388,7 +428,7 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 	// Link the implementation after all interface type names have been
 	// registered by pass 0.
 	if len(c.Implements) > 0 {
-		classMod := class.(*Module)
+		classMod := class
 		for _, ifaceSym := range c.Implements {
 			ifaceType, found := mod.NamedType(ifaceSym.Name)
 			if !found {
@@ -444,11 +484,7 @@ func (c *ClassDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 		return nil, fmt.Errorf("ClassDecl.Infer: environment does not support module operations")
 	}
 
-	class, found := mod.LocalNamedType(c.Name.Name)
-	if !found {
-		class = NewModule(c.Name.Name, ObjectKind)
-		mod.AddClass(c.Name.Name, class)
-	}
+	class := declareLocalType(mod, c.Name.Name, ObjectKind)
 
 	// Store doc string for the class name in the environment
 	if c.DocString != "" {
@@ -456,7 +492,7 @@ func (c *ClassDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 	}
 
 	// Set this early so we can at least partially infer.
-	c.Inferred = class.(*Module)
+	c.Inferred = class
 
 	// Set dynamic scope type to the class type
 	selfType := hm.NonNullType{Type: class}
@@ -696,6 +732,7 @@ func (c *ClassDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 		}
 
 		// Add the constructor to the evaluation environment
+		clearEvalShadowedUnqualifiedImports(env, c.Name.Name)
 		env.SetWithVisibility(c.Name.Name, constructor, c.Visibility)
 
 		return constructor, nil
@@ -751,14 +788,9 @@ func (e *EnumDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 		return fmt.Errorf("EnumDecl.Hoist: environment does not support module operations")
 	}
 
-	// Create the enum type (module) if it doesn't exist
-	enumType, found := mod.LocalNamedType(e.Name.Name)
-	if !found {
-		enumType = NewModule(e.Name.Name, EnumKind)
-		mod.AddClass(e.Name.Name, enumType)
-	}
+	enumType := declareLocalType(mod, e.Name.Name, EnumKind)
 
-	e.Inferred = enumType.(*Module)
+	e.Inferred = enumType
 
 	// Add the enum module to the environment so it can be referenced
 	// Note: We add the enum type itself, not wrapped in NonNullType, matching GraphQL enum behavior
@@ -794,17 +826,12 @@ func (e *EnumDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.
 		return nil, fmt.Errorf("EnumDecl.Infer: environment does not support module operations")
 	}
 
-	enumType, found := mod.LocalNamedType(e.Name.Name)
-	if !found {
-		enumType = NewModule(e.Name.Name, EnumKind)
-		mod.AddClass(e.Name.Name, enumType)
-
-		if e.DocString != "" {
-			mod.SetDocString(e.Name.Name, e.DocString)
-		}
+	enumType := declareLocalType(mod, e.Name.Name, EnumKind)
+	if e.DocString != "" {
+		mod.SetDocString(e.Name.Name, e.DocString)
 	}
 
-	e.Inferred = enumType.(*Module)
+	e.Inferred = enumType
 	e.SetInferredType(enumType)
 
 	return enumType, nil
@@ -832,6 +859,7 @@ func (e *EnumDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	}
 
 	// Register the enum module in the environment
+	clearEvalShadowedUnqualifiedImports(env, e.Name.Name)
 	env.SetWithVisibility(e.Name.Name, enumModule, e.Visibility)
 
 	return enumModule, nil
@@ -885,14 +913,9 @@ func (s *ScalarDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pa
 		return fmt.Errorf("ScalarDecl.Hoist: environment does not support module operations")
 	}
 
-	// Create the scalar type (module) if it doesn't exist
-	scalarType, found := mod.LocalNamedType(s.Name.Name)
-	if !found {
-		scalarType = NewModule(s.Name.Name, ScalarKind)
-		mod.AddClass(s.Name.Name, scalarType)
-	}
+	scalarType := declareLocalType(mod, s.Name.Name, ScalarKind)
 
-	s.Inferred = scalarType.(*Module)
+	s.Inferred = scalarType
 
 	// Add the scalar type to the environment
 	scalarScheme := hm.NewScheme(nil, scalarType)
@@ -911,17 +934,12 @@ func (s *ScalarDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (h
 		return nil, fmt.Errorf("ScalarDecl.Infer: environment does not support module operations")
 	}
 
-	scalarType, found := mod.LocalNamedType(s.Name.Name)
-	if !found {
-		scalarType = NewModule(s.Name.Name, ScalarKind)
-		mod.AddClass(s.Name.Name, scalarType)
-
-		if s.DocString != "" {
-			mod.SetDocString(s.Name.Name, s.DocString)
-		}
+	scalarType := declareLocalType(mod, s.Name.Name, ScalarKind)
+	if s.DocString != "" {
+		mod.SetDocString(s.Name.Name, s.DocString)
 	}
 
-	s.Inferred = scalarType.(*Module)
+	s.Inferred = scalarType
 	s.SetInferredType(scalarType)
 
 	return scalarType, nil
@@ -933,6 +951,7 @@ func (s *ScalarDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	scalarModule := NewModuleValue(s.Inferred)
 
 	// Register the scalar type in the environment
+	clearEvalShadowedUnqualifiedImports(env, s.Name.Name)
 	env.SetWithVisibility(s.Name.Name, scalarModule, s.Visibility)
 
 	return scalarModule, nil
@@ -991,8 +1010,7 @@ func (i *InterfaceDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher,
 
 	// Pass 0: Register the interface type
 	if pass == 0 {
-		iface := NewModule(i.Name.Name, InterfaceKind)
-		mod.AddClass(i.Name.Name, iface)
+		iface := declareLocalType(mod, i.Name.Name, InterfaceKind)
 
 		// Add the interface type to the environment so it can be referenced
 		interfaceScheme := hm.NewScheme(nil, iface)
@@ -1042,6 +1060,7 @@ func (i *InterfaceDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	// Interfaces are pure type declarations - they don't have runtime values
 	// Just register the interface module in the environment
 	interfaceModule := NewModuleValue(i.Inferred)
+	clearEvalShadowedUnqualifiedImports(env, i.Name.Name)
 	env.SetWithVisibility(i.Name.Name, interfaceModule, i.Visibility)
 	return interfaceModule, nil
 }
@@ -1099,8 +1118,7 @@ func (u *UnionDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 
 	if pass == 0 {
 		// Pass 0: Register the union type
-		unionMod := NewModule(u.Name.Name, UnionKind)
-		mod.AddClass(u.Name.Name, unionMod)
+		unionMod := declareLocalType(mod, u.Name.Name, UnionKind)
 
 		// Add the union type to the environment so it can be referenced
 		env.Add(u.Name.Name, hm.NewScheme(nil, unionMod))
@@ -1170,6 +1188,7 @@ func (u *UnionDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm
 func (u *UnionDecl) Eval(ctx context.Context, env EvalEnv) (Value, error) {
 	// Unions are pure type declarations - register the union module
 	unionModule := NewModuleValue(u.Inferred)
+	clearEvalShadowedUnqualifiedImports(env, u.Name.Name)
 	env.SetWithVisibility(u.Name.Name, unionModule, u.Visibility)
 	return unionModule, nil
 }

--- a/pkg/dang/types.go
+++ b/pkg/dang/types.go
@@ -116,7 +116,7 @@ type ListType struct {
 var _ hm.Type = ListType{}
 
 func (t ListType) Name() string {
-	return fmt.Sprintf("[%s]", t.Type.Name())
+	return fmt.Sprintf("[%s]", t.Type)
 }
 
 func (t ListType) Apply(subs hm.Subs) hm.Substitutable {
@@ -171,7 +171,7 @@ type GraphQLListType struct {
 var _ hm.Type = GraphQLListType{}
 
 func (t GraphQLListType) Name() string {
-	return fmt.Sprintf("GraphQL[%s]", t.Type.Name())
+	return fmt.Sprintf("GraphQL[%s]", t.Type)
 }
 
 func (t GraphQLListType) Apply(subs hm.Subs) hm.Substitutable {

--- a/pkg/hm/types.go
+++ b/pkg/hm/types.go
@@ -204,8 +204,8 @@ func (ft *FunctionType) Supertypes() []Type {
 
 func (ft *FunctionType) String() string {
 	return fmt.Sprintf("(%s): %s",
-		strings.TrimSuffix(strings.TrimPrefix(ft.arg.Name(), "{"), "}"),
-		ft.ret.Name())
+		strings.TrimSuffix(strings.TrimPrefix(ft.arg.String(), "{"), "}"),
+		ft.ret.String())
 }
 
 func (ft *FunctionType) Format(s fmt.State, c rune) {
@@ -288,7 +288,7 @@ func NewUnionType(options ...Type) Type {
 func (t *UnionType) Name() string {
 	parts := make([]string, len(t.Options))
 	for i, option := range t.Options {
-		parts[i] = option.Name()
+		parts[i] = option.String()
 	}
 	return strings.Join(parts, " | ")
 }
@@ -364,9 +364,9 @@ type NonNullType struct {
 
 func (t NonNullType) Name() string {
 	if _, ok := t.Type.(*UnionType); ok {
-		return fmt.Sprintf("(%s)!", t.Type.Name())
+		return fmt.Sprintf("(%s)!", t.Type)
 	}
-	return fmt.Sprintf("%s!", t.Type.Name())
+	return fmt.Sprintf("%s!", t.Type)
 }
 
 func (t NonNullType) Apply(subs Subs) Substitutable {

--- a/tests/errors/import_shadowing_local_distinct.dang
+++ b/tests/errors/import_shadowing_local_distinct.dang
@@ -1,0 +1,34 @@
+# Local declarations that shadow imported GraphQL types must remain distinct
+# from the qualified imported types.
+
+import Test
+
+type User {
+  pub name: String!
+  pub origin: String! = "local"
+}
+
+enum Status { LOCAL REMOTE }
+
+scalar URL
+
+interface Node {
+  pub label: String!
+}
+
+type Cat {
+  pub name: String!
+}
+
+type Dog {
+  pub name: String!
+}
+
+union SearchResult = Cat | Dog
+
+# These imported values have qualified Test.* types, not the local shadowing types.
+let userShouldFail: User! = Test.primaryUser
+let statusShouldFail: Status! = Test.status
+let urlShouldFail: URL! = Test.homepage
+let nodeShouldFail: Node = Test.node(id: "1")
+let searchShouldFail: [SearchResult!]! = Test.search(query: "John")

--- a/tests/errors/inline_fragment_import_shadowing_interface.dang
+++ b/tests/errors/inline_fragment_import_shadowing_interface.dang
@@ -1,0 +1,13 @@
+# Local fields on a type that shadows an imported GraphQL type must not be
+# accepted inside inline fragments for the imported interface implementer.
+
+import Test
+
+type User {
+  pub name: String!
+  pub origin: String! = "local"
+}
+
+pub bad = node(id: "1").{
+  ... on User { origin }
+}

--- a/tests/errors/inline_fragment_import_shadowing_union.dang
+++ b/tests/errors/inline_fragment_import_shadowing_union.dang
@@ -1,0 +1,13 @@
+# Local fields on a type that shadows an imported GraphQL type must not be
+# accepted inside inline fragments for the imported union member.
+
+import Test
+
+type User {
+  pub name: String!
+  pub origin: String! = "local"
+}
+
+pub bad = search(query: "John").{
+  ... on User { origin }
+}

--- a/tests/test_import_shadowing.dang
+++ b/tests/test_import_shadowing.dang
@@ -1,0 +1,83 @@
+# Local declarations should shadow unqualified GraphQL imports while qualified
+# imports remain available. Test and Other expose the same schema, so these
+# local declarations also prove a local type resolves import ambiguity.
+
+import Other
+import Test
+
+type User {
+  pub name: String!
+  pub origin: String! = "local"
+}
+
+pub localUser: User! = User("Local User")
+assert { localUser.name == "Local User" }
+assert { localUser.origin == "local" }
+
+pub testUser: Test.User! = Test.primaryUser
+assert { testUser.name == "John Doe" }
+
+pub otherUser: Other.User! = Other.secondaryUser
+assert { otherUser.name == "Jane Smith" }
+
+enum Status { LOCAL REMOTE }
+
+pub localStatus: Status! = Status.LOCAL
+assert { localStatus == Status.LOCAL }
+assert { localStatus != Status.REMOTE }
+assert { Test.status == Test.Status.ACTIVE }
+assert { Other.status == Other.Status.ACTIVE }
+
+scalar URL
+
+pub localURL = URL
+assert { localURL != null }
+
+pub testURL: Test.URL! = Test.homepage
+assert { testURL == "https://dang-lang.dev" }
+
+pub otherURL: Other.URL! = Other.homepage
+assert { otherURL == "https://dang-lang.dev" }
+
+interface Node {
+  pub label: String!
+}
+
+type Labelled implements Node {
+  pub label: String!
+}
+
+pub localNode: Node! = Labelled("local-node")
+assert { Node != null }
+assert { localNode.label == "local-node" }
+
+pub testNode: Test.Node = Test.node(id: "1")
+assert { testNode.id == "1" }
+
+pub otherNode: Other.Node = Other.node(id: "2")
+assert { otherNode.id == "2" }
+
+type Cat {
+  pub name: String!
+}
+
+type Dog {
+  pub name: String!
+}
+
+union SearchResult = Cat | Dog
+
+pub localSearchResult: SearchResult! = Cat("Whiskers")
+assert { SearchResult != null }
+
+pub localSearchName = case (localSearchResult) {
+  c: Cat => c.name
+  d: Dog => d.name
+}
+assert { localSearchName == "Whiskers" }
+
+pub testSearchResults: [Test.SearchResult!]! = Test.search(query: "John")
+assert { testSearchResults != null }
+
+pub otherSearchResults: [Other.SearchResult!]! = Other.search(query: "Jane")
+assert { otherSearchResults != null }

--- a/tests/test_imported_type_shadowing_annotation.dang
+++ b/tests/test_imported_type_shadowing_annotation.dang
@@ -1,0 +1,18 @@
+# Local type declarations shadow unqualified imported types before constant
+# annotations are resolved. The Test schema also exports User; this nullable
+# slot must use the local User declared below, not Test.User.
+
+import Test
+
+pub maybe: User = null
+
+# This assignment is inferred after local types are declared. If `maybe` was
+# incorrectly inferred as Test.User during the constants phase, assigning it to
+# local User would fail with "cannot use Test.User as User".
+pub echoed: User = maybe
+
+type User {
+  pub name: String!
+}
+
+assert { echoed == null }

--- a/tests/test_inline_fragment_import_shadowing.dang
+++ b/tests/test_inline_fragment_import_shadowing.dang
@@ -1,0 +1,36 @@
+# Inline fragment type conditions should resolve against the receiver schema,
+# not a local type that shadows an imported GraphQL type.
+
+import Test
+
+type User {
+  pub name: String!
+  pub origin: String! = "local"
+}
+
+pub localUser: User! = User("Local User")
+assert { localUser.origin == "local" }
+
+# search returns [Test.SearchResult!]!, whose User member is Test.User.
+pub searchResults = search(query: "John").{
+  ... on User { name, age }
+}
+
+pub searchAge = case (searchResults[0]) {
+  u: User => u.age
+  else => null
+}
+assert { searchAge == 30 }
+
+# node returns Test.Node, whose User implementer is Test.User.
+pub nodeResult = node(id: "1").{
+  ... on User { name, age }
+}
+
+pub nodeAge = case (nodeResult) {
+  u: User => u.age
+  else => null
+}
+assert { nodeAge == 30 }
+
+print("Inline fragment import shadowing tests passed!")

--- a/tests/testdata/import_shadowing_local_distinct.golden
+++ b/tests/testdata/import_shadowing_local_distinct.golden
@@ -1,0 +1,65 @@
+5 inference errors:
+
+Error 1:
+[1m[31mError:[0m cannot use User! as User!
+  [2m[34m--> errors/import_shadowing_local_distinct.dang:30:29[0m
+ [2m    |[0m
+ [2m 28 | [0m
+ [2m 29 | # These imported values have qualified Test.* types, not the local shadowing types.[0m
+ [2m[34m[1m 30 | [0mlet userShouldFail: User! = Test.primaryUser
+[2m                                   [31m^^^^^^^^^^^^^^^^[0m
+ [2m 31 | let statusShouldFail: Status! = Test.status[0m
+ [2m 32 | let urlShouldFail: URL! = Test.homepage[0m
+ [2m    |[0m
+
+
+Error 2:
+[1m[31mError:[0m cannot use Status! as Status!
+  [2m[34m--> errors/import_shadowing_local_distinct.dang:31:33[0m
+ [2m    |[0m
+ [2m 29 | # These imported values have qualified Test.* types, not the local shadowing types.[0m
+ [2m 30 | let userShouldFail: User! = Test.primaryUser[0m
+ [2m[34m[1m 31 | [0mlet statusShouldFail: Status! = Test.status
+[2m                                       [31m^^^^^^^^^^^[0m
+ [2m 32 | let urlShouldFail: URL! = Test.homepage[0m
+ [2m 33 | let nodeShouldFail: Node = Test.node(id: "1")[0m
+ [2m    |[0m
+
+
+Error 3:
+[1m[31mError:[0m cannot use URL! as URL!
+  [2m[34m--> errors/import_shadowing_local_distinct.dang:32:27[0m
+ [2m    |[0m
+ [2m 30 | let userShouldFail: User! = Test.primaryUser[0m
+ [2m 31 | let statusShouldFail: Status! = Test.status[0m
+ [2m[34m[1m 32 | [0mlet urlShouldFail: URL! = Test.homepage
+[2m                                 [31m^^^^^^^^^^^^^[0m
+ [2m 33 | let nodeShouldFail: Node = Test.node(id: "1")[0m
+ [2m 34 | let searchShouldFail: [SearchResult!]! = Test.search(query: "John")[0m
+ [2m    |[0m
+
+
+Error 4:
+[1m[31mError:[0m cannot use Node as Node
+  [2m[34m--> errors/import_shadowing_local_distinct.dang:33:28[0m
+ [2m    |[0m
+ [2m 31 | let statusShouldFail: Status! = Test.status[0m
+ [2m 32 | let urlShouldFail: URL! = Test.homepage[0m
+ [2m[34m[1m 33 | [0mlet nodeShouldFail: Node = Test.node(id: "1")
+[2m                                  [31m^^^^^^^^^^^^^^^^^^[0m
+ [2m 34 | let searchShouldFail: [SearchResult!]! = Test.search(query: "John")[0m
+ [2m 35 | [0m
+ [2m    |[0m
+
+
+Error 5:
+[1m[31mError:[0m cannot use [SearchResult!]! as [SearchResult!]!
+  [2m[34m--> errors/import_shadowing_local_distinct.dang:34:42[0m
+ [2m    |[0m
+ [2m 32 | let urlShouldFail: URL! = Test.homepage[0m
+ [2m 33 | let nodeShouldFail: Node = Test.node(id: "1")[0m
+ [2m[34m[1m 34 | [0mlet searchShouldFail: [SearchResult!]! = Test.search(query: "John")
+[2m                                                [31m^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+ [2m 35 | [0m
+ [2m    |[0m
+

--- a/tests/testdata/import_shadowing_local_distinct.golden
+++ b/tests/testdata/import_shadowing_local_distinct.golden
@@ -1,7 +1,7 @@
 5 inference errors:
 
 Error 1:
-[1m[31mError:[0m cannot use User! as User!
+[1m[31mError:[0m cannot use Test.User! as User!
   [2m[34m--> errors/import_shadowing_local_distinct.dang:30:29[0m
  [2m    |[0m
  [2m 28 | [0m
@@ -14,7 +14,7 @@ Error 1:
 
 
 Error 2:
-[1m[31mError:[0m cannot use Status! as Status!
+[1m[31mError:[0m cannot use Test.Status! as Status!
   [2m[34m--> errors/import_shadowing_local_distinct.dang:31:33[0m
  [2m    |[0m
  [2m 29 | # These imported values have qualified Test.* types, not the local shadowing types.[0m
@@ -27,7 +27,7 @@ Error 2:
 
 
 Error 3:
-[1m[31mError:[0m cannot use URL! as URL!
+[1m[31mError:[0m cannot use Test.URL! as URL!
   [2m[34m--> errors/import_shadowing_local_distinct.dang:32:27[0m
  [2m    |[0m
  [2m 30 | let userShouldFail: User! = Test.primaryUser[0m
@@ -40,7 +40,7 @@ Error 3:
 
 
 Error 4:
-[1m[31mError:[0m cannot use Node as Node
+[1m[31mError:[0m cannot use Test.Node as Node
   [2m[34m--> errors/import_shadowing_local_distinct.dang:33:28[0m
  [2m    |[0m
  [2m 31 | let statusShouldFail: Status! = Test.status[0m
@@ -53,7 +53,7 @@ Error 4:
 
 
 Error 5:
-[1m[31mError:[0m cannot use [SearchResult!]! as [SearchResult!]!
+[1m[31mError:[0m cannot use [Test.SearchResult!]! as [SearchResult!]!
   [2m[34m--> errors/import_shadowing_local_distinct.dang:34:42[0m
  [2m    |[0m
  [2m 32 | let urlShouldFail: URL! = Test.homepage[0m

--- a/tests/testdata/inline_fragment_import_shadowing_interface.golden
+++ b/tests/testdata/inline_fragment_import_shadowing_interface.golden
@@ -1,0 +1,11 @@
+[1m[31mError:[0m field origin not found on type Test.User
+  [2m[34m--> errors/inline_fragment_import_shadowing_interface.dang:12:17[0m
+ [2m    |[0m
+ [2m 10 | [0m
+ [2m 11 | pub bad = node(id: "1").{[0m
+ [2m[34m[1m 12 | [0m  ... on User { origin }
+[2m                       [31m^^^^^^[0m
+ [2m 13 | }[0m
+ [2m 14 | [0m
+ [2m    |[0m
+

--- a/tests/testdata/inline_fragment_import_shadowing_union.golden
+++ b/tests/testdata/inline_fragment_import_shadowing_union.golden
@@ -1,0 +1,11 @@
+[1m[31mError:[0m field origin not found on type Test.User
+  [2m[34m--> errors/inline_fragment_import_shadowing_union.dang:12:17[0m
+ [2m    |[0m
+ [2m 10 | [0m
+ [2m 11 | pub bad = search(query: "John").{[0m
+ [2m[34m[1m 12 | [0m  ... on User { origin }
+[2m                       [31m^^^^^^[0m
+ [2m 13 | }[0m
+ [2m 14 | [0m
+ [2m    |[0m
+

--- a/tests/testdata/inline_fragment_unselected_field_graphql.golden
+++ b/tests/testdata/inline_fragment_unselected_field_graphql.golden
@@ -1,4 +1,4 @@
-[1m[31mError:[0m field "age" not found in User
+[1m[31mError:[0m field "age" not found in Test.User
   [2m[34m--> errors/inline_fragment_unselected_field_graphql.dang:12:14[0m
  [2m    |[0m
  [2m 10 | pub first = results[0][0m


### PR DESCRIPTION
## Summary

Fix local declaration shadowing for imported GraphQL schema types.

When an imported schema provides a type like `Container`, a local Dang declaration
with the same name now replaces only the unqualified import alias. Qualified
references such as `Dagger.Container` or `Test.User` still resolve to the
imported schema type, while bare `Container` / `User` resolve to the local
Dang declaration.

Fixes #52.

## What changed

- Teach local `type`, `enum`, `scalar`, `interface`, and `union` declarations to
  shadow imported unqualified aliases without mutating the imported schema module.
- Track binding provenance on environment entries and centralize import
  installation so unqualified import conflicts remain accurate while qualified
  imports stay stable.
- Keep imported aliases and unqualified imported bindings private to the current
  module so imports are usable locally without being re-exported.
- Reject local declarations that conflict with a qualified import alias, e.g.
  `type Dagger`, so qualified references like `Dagger.Container` continue to
  resolve through the imported module.
- Resolve inline fragment type conditions from the receiver union/interface
  members instead of the ambient environment, so local shadowing declarations
  cannot select the wrong imported type.
- Qualify imported schema type names in diagnostics, including through wrappers,
  function types, inline fragments, and interface/type-pattern checks, so
  mismatches are clear, e.g. `cannot use Test.User! as User!` instead of
  `cannot use User! as User!`.
- Add language-level gqltest coverage and unit tests for shadowing behavior,
  import visibility, alias protection, qualified diagnostics, and inline
  fragment receiver resolution.

## Tests

- `go test ./pkg/hm`
- `go test ./pkg/dang`
- `go test ./tests/`
