### PR TITLE
feat(dang): add declare-only loading

### DIFF
--- a/pkg/dang/ast_declarations.go
+++ b/pkg/dang/ast_declarations.go
@@ -28,21 +28,33 @@ type FunctionBase struct {
 
 // inferFunctionArguments processes SlotDecl arguments into function type arguments
 func (f *FunctionBase) inferFunctionArguments(ctx context.Context, env hm.Env, fresh hm.Fresher) ([]Keyed[*hm.Scheme], []Keyed[[]*DirectiveApplication], map[string]string, error) {
+	return f.inferFunctionArgumentsWith(ctx, env, fresh, (*SlotDecl).Infer)
+}
+
+func (f *FunctionBase) inferFunctionSignatureArguments(ctx context.Context, env hm.Env, fresh hm.Fresher) ([]Keyed[*hm.Scheme], []Keyed[[]*DirectiveApplication], map[string]string, error) {
+	return f.inferFunctionArgumentsWith(ctx, env, fresh, (*SlotDecl).InferSignature)
+}
+
+func (f *FunctionBase) inferFunctionArgumentsWith(ctx context.Context, env hm.Env, fresh hm.Fresher, inferArg func(*SlotDecl, context.Context, hm.Env, hm.Fresher) (hm.Type, error)) ([]Keyed[*hm.Scheme], []Keyed[[]*DirectiveApplication], map[string]string, error) {
 	args := []Keyed[*hm.Scheme]{}
 	directives := []Keyed[[]*DirectiveApplication]{}
 	docStrings := make(map[string]string)
 	for _, arg := range f.Args {
-		_, err := arg.Infer(ctx, env, fresh)
+		finalArgType, err := inferArg(arg, ctx, env, fresh)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		scheme, found := env.SchemeOf(arg.Name.Name)
-		if !found {
-			return nil, nil, nil, fmt.Errorf("argument %q not found in environment after inference", arg.Name.Name)
-		}
-		finalArgType, isMono := scheme.Type()
-		if !isMono {
-			return nil, nil, nil, fmt.Errorf("argument %q has polymorphic type %s", arg.Name.Name, scheme)
+
+		if finalArgType == nil {
+			scheme, found := env.SchemeOf(arg.Name.Name)
+			if !found {
+				return nil, nil, nil, fmt.Errorf("argument %q not found in environment after inference", arg.Name.Name)
+			}
+			var isMono bool
+			finalArgType, isMono = scheme.Type()
+			if !isMono {
+				return nil, nil, nil, fmt.Errorf("argument %q has polymorphic type %s", arg.Name.Name, scheme)
+			}
 		}
 
 		// For arguments with defaults, make them nullable in the function signature
@@ -75,6 +87,55 @@ func (f *FunctionBase) inferFunctionArguments(ctx context.Context, env hm.Env, f
 		}
 	}
 	return args, directives, docStrings, nil
+}
+
+func (f *FunctionBase) inferFunctionSignature(ctx context.Context, env hm.Env, fresh hm.Fresher, explicitRetType TypeNode, contextName string) (*hm.FunctionType, error) {
+	// Clone environment for closure semantics and so argument names don't leak.
+	newEnv := env.Clone()
+	signatureCtx := contextWithInferFunctionControlBoundary(ctx)
+
+	if dangEnv, ok := newEnv.(Env); ok {
+		f.InferredScope = dangEnv
+	}
+
+	args, directives, docStrings, err := f.inferFunctionSignatureArguments(signatureCtx, newEnv, fresh)
+	if err != nil {
+		return nil, fmt.Errorf("%s.Hoist: %w", contextName, err)
+	}
+
+	argsRec := NewRecordType("", args...)
+	argsRec.Directives = directives
+	argsRec.DocStrings = docStrings
+
+	var blockType *hm.FunctionType
+	if f.BlockParam != nil {
+		blockParamType, err := f.BlockParam.Type_.Infer(signatureCtx, env, fresh)
+		if err != nil {
+			return nil, fmt.Errorf("%s.Hoist block parameter: %w", contextName, err)
+		}
+		bt, ok := blockParamType.(*hm.FunctionType)
+		if !ok {
+			return nil, fmt.Errorf("%s.Hoist: block parameter must be a function type, got %T", contextName, blockParamType)
+		}
+		blockType = bt
+	}
+
+	var retType hm.Type
+	if explicitRetType != nil {
+		retType, err = explicitRetType.Infer(signatureCtx, env, fresh)
+		if err != nil {
+			return nil, fmt.Errorf("%s.Hoist return type: %w", contextName, err)
+		}
+	} else {
+		retType = fresh.Fresh()
+	}
+
+	f.Inferred = hm.NewFnType(argsRec, retType)
+	if blockType != nil {
+		f.Inferred.SetBlock(blockType)
+	}
+	f.SetInferredType(f.Inferred)
+	return f.Inferred, nil
 }
 
 // createFunctionValue creates a FunctionValue from processed arguments
@@ -230,57 +291,22 @@ var _ Hoister = &FunDecl{}
 func (f *FunDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass int) error {
 	switch pass {
 	case 0:
-		// Pass 0: Hoist function signature (declare type without inferring body)
-		// Clone environment to avoid mutating original during signature inference
-		signatureEnv := env.Clone()
-		signatureCtx := contextWithInferFunctionControlBoundary(ctx)
-
-		// Process arguments to get function signature. Default values belong to
-		// this function, not to the caller's return/break/continue frames.
-		args, directives, docStrings, err := f.inferFunctionArguments(signatureCtx, signatureEnv, fresh)
+		// Pass 0: Hoist function signature (declare type without inferring body).
+		fnType, err := f.inferFunctionSignature(ctx, env, fresh, f.Ret, fmt.Sprintf("FuncDecl(%s)", f.Named))
 		if err != nil {
-			return fmt.Errorf("FuncDecl.Hoist: %s signature: %w", f.Named, err)
-		}
-		argsRec := NewRecordType("", args...)
-		argsRec.Directives = directives
-		argsRec.DocStrings = docStrings
-
-		// Process block parameter if present
-		var blockType *hm.FunctionType
-		if f.BlockParam != nil {
-			blockParamType, err := f.BlockParam.Type_.Infer(signatureCtx, env, fresh)
-			if err != nil {
-				return fmt.Errorf("FuncDecl.Hoist: %s block parameter: %w", f.Named, err)
-			}
-			bt, ok := blockParamType.(*hm.FunctionType)
-			if !ok {
-				return fmt.Errorf("FuncDecl.Hoist: %s block parameter must be a function type, got %T", f.Named, blockParamType)
-			}
-			blockType = bt
-		}
-
-		// Handle explicit return type if provided
-		var retType hm.Type
-		if f.Ret != nil {
-			retType, err = f.Ret.Infer(signatureCtx, env, fresh)
-			if err != nil {
-				return fmt.Errorf("FuncDecl.Hoist: %s return type: %w", f.Named, err)
-			}
-		} else {
-			// Use a fresh type variable for the return type if not specified
-			retType = fresh.Fresh()
-		}
-
-		// Create function type and add to environment
-		fnType := hm.NewFnType(argsRec, retType)
-		if blockType != nil {
-			fnType.SetBlock(blockType)
+			return err
 		}
 		env.Add(f.Named, hm.NewScheme(nil, fnType))
+		if e, ok := env.(Env); ok {
+			e.SetVisibility(f.Named, f.Visibility)
+			if len(f.Directives) > 0 {
+				e.SetDirectives(f.Named, f.Directives)
+			}
+		}
 		return nil
 	case 1:
 		// Pass 1: Infer function body (function signature already available)
-		// The actual inference will happen in the normal Infer method
+		// The actual inference will happen in the normal Infer method.
 		return nil
 	}
 	return nil

--- a/pkg/dang/ast_declarations.go
+++ b/pkg/dang/ast_declarations.go
@@ -31,8 +31,8 @@ func (f *FunctionBase) inferFunctionArguments(ctx context.Context, env hm.Env, f
 	return f.inferFunctionArgumentsWith(ctx, env, fresh, (*SlotDecl).Infer)
 }
 
-func (f *FunctionBase) inferFunctionSignatureArguments(ctx context.Context, env hm.Env, fresh hm.Fresher) ([]Keyed[*hm.Scheme], []Keyed[[]*DirectiveApplication], map[string]string, error) {
-	return f.inferFunctionArgumentsWith(ctx, env, fresh, (*SlotDecl).InferSignature)
+func (f *FunctionBase) declareFunctionSignatureArguments(ctx context.Context, env hm.Env, fresh hm.Fresher) ([]Keyed[*hm.Scheme], []Keyed[[]*DirectiveApplication], map[string]string, error) {
+	return f.inferFunctionArgumentsWith(ctx, env, fresh, (*SlotDecl).DeclareSignature)
 }
 
 func (f *FunctionBase) inferFunctionArgumentsWith(ctx context.Context, env hm.Env, fresh hm.Fresher, inferArg func(*SlotDecl, context.Context, hm.Env, hm.Fresher) (hm.Type, error)) ([]Keyed[*hm.Scheme], []Keyed[[]*DirectiveApplication], map[string]string, error) {
@@ -89,7 +89,7 @@ func (f *FunctionBase) inferFunctionArgumentsWith(ctx context.Context, env hm.En
 	return args, directives, docStrings, nil
 }
 
-func (f *FunctionBase) inferFunctionSignature(ctx context.Context, env hm.Env, fresh hm.Fresher, explicitRetType TypeNode, contextName string) (*hm.FunctionType, error) {
+func (f *FunctionBase) declareFunctionSignature(ctx context.Context, env hm.Env, fresh hm.Fresher, explicitRetType TypeNode, contextName string) (*hm.FunctionType, error) {
 	// Clone environment for closure semantics and so argument names don't leak.
 	newEnv := env.Clone()
 	signatureCtx := contextWithInferFunctionControlBoundary(ctx)
@@ -98,9 +98,9 @@ func (f *FunctionBase) inferFunctionSignature(ctx context.Context, env hm.Env, f
 		f.InferredScope = dangEnv
 	}
 
-	args, directives, docStrings, err := f.inferFunctionSignatureArguments(signatureCtx, newEnv, fresh)
+	args, directives, docStrings, err := f.declareFunctionSignatureArguments(signatureCtx, newEnv, fresh)
 	if err != nil {
-		return nil, fmt.Errorf("%s.Hoist: %w", contextName, err)
+		return nil, fmt.Errorf("%s.Declare: %w", contextName, err)
 	}
 
 	argsRec := NewRecordType("", args...)
@@ -111,11 +111,11 @@ func (f *FunctionBase) inferFunctionSignature(ctx context.Context, env hm.Env, f
 	if f.BlockParam != nil {
 		blockParamType, err := f.BlockParam.Type_.Infer(signatureCtx, env, fresh)
 		if err != nil {
-			return nil, fmt.Errorf("%s.Hoist block parameter: %w", contextName, err)
+			return nil, fmt.Errorf("%s.Declare block parameter: %w", contextName, err)
 		}
 		bt, ok := blockParamType.(*hm.FunctionType)
 		if !ok {
-			return nil, fmt.Errorf("%s.Hoist: block parameter must be a function type, got %T", contextName, blockParamType)
+			return nil, fmt.Errorf("%s.Declare: block parameter must be a function type, got %T", contextName, blockParamType)
 		}
 		blockType = bt
 	}
@@ -124,7 +124,7 @@ func (f *FunctionBase) inferFunctionSignature(ctx context.Context, env hm.Env, f
 	if explicitRetType != nil {
 		retType, err = explicitRetType.Infer(signatureCtx, env, fresh)
 		if err != nil {
-			return nil, fmt.Errorf("%s.Hoist return type: %w", contextName, err)
+			return nil, fmt.Errorf("%s.Declare return type: %w", contextName, err)
 		}
 	} else {
 		retType = fresh.Fresh()
@@ -292,7 +292,7 @@ func (f *FunDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass 
 	switch pass {
 	case 0:
 		// Pass 0: Hoist function signature (declare type without inferring body).
-		fnType, err := f.inferFunctionSignature(ctx, env, fresh, f.Ret, fmt.Sprintf("FuncDecl(%s)", f.Named))
+		fnType, err := f.declareFunctionSignature(ctx, env, fresh, f.Ret, fmt.Sprintf("FuncDecl(%s)", f.Named))
 		if err != nil {
 			return err
 		}

--- a/pkg/dang/block.go
+++ b/pkg/dang/block.go
@@ -234,7 +234,7 @@ func classifyForms(forms []Node) ClassifiedForms {
 	return classified
 }
 
-// HoistFormsWithPhases performs the declaration/signature half of phased
+// DeclareFormsWithPhases performs the declaration/signature half of phased
 // compilation. It establishes imports, directives, constants, type names,
 // object/interface/union shapes, constructors, fields, and function signatures,
 // but deliberately does not infer computed variables, function bodies, or other
@@ -242,7 +242,7 @@ func classifyForms(forms []Node) ClassifiedForms {
 //
 // This is the boundary used by tooling that needs a module's public API before
 // the full program can be checked, such as Dagger self-call bootstrapping.
-func HoistFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
+func DeclareFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
 	errs := &InferenceErrors{}
 	classified := classifyForms(forms)
 
@@ -263,10 +263,10 @@ func HoistFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh h
 			return inferConstantsPhaseResilient(ctx, classified.Constants, env, fresh, errs)
 		}},
 		{"type signatures", func(errs *InferenceErrors) (hm.Type, error) {
-			return hoistTypesPhaseResilient(ctx, classified.Types, env, fresh, errs)
+			return declareTypeSignaturesPhaseResilient(ctx, classified.Types, env, fresh, errs)
 		}},
 		{"function signatures", func(errs *InferenceErrors) (hm.Type, error) {
-			return inferFunctionSignaturesPhaseResilient(ctx, classified.Functions, env, fresh, errs)
+			return declareFunctionSignaturesPhaseResilient(ctx, classified.Functions, env, fresh, errs)
 		}},
 	}
 
@@ -287,10 +287,10 @@ func HoistFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh h
 	return lastT, nil
 }
 
-// EvaluateHoistedFormsWithPhases evaluates only the declarations made safe by
-// HoistFormsWithPhases. Function and method bodies are captured as closures but
-// not executed; variables and non-declarations are skipped.
-func EvaluateHoistedFormsWithPhases(ctx context.Context, forms []Node, env EvalEnv) (Value, error) {
+// EvaluateDeclaredFormsWithPhases evaluates only the declaration forms made
+// safe by DeclareFormsWithPhases. Function and method bodies are captured as
+// closures but not executed; variables and non-declarations are skipped.
+func EvaluateDeclaredFormsWithPhases(ctx context.Context, forms []Node, env EvalEnv) (Value, error) {
 	var result Value = NullValue{}
 	classified := classifyForms(forms)
 
@@ -349,7 +349,7 @@ func InferFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh h
 			return inferTypesPhaseResilient(ctx, classified.Types, env, fresh, errs)
 		}},
 		{"function signatures", func(errs *InferenceErrors) (hm.Type, error) {
-			return inferFunctionSignaturesPhaseResilient(ctx, classified.Functions, env, fresh, errs)
+			return declareFunctionSignaturesPhaseResilient(ctx, classified.Functions, env, fresh, errs)
 		}},
 		{"variables", func(errs *InferenceErrors) (hm.Type, error) {
 			return inferVariablesPhaseResilient(ctx, classified.Variables, env, fresh, errs)
@@ -684,8 +684,8 @@ func inferTypeNamesPhaseResilient(ctx context.Context, types []Node, env hm.Env,
 	return nil, nil
 }
 
-func hoistTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
-	// Pass 1: Hoist type signatures (constructors, fields, methods,
+func declareTypeSignaturesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+	// Pass 1: Declare type signatures (constructors, fields, methods,
 	// interface members, union members) without inferring executable bodies.
 	for _, form := range types {
 		if hoister, ok := form.(Hoister); ok {
@@ -699,7 +699,9 @@ func hoistTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fre
 }
 
 func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
-	hoistTypesPhaseResilient(ctx, types, env, fresh, errs)
+	if _, err := declareTypeSignaturesPhaseResilient(ctx, types, env, fresh, errs); err != nil {
+		return nil, err
+	}
 
 	// Complete type inference
 	var lastT hm.Type
@@ -717,7 +719,7 @@ func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fre
 	return lastT, nil
 }
 
-func inferFunctionSignaturesPhaseResilient(ctx context.Context, functions []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+func declareFunctionSignaturesPhaseResilient(ctx context.Context, functions []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
 	for _, form := range functions {
 		if hoister, ok := form.(Hoister); ok {
 			if err := hoister.Hoist(ctx, env, fresh, 0); err != nil {

--- a/pkg/dang/block.go
+++ b/pkg/dang/block.go
@@ -234,6 +234,85 @@ func classifyForms(forms []Node) ClassifiedForms {
 	return classified
 }
 
+// HoistFormsWithPhases performs the declaration/signature half of phased
+// compilation. It establishes imports, directives, constants, type names,
+// object/interface/union shapes, constructors, fields, and function signatures,
+// but deliberately does not infer computed variables, function bodies, or other
+// executable expressions.
+//
+// This is the boundary used by tooling that needs a module's public API before
+// the full program can be checked, such as Dagger self-call bootstrapping.
+func HoistFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
+	errs := &InferenceErrors{}
+	classified := classifyForms(forms)
+
+	phases := []struct {
+		name string
+		fn   func(*InferenceErrors) (hm.Type, error)
+	}{
+		{"imports", func(errs *InferenceErrors) (hm.Type, error) {
+			return inferImportsPhaseResilient(ctx, classified.Imports, env, fresh, errs)
+		}},
+		{"type names", func(errs *InferenceErrors) (hm.Type, error) {
+			return inferTypeNamesPhaseResilient(ctx, classified.Types, env, fresh, errs)
+		}},
+		{"directives", func(errs *InferenceErrors) (hm.Type, error) {
+			return inferDirectivesPhaseResilient(ctx, classified.Directives, env, fresh, errs)
+		}},
+		{"constants", func(errs *InferenceErrors) (hm.Type, error) {
+			return inferConstantsPhaseResilient(ctx, classified.Constants, env, fresh, errs)
+		}},
+		{"type signatures", func(errs *InferenceErrors) (hm.Type, error) {
+			return hoistTypesPhaseResilient(ctx, classified.Types, env, fresh, errs)
+		}},
+		{"function signatures", func(errs *InferenceErrors) (hm.Type, error) {
+			return inferFunctionSignaturesPhaseResilient(ctx, classified.Functions, env, fresh, errs)
+		}},
+	}
+
+	var lastT hm.Type
+	for _, phase := range phases {
+		t, err := phase.fn(errs)
+		if err != nil {
+			errs.Add(fmt.Errorf("%s phase failed: %w", phase.name, err))
+		}
+		if t != nil {
+			lastT = t
+		}
+	}
+
+	if errs.HasErrors() {
+		return lastT, errs
+	}
+	return lastT, nil
+}
+
+// EvaluateHoistedFormsWithPhases evaluates only the declarations made safe by
+// HoistFormsWithPhases. Function and method bodies are captured as closures but
+// not executed; variables and non-declarations are skipped.
+func EvaluateHoistedFormsWithPhases(ctx context.Context, forms []Node, env EvalEnv) (Value, error) {
+	var result Value = NullValue{}
+	classified := classifyForms(forms)
+
+	for _, group := range [][]Node{
+		classified.Imports,
+		classified.Directives,
+		classified.Constants,
+		classified.Types,
+		classified.Functions,
+	} {
+		for _, form := range group {
+			val, err := EvalNode(ctx, env, form)
+			if err != nil {
+				return nil, err
+			}
+			result = val
+		}
+	}
+
+	return result, nil
+}
+
 // InferFormsWithPhases implements phased compilation:
 // 1. Parse all files (already done)
 // 2. Build dependency graph of all declarations
@@ -605,16 +684,22 @@ func inferTypeNamesPhaseResilient(ctx context.Context, types []Node, env hm.Env,
 	return nil, nil
 }
 
-func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
-	// Pass 1: Infer class bodies
+func hoistTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+	// Pass 1: Hoist type signatures (constructors, fields, methods,
+	// interface members, union members) without inferring executable bodies.
 	for _, form := range types {
 		if hoister, ok := form.(Hoister); ok {
 			if err := hoister.Hoist(ctx, env, fresh, 1); err != nil {
 				errs.Add(err)
-				// Continue to try other types
+				// Continue to try other types.
 			}
 		}
 	}
+	return nil, nil
+}
+
+func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+	hoistTypesPhaseResilient(ctx, types, env, fresh, errs)
 
 	// Complete type inference
 	var lastT hm.Type

--- a/pkg/dang/env.go
+++ b/pkg/dang/env.go
@@ -1029,6 +1029,9 @@ func (t *Module) AcceptsCoercionFrom(other hm.Type) bool {
 
 // AddInterface adds an interface that this type implements
 func (m *Module) AddInterface(iface Env) {
+	if slices.Contains(m.interfaces, iface) {
+		return
+	}
 	m.interfaces = append(m.interfaces, iface)
 }
 
@@ -1039,6 +1042,9 @@ func (m *Module) GetInterfaces() []Env {
 
 // AddImplementer adds a type that implements this interface (for interface modules)
 func (m *Module) AddImplementer(impl Env) {
+	if slices.Contains(m.implementers, impl) {
+		return
+	}
 	m.implementers = append(m.implementers, impl)
 }
 
@@ -1054,6 +1060,9 @@ func (m *Module) ImplementsInterface(iface Env) bool {
 
 // AddMember adds a member type to this union (for union modules).
 func (m *Module) AddMember(member Env) {
+	if slices.Contains(m.members, member) {
+		return
+	}
 	m.members = append(m.members, member)
 }
 
@@ -1064,6 +1073,9 @@ func (m *Module) AddMember(member Env) {
 func (m *Module) LinkMember(member Env) {
 	m.AddMember(member)
 	if memberMod, ok := member.(*Module); ok {
+		if slices.Contains(memberMod.unions, Env(m)) {
+			return
+		}
 		memberMod.unions = append(memberMod.unions, m)
 	}
 }

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -294,7 +294,7 @@ type Directory {
 	require.Same(t, importedContainer, functionReturnType(t, coreScheme))
 }
 
-func TestHoistDirSkipsBodiesAndKeepsDaggerTypes(t *testing.T) {
+func TestDeclareDirSkipsBodiesAndKeepsDaggerTypes(t *testing.T) {
 	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
 		Name:       "Dagger",
 		Schema:     schemaWithCoreShadowTypes(),
@@ -316,7 +316,7 @@ type Test {
 	_, err := RunDir(ctx, dir, false)
 	require.Error(t, err)
 
-	env, err := HoistDir(ctx, dir, false)
+	env, err := DeclareDir(ctx, dir, false)
 	require.NoError(t, err)
 
 	daggerVal, found := env.Get("Dagger")

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -294,6 +294,52 @@ type Directory {
 	require.Same(t, importedContainer, functionReturnType(t, coreScheme))
 }
 
+func TestHoistDirSkipsBodiesAndKeepsDaggerTypes(t *testing.T) {
+	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+		Name:       "Dagger",
+		Schema:     schemaWithCoreShadowTypes(),
+		AutoImport: true,
+	})
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.dang"), []byte(`
+type Test {
+  pub containerEcho(stringArg: String! = missing.default): Container! {
+    Dagger.container
+  }
+
+  pub print(stringArg: String!): String! {
+    test.containerEcho(stringArg: stringArg).stdout
+  }
+}
+`), 0o600))
+
+	_, err := RunDir(ctx, dir, false)
+	require.Error(t, err)
+
+	env, err := HoistDir(ctx, dir, false)
+	require.NoError(t, err)
+
+	daggerVal, found := env.Get("Dagger")
+	require.True(t, found)
+	daggerMod, ok := daggerVal.(*ModuleValue)
+	require.True(t, ok)
+	importedContainer, found := daggerMod.Mod.NamedType("Container")
+	require.True(t, found)
+
+	testVal, found := env.Get("Test")
+	require.True(t, found)
+	testCtor, ok := testVal.(*ConstructorFunction)
+	require.True(t, ok)
+
+	containerEcho, found := testCtor.ClassType.LocalSchemeOf("containerEcho")
+	require.True(t, found)
+	require.Same(t, importedContainer, functionReturnType(t, containerEcho))
+
+	print, found := testCtor.ClassType.LocalSchemeOf("print")
+	require.True(t, found)
+	require.Same(t, StringType, functionReturnType(t, print))
+}
+
 func TestRunDirImplementingPreludeInterfaceDoesNotMutatePrelude(t *testing.T) {
 	before := len(ErrorType.GetImplementers())
 	runDangSnippet(t, `

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -1906,6 +1906,88 @@ func InjectAutoImports(ctx context.Context, forms []Node) []Node {
 	return append(injected, forms...)
 }
 
+func parseDirForms(ctx context.Context, dirPath string) (context.Context, []Node, int, error) {
+	// Load project config (dang.toml) if not already in context.
+	ctx, err := ensureProjectImports(ctx, dirPath)
+	if err != nil {
+		return ctx, nil, 0, fmt.Errorf("loading project config: %w", err)
+	}
+
+	// Discover all .dang files in the directory.
+	dangFiles, err := filepath.Glob(filepath.Join(dirPath, "*.dang"))
+	if err != nil {
+		return ctx, nil, 0, fmt.Errorf("failed to find .dang files in directory %s: %w", dirPath, err)
+	}
+
+	if len(dangFiles) == 0 {
+		return ctx, nil, 0, nil
+	}
+
+	// Sort files for deterministic order.
+	sort.Strings(dangFiles)
+
+	var allForms []Node
+	for _, filePath := range dangFiles {
+		parsed, err := ParseFileWithRecovery(filePath, GlobalStore("filePath", filePath))
+		if err != nil {
+			return ctx, nil, len(dangFiles), fmt.Errorf("failed to parse file %s: %w", filePath, err)
+		}
+
+		moduleBlock := parsed.(*ModuleBlock)
+		allForms = append(allForms, moduleBlock.Forms...)
+	}
+
+	// Auto-inject imports for any import configs in context that aren't
+	// already explicitly imported. This allows SDKs (e.g. Dagger) to make
+	// their import available without requiring module authors to write it.
+	allForms = InjectAutoImports(ctx, allForms)
+
+	return ctx, allForms, len(dangFiles), nil
+}
+
+// HoistDir hoists all .dang files in a directory as a single module and returns
+// an evaluation environment containing only hoisted declarations. It resolves
+// imports and signatures, but it does not infer or evaluate function bodies,
+// computed variables, or non-declaration expressions.
+func HoistDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) {
+	// Ensure service registry exists for cleanup.
+	ctx, services := ensureServiceRegistry(ctx)
+	if services != nil {
+		defer services.StopAll()
+	}
+
+	ctx, allForms, fileCount, err := parseDirForms(ctx, dirPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(allForms) == 0 {
+		return NewEvalEnv(NewPreludeEnv("")), nil
+	}
+
+	masterBlock := &ModuleBlock{
+		Forms:  allForms,
+		Inline: true,
+	}
+
+	if isDebug {
+		fmt.Printf("Hoisting directory: %s\n", dirPath)
+		fmt.Printf("Found %d .dang files with %d total forms\n", fileCount, len(masterBlock.Forms))
+	}
+
+	typeEnv := NewPreludeEnv("")
+	fresh := hm.NewSimpleFresher()
+	if _, err := HoistFormsWithPhases(ctx, masterBlock.Forms, typeEnv, fresh); err != nil {
+		return nil, ConvertInferError(err)
+	}
+
+	evalEnv := NewEvalEnv(typeEnv)
+	if _, err := EvaluateHoistedFormsWithPhases(ctx, masterBlock.Forms, evalEnv); err != nil {
+		return nil, err
+	}
+
+	return evalEnv, nil
+}
+
 // RunDir evaluates all .dang files in a directory as a single module
 func RunDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) {
 	// Ensure service registry exists for cleanup

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -1945,11 +1945,11 @@ func parseDirForms(ctx context.Context, dirPath string) (context.Context, []Node
 	return ctx, allForms, len(dangFiles), nil
 }
 
-// HoistDir hoists all .dang files in a directory as a single module and returns
-// an evaluation environment containing only hoisted declarations. It resolves
-// imports and signatures, but it does not infer or evaluate function bodies,
-// computed variables, or non-declaration expressions.
-func HoistDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) {
+// DeclareDir declares all .dang files in a directory as a single module and
+// returns an evaluation environment containing only declared API-shape values.
+// It resolves imports and signatures, but it does not infer or evaluate
+// function bodies, computed variables, or non-declaration expressions.
+func DeclareDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) {
 	// Ensure service registry exists for cleanup.
 	ctx, services := ensureServiceRegistry(ctx)
 	if services != nil {
@@ -1970,18 +1970,18 @@ func HoistDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error
 	}
 
 	if isDebug {
-		fmt.Printf("Hoisting directory: %s\n", dirPath)
+		fmt.Printf("Declaring directory: %s\n", dirPath)
 		fmt.Printf("Found %d .dang files with %d total forms\n", fileCount, len(masterBlock.Forms))
 	}
 
 	typeEnv := NewPreludeEnv("")
 	fresh := hm.NewSimpleFresher()
-	if _, err := HoistFormsWithPhases(ctx, masterBlock.Forms, typeEnv, fresh); err != nil {
+	if _, err := DeclareFormsWithPhases(ctx, masterBlock.Forms, typeEnv, fresh); err != nil {
 		return nil, ConvertInferError(err)
 	}
 
 	evalEnv := NewEvalEnv(typeEnv)
-	if _, err := EvaluateHoistedFormsWithPhases(ctx, masterBlock.Forms, evalEnv); err != nil {
+	if _, err := EvaluateDeclaredFormsWithPhases(ctx, masterBlock.Forms, evalEnv); err != nil {
 		return nil, err
 	}
 

--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -95,15 +95,15 @@ func (s *SlotDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 
 	// For non-function slots, register the type during pass 0 so that
 	// sibling declarations (e.g. method default-value expressions) can
-	// reference it before full inference runs. This mirrors what
-	// FunDecl.Hoist does for function signatures.
+	// reference it before full inference runs. This mirrors the declaration
+	// pass for function signatures.
 	//
 	// The type is determined from the explicit annotation if present,
 	// otherwise from the value if it implements Constant (literals whose
 	// type is known without consulting the environment). Computed values are
 	// intentionally not inferred at the hoist boundary.
 	if pass == 0 {
-		slotType, err := s.inferSignatureType(ctx, env, fresh, false)
+		slotType, err := s.signatureType(ctx, env, fresh, false)
 		if err != nil {
 			return err
 		}
@@ -125,7 +125,7 @@ func (s *SlotDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 	return nil
 }
 
-func (s *SlotDecl) inferSignatureType(ctx context.Context, env hm.Env, fresh hm.Fresher, allowComputed bool) (hm.Type, error) {
+func (s *SlotDecl) signatureType(ctx context.Context, env hm.Env, fresh hm.Fresher, allowComputed bool) (hm.Type, error) {
 	if s.Type_ != nil {
 		slotType, err := s.Type_.Infer(ctx, env, fresh)
 		if err != nil {
@@ -148,8 +148,8 @@ func (s *SlotDecl) inferSignatureType(ctx context.Context, env hm.Env, fresh hm.
 	return nil, nil
 }
 
-func (s *SlotDecl) InferSignature(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
-	slotType, err := s.inferSignatureType(ctx, env, fresh, true)
+func (s *SlotDecl) DeclareSignature(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
+	slotType, err := s.signatureType(ctx, env, fresh, true)
 	if err != nil {
 		return nil, err
 	}
@@ -709,9 +709,9 @@ func (c *ClassDecl) extractConstructorParameters() []*SlotDecl {
 func (c *ClassDecl) buildConstructorType(ctx context.Context, env hm.Env, params []*SlotDecl, classType *Module, fresh hm.Fresher) (*hm.FunctionType, error) {
 	fnDecl := FunctionBase{Args: params}
 	argEnv := env.Clone()
-	args, directives, docStrings, err := fnDecl.inferFunctionSignatureArguments(contextWithInferFunctionControlBoundary(ctx), argEnv, fresh)
+	args, directives, docStrings, err := fnDecl.declareFunctionSignatureArguments(contextWithInferFunctionControlBoundary(ctx), argEnv, fresh)
 	if err != nil {
-		return nil, fmt.Errorf("%s Constructor.Hoist: %w", classType.Named, err)
+		return nil, fmt.Errorf("%s Constructor.Declare: %w", classType.Named, err)
 	}
 	argsRec := NewRecordType("", args...)
 	argsRec.Directives = directives
@@ -727,7 +727,7 @@ func (c *ClassDecl) inferNewConstructor(ctx context.Context, newDecl *NewConstru
 	newEnv := inferEnv.Clone().(*CompositeModule)
 	for _, arg := range newDecl.Args {
 		// Fully infer constructor arguments here so default expressions are
-		// validated during normal inference. Hoisting may have recorded the
+		// validated during normal inference. Declaration may have recorded the
 		// signature without checking computed defaults.
 		argType, err := arg.Infer(constructorCtx, newEnv, fresh)
 		if err != nil {
@@ -1109,7 +1109,7 @@ func (i *InterfaceDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher,
 		return nil
 	}
 
-	// Pass 1: Hoist interface field and method signatures without inferring
+	// Pass 1: Declare interface field and method signatures without inferring
 	// implementation bodies. Interface bodies only describe the public shape.
 	inferEnv := &CompositeModule{
 		primary: iface,

--- a/pkg/dang/slots.go
+++ b/pkg/dang/slots.go
@@ -61,36 +61,113 @@ func (s *SlotDecl) Body() hm.Expression {
 func (s *SlotDecl) GetSourceLocation() *SourceLocation { return s.Loc }
 
 func (s *SlotDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass int) error {
-	// If the slot value is a hoister (e.g. wraps a FunDecl), delegate.
-	if funDecl, ok := s.Value.(Hoister); ok {
-		return funDecl.Hoist(ctx, env, fresh, pass)
+	// If the slot value is a hoister (e.g. wraps a FunDecl), delegate while
+	// preserving the slot's name and metadata. This is the signature boundary:
+	// function bodies are not inferred, but callers can see the function type.
+	if funDecl, ok := s.Value.(*FunDecl); ok {
+		if funDecl.Named == "" {
+			funDecl.Named = s.Name.Name
+		}
+		if err := funDecl.Hoist(ctx, env, fresh, pass); err != nil {
+			return err
+		}
+		if pass == 0 {
+			s.SetInferredType(funDecl.Inferred)
+			if e, ok := env.(Env); ok {
+				e.SetVisibility(s.Name.Name, s.Visibility)
+				if s.DocString != "" {
+					e.SetDocString(s.Name.Name, s.DocString)
+				}
+				directives := s.Directives
+				if len(directives) == 0 {
+					directives = funDecl.Directives
+				}
+				if len(directives) > 0 {
+					e.SetDirectives(s.Name.Name, directives)
+				}
+			}
+		}
+		return nil
+	}
+	if hoister, ok := s.Value.(Hoister); ok {
+		return hoister.Hoist(ctx, env, fresh, pass)
 	}
 
 	// For non-function slots, register the type during pass 0 so that
 	// sibling declarations (e.g. method default-value expressions) can
-	// reference it before full inference runs.  This mirrors what
+	// reference it before full inference runs. This mirrors what
 	// FunDecl.Hoist does for function signatures.
 	//
 	// The type is determined from the explicit annotation if present,
 	// otherwise from the value if it implements Constant (literals whose
-	// type is known without consulting the environment).
+	// type is known without consulting the environment). Computed values are
+	// intentionally not inferred at the hoist boundary.
 	if pass == 0 {
-		var slotType hm.Type
-		if s.Type_ != nil {
-			var err error
-			slotType, err = s.Type_.Infer(ctx, env, fresh)
-			if err != nil {
-				return err
-			}
-		} else if c, ok := s.Value.(Constant); ok {
-			slotType = c.ConstantType()
+		slotType, err := s.inferSignatureType(ctx, env, fresh, false)
+		if err != nil {
+			return err
 		}
 		if slotType != nil {
 			env.Add(s.Name.Name, hm.NewScheme(nil, slotType))
+			s.SetInferredType(slotType)
+			if e, ok := env.(Env); ok {
+				e.SetVisibility(s.Name.Name, s.Visibility)
+				if s.DocString != "" {
+					e.SetDocString(s.Name.Name, s.DocString)
+				}
+				if len(s.Directives) > 0 {
+					e.SetDirectives(s.Name.Name, s.Directives)
+				}
+			}
 		}
 	}
 
 	return nil
+}
+
+func (s *SlotDecl) inferSignatureType(ctx context.Context, env hm.Env, fresh hm.Fresher, allowComputed bool) (hm.Type, error) {
+	if s.Type_ != nil {
+		slotType, err := s.Type_.Infer(ctx, env, fresh)
+		if err != nil {
+			return nil, err
+		}
+		return slotType, nil
+	}
+	if constant, ok := s.Value.(Constant); ok {
+		return constant.ConstantType(), nil
+	}
+	if s.Value == nil {
+		if allowComputed {
+			return fresh.Fresh(), nil
+		}
+		return nil, nil
+	}
+	if allowComputed {
+		return s.Value.Infer(ctx, env, fresh)
+	}
+	return nil, nil
+}
+
+func (s *SlotDecl) InferSignature(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
+	slotType, err := s.inferSignatureType(ctx, env, fresh, true)
+	if err != nil {
+		return nil, err
+	}
+	if slotType == nil {
+		slotType = fresh.Fresh()
+	}
+	env.Add(s.Name.Name, hm.NewScheme(nil, slotType))
+	s.SetInferredType(slotType)
+	if e, ok := env.(Env); ok {
+		e.SetVisibility(s.Name.Name, s.Visibility)
+		if s.DocString != "" {
+			e.SetDocString(s.Name.Name, s.DocString)
+		}
+		if len(s.Directives) > 0 {
+			e.SetDirectives(s.Name.Name, s.Directives)
+		}
+	}
+	return slotType, nil
 }
 
 func (s *SlotDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
@@ -385,6 +462,8 @@ func (c *ClassDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 	if declareErr != nil {
 		return WrapInferError(declareErr, c.Name)
 	}
+	c.Inferred = class
+	c.SetInferredType(class)
 
 	// Pass 0 must only register the type name. Other top-level types may refer
 	// to this class before its file is reached, so anything that resolves field
@@ -628,15 +707,16 @@ func (c *ClassDecl) extractConstructorParameters() []*SlotDecl {
 
 // buildConstructorType creates a function type for the constructor based on the parameters
 func (c *ClassDecl) buildConstructorType(ctx context.Context, env hm.Env, params []*SlotDecl, classType *Module, fresh hm.Fresher) (*hm.FunctionType, error) {
-	fnDecl := FunctionBase{
-		Args: params,
-		Body: &Block{
-			Forms: []Node{
-				&ValueNode{Val: NewModuleValue(classType)},
-			},
-		},
+	fnDecl := FunctionBase{Args: params}
+	argEnv := env.Clone()
+	args, directives, docStrings, err := fnDecl.inferFunctionSignatureArguments(contextWithInferFunctionControlBoundary(ctx), argEnv, fresh)
+	if err != nil {
+		return nil, fmt.Errorf("%s Constructor.Hoist: %w", classType.Named, err)
 	}
-	return fnDecl.inferFunctionType(ctx, env, fresh, nil, classType.Named+" Constructor")
+	argsRec := NewRecordType("", args...)
+	argsRec.Directives = directives
+	argsRec.DocStrings = docStrings
+	return hm.NewFnType(argsRec, hm.NonNullType{Type: classType}), nil
 }
 
 // inferNewConstructor infers the body of an explicit new() constructor
@@ -646,14 +726,12 @@ func (c *ClassDecl) inferNewConstructor(ctx context.Context, newDecl *NewConstru
 	// Create an environment with the constructor args in scope
 	newEnv := inferEnv.Clone().(*CompositeModule)
 	for _, arg := range newDecl.Args {
-		argType := arg.GetInferredType()
-		if argType == nil {
-			// Infer the arg type if not already done
-			var err error
-			argType, err = arg.Infer(constructorCtx, newEnv, fresh)
-			if err != nil {
-				return fmt.Errorf("inferring new() arg %s: %w", arg.Name.Name, err)
-			}
+		// Fully infer constructor arguments here so default expressions are
+		// validated during normal inference. Hoisting may have recorded the
+		// signature without checking computed defaults.
+		argType, err := arg.Infer(constructorCtx, newEnv, fresh)
+		if err != nil {
+			return fmt.Errorf("inferring new() arg %s: %w", arg.Name.Name, err)
 		}
 		newEnv.Add(arg.Name.Name, hm.NewScheme(nil, argType))
 	}
@@ -788,6 +866,10 @@ func (e *EnumDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 	}
 
 	e.Inferred = enumType
+	e.SetInferredType(enumType)
+	if e.DocString != "" {
+		mod.SetDocString(e.Name.Name, e.DocString)
+	}
 
 	// Add the enum module to the environment so it can be referenced
 	// Note: We add the enum type itself, not wrapped in NonNullType, matching GraphQL enum behavior
@@ -802,10 +884,6 @@ func (e *EnumDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 			enumType.Add(value.Name, valueScheme)
 			enumType.SetVisibility(value.Name, PublicVisibility)
 
-			// Store doc string if present
-			if e.DocString != "" {
-				mod.SetDocString(e.Name.Name, e.DocString)
-			}
 		}
 
 		// Add the values() method that returns all enum values as a list
@@ -918,6 +996,7 @@ func (s *ScalarDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pa
 	}
 
 	s.Inferred = scalarType
+	s.SetInferredType(scalarType)
 
 	// Add the scalar type to the environment
 	scalarScheme := hm.NewScheme(nil, scalarType)
@@ -1012,19 +1091,38 @@ func (i *InterfaceDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher,
 		return fmt.Errorf("InterfaceDecl.Hoist: environment does not support module operations")
 	}
 
-	// Pass 0: Register the interface type
-	if pass == 0 {
-		iface, declareErr := declareLocalType(mod, i.Name.Name, InterfaceKind)
-		if declareErr != nil {
-			return WrapInferError(declareErr, i.Name)
-		}
-
-		// Add the interface type to the environment so it can be referenced
-		interfaceScheme := hm.NewScheme(nil, iface)
-		env.Add(i.Name.Name, interfaceScheme)
+	iface, declareErr := declareLocalType(mod, i.Name.Name, InterfaceKind)
+	if declareErr != nil {
+		return WrapInferError(declareErr, i.Name)
+	}
+	i.Inferred = iface
+	i.SetInferredType(iface)
+	if i.DocString != "" {
+		mod.SetDocString(i.Name.Name, i.DocString)
 	}
 
-	// Interface fields are handled in Infer, not Hoist
+	// Pass 0: Register the interface type.
+	if pass == 0 {
+		// Add the interface type to the environment so it can be referenced.
+		interfaceScheme := hm.NewScheme(nil, iface)
+		env.Add(i.Name.Name, interfaceScheme)
+		return nil
+	}
+
+	// Pass 1: Hoist interface field and method signatures without inferring
+	// implementation bodies. Interface bodies only describe the public shape.
+	inferEnv := &CompositeModule{
+		primary: iface,
+		lexical: mod,
+	}
+	for _, form := range i.Value.Forms {
+		if hoister, ok := form.(Hoister); ok {
+			if err := hoister.Hoist(ctx, inferEnv, fresh, 0); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1122,15 +1220,40 @@ func (u *UnionDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 		return fmt.Errorf("UnionDecl.Hoist: environment does not support module operations")
 	}
 
+	unionMod, declareErr := declareLocalType(mod, u.Name.Name, UnionKind)
+	if declareErr != nil {
+		return WrapInferError(declareErr, u.Name)
+	}
+	u.Inferred = unionMod
+	u.SetInferredType(unionMod)
+	if u.DocString != "" {
+		mod.SetDocString(u.Name.Name, u.DocString)
+	}
+
 	if pass == 0 {
-		// Pass 0: Register the union type
-		unionMod, declareErr := declareLocalType(mod, u.Name.Name, UnionKind)
-		if declareErr != nil {
-			return WrapInferError(declareErr, u.Name)
+		// Pass 0: Register the union type so it can be referenced.
+		env.Add(u.Name.Name, hm.NewScheme(nil, unionMod))
+		return nil
+	}
+
+	// Pass 1: Link member names. This is still signature information; no
+	// expression bodies are inferred.
+	for _, memberSym := range u.Members {
+		memberType, found := mod.NamedType(memberSym.Name)
+		if !found {
+			continue
 		}
 
-		// Add the union type to the environment so it can be referenced
-		env.Add(u.Name.Name, hm.NewScheme(nil, unionMod))
+		memberMod, ok := memberType.(*Module)
+		if !ok || memberMod.Kind != ObjectKind {
+			continue
+		}
+
+		if localMember, found := mod.LocalNamedType(memberSym.Name); found && localMember == memberType {
+			unionMod.LinkMember(memberType)
+		} else {
+			unionMod.AddMember(memberType)
+		}
 	}
 
 	return nil

--- a/tests/testdata/ambiguous_directive.golden
+++ b/tests/testdata/ambiguous_directive.golden
@@ -1,19 +1,3 @@
-2 inference errors:
-
-Error 1:
-[1m[31mError:[0m ambiguous reference to directive @experimental: provided by imports [Other Test]
-  [2m[34m--> errors/ambiguous_directive.dang:9:21[0m
- [2m    |[0m
- [2m  7 | # Using unqualified @experimental should fail[0m
- [2m  8 | type MyType {[0m
- [2m[34m[1m  9 | [0m  pub field: String! @experimental
-[2m                           [31m^^^^^^^^^^^^^^[0m
- [2m 10 | }[0m
- [2m 11 | [0m
- [2m    |[0m
-
-
-Error 2:
 [1m[31mError:[0m ambiguous reference to directive @experimental: provided by imports [Other Test]
   [2m[34m--> errors/ambiguous_directive.dang:9:21[0m
  [2m    |[0m

--- a/tests/testdata/directive_positional_after_named.golden
+++ b/tests/testdata/directive_positional_after_named.golden
@@ -1,19 +1,3 @@
-2 inference errors:
-
-Error 1:
-[1m[31mError:[0m DirectiveApplication.Infer: positional arguments must come before named arguments
-  [2m[34m--> errors/directive_positional_after_named.dang:7:21[0m
- [2m    |[0m
- [2m  5 | type Test {[0m
- [2m  6 |   # This should fail: positional arg after named arg[0m
- [2m[34m[1m  7 | [0m  pub field: String! @example(a: "named", "positional")
-[2m                           [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
- [2m  8 | }[0m
- [2m  9 | [0m
- [2m    |[0m
-
-
-Error 2:
 [1m[31mError:[0m DirectiveApplication.Infer: positional arguments must come before named arguments
   [2m[34m--> errors/directive_positional_after_named.dang:7:21[0m
  [2m    |[0m


### PR DESCRIPTION
## Summary

- add `DeclareDir` and declaration-only form evaluation for API-shape loading
- move the public boundary from "hoist" terminology to "declare"
- keep `Hoist` as the internal implementation detail for phased declaration
- add coverage for Dagger-style self-call bootstrapping with imported types

## Tests

- `go test ./...`
- `git diff --check`
