### PR TITLE
feat: file-local imports + LSP performance

### DIFF
--- a/pkg/dang/ast_declarations.go
+++ b/pkg/dang/ast_declarations.go
@@ -1223,11 +1223,6 @@ func (i *ImportDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (h
 
 		// Add the import declaration to the environment for later resolution
 		if dangEnv, ok := env.(Env); ok {
-			// Import with alias - check for conflicts and create schema module
-			if err := i.checkAliasConflicts(dangEnv, i.Name.Name); err != nil {
-				return nil, err
-			}
-
 			// Create module with GraphQL schema types and functions
 			schemaModule := NewEnv(i.Name.Name, schema)
 
@@ -1279,27 +1274,3 @@ func (i *ImportDecl) Walk(fn func(Node) bool) {
 	// ImportDecl has no child nodes to walk
 }
 
-// checkAliasConflicts checks if an import alias conflicts with existing symbols
-//
-// TODO: remove, feels redundant
-func (i *ImportDecl) checkAliasConflicts(env Env, alias string) error {
-	// Check if alias conflicts with existing classes (types)
-	if _, exists := env.NamedType(alias); exists {
-		return fmt.Errorf("import alias %q conflicts with existing type", alias)
-	}
-
-	// Check if alias conflicts with existing variables/functions
-	if _, exists := env.LocalSchemeOf(alias); exists {
-		return fmt.Errorf("import alias %q conflicts with existing symbol", alias)
-	}
-
-	// Check if alias conflicts with built-in types
-	builtinTypes := []string{"String", "Int", "Boolean"}
-	for _, builtin := range builtinTypes {
-		if alias == builtin {
-			return fmt.Errorf("import alias %q conflicts with built-in type %s", alias, builtin)
-		}
-	}
-
-	return nil
-}

--- a/pkg/dang/ast_declarations.go
+++ b/pkg/dang/ast_declarations.go
@@ -1207,32 +1207,23 @@ var _ hm.Inferer = &ImportDecl{}
 
 func (i *ImportDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.Type, error) {
 	return WithInferErrorHandling(i, func() (hm.Type, error) {
-		if i.inferred != nil {
-			// If we've already inferred, skip.
-			// (This is defensive.)
-			return NonNull(i.inferred), nil
+		// Build the schema module on first Infer; subsequent calls reuse the
+		// cached module but still install it into env. The LSP reuses parsed
+		// blocks (and thus their ImportDecls) across keystrokes against fresh
+		// per-file envs, so installation has to run every time even on cache
+		// hit.
+		if i.inferred == nil {
+			config, err := i.loadImportConfig(ctx)
+			if err != nil {
+				return nil, err
+			}
+			i.client = config.Client
+			i.schema = config.Schema
+			i.inferred = NewEnv(i.Name.Name, config.Schema)
 		}
 
-		// Perform actual schema introspection now during hoisting
-		config, err := i.loadImportConfig(ctx)
-		if err != nil {
-			return nil, err
-		}
-		client := config.Client
-		schema := config.Schema
-
-		// Add the import declaration to the environment for later resolution
 		if dangEnv, ok := env.(Env); ok {
-			// Create module with GraphQL schema types and functions
-			schemaModule := NewEnv(i.Name.Name, schema)
-
-			// Store client and schema information for runtime
-			i.client = client
-			i.schema = schema
-
-			installImportedTypeEnvironment(dangEnv, i.Name.Name, schemaModule)
-
-			i.inferred = schemaModule
+			installImportedTypeEnvironment(dangEnv, i.Name.Name, i.inferred)
 		}
 
 		return NonNull(i.inferred), nil

--- a/pkg/dang/block.go
+++ b/pkg/dang/block.go
@@ -729,8 +729,10 @@ func inferTypesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fre
 	if _, err := declareTypeSignaturesPhaseResilient(ctx, types, env, fresh, errs); err != nil {
 		return nil, err
 	}
+	return inferTypeBodiesPhaseResilient(ctx, types, env, fresh, errs)
+}
 
-	// Complete type inference
+func inferTypeBodiesPhaseResilient(ctx context.Context, types []Node, env hm.Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
 	var lastT hm.Type
 	for _, form := range types {
 		t, err := form.Infer(ctx, env, fresh)

--- a/pkg/dang/dir_inference.go
+++ b/pkg/dang/dir_inference.go
@@ -121,6 +121,39 @@ var inferencePhases = []directoryPhase{
 // API. Body inference is skipped, matching DeclareFormsWithPhases.
 var declarationPhases = inferencePhases[:6]
 
+// bodyPhases are the post-signature phases that walk into bodies: type bodies,
+// variable bodies, function bodies, and non-declarations.
+var bodyPhases = inferencePhases[6:]
+
+// InferDirectoryFilesFocused runs phased inference with full body checks only
+// for the active file. Sibling files contribute their declarations (imports,
+// type names, signatures) to dirEnv so cross-file references in the active
+// file resolve, but their bodies are not inferred. Used by the LSP to keep
+// keystroke-driven analysis cheap without losing sibling visibility.
+//
+// active must be one of files (pointer equality). A nil active runs only the
+// declaration phases.
+func InferDirectoryFilesFocused(ctx context.Context, files []*ModuleBlock, active *ModuleBlock, dirEnv Env, fresh hm.Fresher) error {
+	overall := &InferenceErrors{}
+	scopes := prepareFileScopes(ctx, files, dirEnv, fresh, overall)
+
+	runDirectoryPhases(ctx, scopes, fresh, overall, declarationPhases)
+
+	if active != nil {
+		for i, block := range files {
+			if block == active {
+				runDirectoryPhases(ctx, scopes[i:i+1], fresh, overall, bodyPhases)
+				break
+			}
+		}
+	}
+
+	if overall.HasErrors() {
+		return overall
+	}
+	return nil
+}
+
 // partitionImports splits forms into ImportDecls and everything else, preserving
 // original order within each partition.
 func partitionImports(forms []Node) (imports, rest []Node) {

--- a/pkg/dang/dir_inference.go
+++ b/pkg/dang/dir_inference.go
@@ -44,7 +44,9 @@ type fileScope struct {
 // prepareFileScopes per-file: prepends auto-imports, splits imports from the
 // rest, runs the imports phase against a fresh per-file env, and builds the
 // file's composite env. The file-local imports are installed once up front so
-// that all subsequent phases can refer to them through fileEnv.
+// that all subsequent phases can refer to them through fileEnv. The composite
+// is also stashed on block.Env so editor features can look up symbols (e.g.
+// unqualified imported names) against the same env inference saw.
 func prepareFileScopes(ctx context.Context, files []*ModuleBlock, dirEnv Env, fresh hm.Fresher, errs *InferenceErrors) []fileScope {
 	scopes := make([]fileScope, 0, len(files))
 
@@ -53,9 +55,12 @@ func prepareFileScopes(ctx context.Context, files []*ModuleBlock, dirEnv Env, fr
 		imports, rest := partitionImports(block.Forms)
 
 		importsEnv := NewModule("", ObjectKind)
-		inferImportsPhaseResilient(ctx, imports, importsEnv, fresh, errs)
+		if _, err := inferImportsPhaseResilient(ctx, imports, importsEnv, fresh, errs); err != nil {
+			errs.Add(err)
+		}
 
 		fileEnv := &CompositeModule{primary: dirEnv, lexical: importsEnv}
+		block.Env = fileEnv
 		scopes = append(scopes, fileScope{
 			classified: classifyForms(rest),
 			fileEnv:    fileEnv,

--- a/pkg/dang/dir_inference.go
+++ b/pkg/dang/dir_inference.go
@@ -1,0 +1,167 @@
+package dang
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vito/dang/pkg/hm"
+)
+
+// InferDirectoryFiles runs phased type inference across multiple file blocks of
+// a directory module with file-local import scopes. Each file's imports populate
+// a fresh per-file env, which is then composed with the shared dirEnv: lookups
+// fall through dirEnv → file imports, so local declarations correctly shadow
+// imported names. Adds go to dirEnv so cross-file declarations are visible to
+// siblings.
+//
+// Phases run in lockstep across files (one phase across all files before the
+// next phase begins), matching the behavior of single-module phased inference.
+// This makes cross-file references in signatures and bodies resolve regardless
+// of file order: every type name is registered before any signature is checked,
+// every signature is in place before any body is inferred, and so on.
+//
+// Auto-imports declared in ctx are injected into each block's Forms in place,
+// so subsequent evaluation reuses the same *ImportDecl nodes whose Infer state
+// (cached schema/client) was populated here.
+func InferDirectoryFiles(ctx context.Context, files []*ModuleBlock, dirEnv Env, fresh hm.Fresher) error {
+	overall := &InferenceErrors{}
+	scopes := prepareFileScopes(ctx, files, dirEnv, fresh, overall)
+	runDirectoryPhases(ctx, scopes, fresh, overall, inferencePhases)
+
+	if overall.HasErrors() {
+		return overall
+	}
+	return nil
+}
+
+// fileScope ties a file's rest-of-forms (everything except its imports) to the
+// composite env that scopes its imports file-locally.
+type fileScope struct {
+	classified ClassifiedForms
+	fileEnv    Env
+}
+
+// prepareFileScopes per-file: prepends auto-imports, splits imports from the
+// rest, runs the imports phase against a fresh per-file env, and builds the
+// file's composite env. The file-local imports are installed once up front so
+// that all subsequent phases can refer to them through fileEnv.
+func prepareFileScopes(ctx context.Context, files []*ModuleBlock, dirEnv Env, fresh hm.Fresher, errs *InferenceErrors) []fileScope {
+	scopes := make([]fileScope, 0, len(files))
+
+	for _, block := range files {
+		block.Forms = prependAutoImports(ctx, block.Forms)
+		imports, rest := partitionImports(block.Forms)
+
+		importsEnv := NewModule("", ObjectKind)
+		inferImportsPhaseResilient(ctx, imports, importsEnv, fresh, errs)
+
+		fileEnv := &CompositeModule{primary: dirEnv, lexical: importsEnv}
+		scopes = append(scopes, fileScope{
+			classified: classifyForms(rest),
+			fileEnv:    fileEnv,
+		})
+	}
+	return scopes
+}
+
+// directoryPhase runs a single phase against every file's forms in order. The
+// phase function picks the relevant slice of classified forms for the phase
+// (e.g. types, variables) so all phases share one signature.
+type directoryPhase struct {
+	name string
+	fn   func(ctx context.Context, classified ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error)
+}
+
+func runDirectoryPhases(ctx context.Context, scopes []fileScope, fresh hm.Fresher, errs *InferenceErrors, phases []directoryPhase) {
+	for _, phase := range phases {
+		for _, scope := range scopes {
+			if _, err := phase.fn(ctx, scope.classified, scope.fileEnv, fresh, errs); err != nil {
+				errs.Add(fmt.Errorf("%s phase failed: %w", phase.name, err))
+			}
+		}
+	}
+}
+
+// inferencePhases mirrors InferFormsWithPhases but with each phase reachable
+// per-file. Phase order is critical: type names → signatures → bodies.
+var inferencePhases = []directoryPhase{
+	{"type names", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return inferTypeNamesPhaseResilient(ctx, c.Types, env, fresh, errs)
+	}},
+	{"directives", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return inferDirectivesPhaseResilient(ctx, c.Directives, env, fresh, errs)
+	}},
+	{"constants", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return inferConstantsPhaseResilient(ctx, c.Constants, env, fresh, errs)
+	}},
+	{"variable signatures", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return declareVariableSignaturesPhaseResilient(ctx, c.Variables, env, fresh, errs)
+	}},
+	{"type signatures", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return declareTypeSignaturesPhaseResilient(ctx, c.Types, env, fresh, errs)
+	}},
+	{"function signatures", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return declareFunctionSignaturesPhaseResilient(ctx, c.Functions, env, fresh, errs)
+	}},
+	{"type bodies", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return inferTypeBodiesPhaseResilient(ctx, c.Types, env, fresh, errs)
+	}},
+	{"variables", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return inferVariablesPhaseResilient(ctx, c.Variables, env, fresh, errs)
+	}},
+	{"function bodies", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return inferFunctionBodiesPhaseResilient(ctx, c.Functions, env, fresh, errs)
+	}},
+	{"non-declarations", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+		return inferNonDeclarationsPhaseResilient(ctx, c.NonDeclarations, env, fresh, errs)
+	}},
+}
+
+// declarationPhases is the subset of phases that build the directory's public
+// API. Body inference is skipped, matching DeclareFormsWithPhases.
+var declarationPhases = inferencePhases[:6]
+
+// partitionImports splits forms into ImportDecls and everything else, preserving
+// original order within each partition.
+func partitionImports(forms []Node) (imports, rest []Node) {
+	for _, f := range forms {
+		if _, ok := f.(*ImportDecl); ok {
+			imports = append(imports, f)
+		} else {
+			rest = append(rest, f)
+		}
+	}
+	return
+}
+
+// prependAutoImports prepends synthetic ImportDecls for any auto-import configs
+// in ctx that aren't already explicitly imported in forms. Used per-file so that
+// each file gets the auto-imports it needs without leaking siblings' imports.
+func prependAutoImports(ctx context.Context, forms []Node) []Node {
+	configs := importConfigsFromContext(ctx)
+	if len(configs) == 0 {
+		return forms
+	}
+
+	existing := make(map[string]bool)
+	for _, form := range forms {
+		if imp, ok := form.(*ImportDecl); ok && imp.Name != nil {
+			existing[imp.Name.Name] = true
+		}
+	}
+
+	var injected []Node
+	for _, config := range configs {
+		if config.AutoImport && !existing[config.Name] {
+			injected = append(injected, &ImportDecl{
+				Name: &Symbol{Name: config.Name},
+			})
+		}
+	}
+
+	if len(injected) == 0 {
+		return forms
+	}
+	return append(injected, forms...)
+}
+

--- a/pkg/dang/dir_inference.go
+++ b/pkg/dang/dir_inference.go
@@ -130,27 +130,48 @@ var declarationPhases = inferencePhases[:6]
 // variable bodies, function bodies, and non-declarations.
 var bodyPhases = inferencePhases[6:]
 
+// variablePhase is the body-inference phase that publishes types for
+// unannotated computed variables. It must run even for sibling files in the
+// focused LSP path, because their declaration-phase signatures don't cover
+// `pub answer = expr` (no annotation) — without inferring the body, the
+// active file's references to such a sibling export show up as "not found".
+var variablePhase = []directoryPhase{inferencePhases[7]}
+
 // InferDirectoryFilesFocused runs phased inference with full body checks only
-// for the active file. Sibling files contribute their declarations (imports,
-// type names, signatures) to dirEnv so cross-file references in the active
-// file resolve, but their bodies are not inferred. Used by the LSP to keep
-// keystroke-driven analysis cheap without losing sibling visibility.
+// for the active file. Sibling files run the declaration phases plus the
+// variables phase (needed to publish types of unannotated exports) but skip
+// type-body, function-body, and non-declaration phases. Used by the LSP to
+// keep keystroke-driven analysis cheap without losing sibling visibility.
 //
 // active must be one of files (pointer equality). A nil active runs only the
-// declaration phases.
+// declaration phases (plus variables across all scopes).
 func InferDirectoryFilesFocused(ctx context.Context, files []*ModuleBlock, active *ModuleBlock, dirEnv Env, fresh hm.Fresher) error {
 	overall := &InferenceErrors{}
 	scopes := prepareFileScopes(ctx, files, dirEnv, fresh, overall)
 
 	runDirectoryPhases(ctx, scopes, fresh, overall, declarationPhases)
 
+	// Identify the active scope (if any) so we can run variable inference for
+	// siblings only and run the rest of body inference for the active scope.
+	var activeIdx = -1
 	if active != nil {
 		for i, block := range files {
 			if block == active {
-				runDirectoryPhases(ctx, scopes[i:i+1], fresh, overall, bodyPhases)
+				activeIdx = i
 				break
 			}
 		}
+	}
+
+	for i, scope := range scopes {
+		if i == activeIdx {
+			continue
+		}
+		runDirectoryPhases(ctx, []fileScope{scope}, fresh, overall, variablePhase)
+	}
+
+	if activeIdx >= 0 {
+		runDirectoryPhases(ctx, scopes[activeIdx:activeIdx+1], fresh, overall, bodyPhases)
 	}
 
 	if overall.HasErrors() {

--- a/pkg/dang/dir_inference.go
+++ b/pkg/dang/dir_inference.go
@@ -3,6 +3,7 @@ package dang
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/vito/dang/pkg/hm"
 )
@@ -87,9 +88,10 @@ func runDirectoryPhases(ctx context.Context, scopes []fileScope, fresh hm.Freshe
 	}
 }
 
-// inferencePhases mirrors InferFormsWithPhases but with each phase reachable
-// per-file. Phase order is critical: type names → signatures → bodies.
-var inferencePhases = []directoryPhase{
+// declarationPhases is the subset of phases that build the directory's public
+// API. Body inference is skipped, matching DeclareFormsWithPhases. Phase order
+// is critical: type names → signatures.
+var declarationPhases = []directoryPhase{
 	{"type names", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
 		return inferTypeNamesPhaseResilient(ctx, c.Types, env, fresh, errs)
 	}},
@@ -108,34 +110,44 @@ var inferencePhases = []directoryPhase{
 	{"function signatures", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
 		return declareFunctionSignaturesPhaseResilient(ctx, c.Functions, env, fresh, errs)
 	}},
-	{"type bodies", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
-		return inferTypeBodiesPhaseResilient(ctx, c.Types, env, fresh, errs)
-	}},
+}
+
+// variablePhase is broken out (rather than living inline in bodyPhases) so
+// the LSP focused path can run it for sibling files without paying for the
+// rest of body inference. Siblings need it because declaration-phase
+// signatures don't cover `pub answer = expr` (no annotation) — without the
+// variables phase, the active file's references to such a sibling export
+// show up as "not found".
+var variablePhase = []directoryPhase{
 	{"variables", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
 		return inferVariablesPhaseResilient(ctx, c.Variables, env, fresh, errs)
 	}},
-	{"function bodies", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
-		return inferFunctionBodiesPhaseResilient(ctx, c.Functions, env, fresh, errs)
-	}},
-	{"non-declarations", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
-		return inferNonDeclarationsPhaseResilient(ctx, c.NonDeclarations, env, fresh, errs)
-	}},
 }
 
-// declarationPhases is the subset of phases that build the directory's public
-// API. Body inference is skipped, matching DeclareFormsWithPhases.
-var declarationPhases = inferencePhases[:6]
+// bodyPhases are the post-declaration phases that walk into bodies. Order
+// matters: type bodies first (so method return types are pinned), then
+// variables (which may reference method types), then function bodies, then
+// non-declarations.
+var bodyPhases = slices.Concat(
+	[]directoryPhase{
+		{"type bodies", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+			return inferTypeBodiesPhaseResilient(ctx, c.Types, env, fresh, errs)
+		}},
+	},
+	variablePhase,
+	[]directoryPhase{
+		{"function bodies", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+			return inferFunctionBodiesPhaseResilient(ctx, c.Functions, env, fresh, errs)
+		}},
+		{"non-declarations", func(ctx context.Context, c ClassifiedForms, env Env, fresh hm.Fresher, errs *InferenceErrors) (hm.Type, error) {
+			return inferNonDeclarationsPhaseResilient(ctx, c.NonDeclarations, env, fresh, errs)
+		}},
+	},
+)
 
-// bodyPhases are the post-signature phases that walk into bodies: type bodies,
-// variable bodies, function bodies, and non-declarations.
-var bodyPhases = inferencePhases[6:]
-
-// variablePhase is the body-inference phase that publishes types for
-// unannotated computed variables. It must run even for sibling files in the
-// focused LSP path, because their declaration-phase signatures don't cover
-// `pub answer = expr` (no annotation) — without inferring the body, the
-// active file's references to such a sibling export show up as "not found".
-var variablePhase = []directoryPhase{inferencePhases[7]}
+// inferencePhases mirrors InferFormsWithPhases but with each phase reachable
+// per-file. Phase order is critical: declarations before bodies.
+var inferencePhases = slices.Concat(declarationPhases, bodyPhases)
 
 // InferDirectoryFilesFocused runs phased inference with full body checks only
 // for the active file. Sibling files run the declaration phases plus the

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -382,6 +382,37 @@ type Test {
 	require.Same(t, StringType, functionReturnType(t, print))
 }
 
+func TestRunDirImportedValueDoesNotShadowLocalDeclaration(t *testing.T) {
+	// File-local imports must hold at runtime too: file A's `import Dagger`
+	// brings in an unqualified `container` value, but file B's `pub container`
+	// declaration owns that name in B's scope. With a global eval env the
+	// import would be installed first and SlotDecl.Eval would skip B's
+	// declaration as "already defined".
+	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	})
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a_uses_dagger.dang"), []byte(`
+import Dagger
+
+pub fromA: Dagger.Container! = Dagger.container
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b_declares_container.dang"), []byte(`
+pub container: String! = "local"
+pub useContainer: String! = container
+`), 0o600))
+
+	env, err := RunDir(ctx, dir, false)
+	require.NoError(t, err)
+
+	useVal, found := requireEvalGet(t, env, "useContainer")
+	require.True(t, found)
+	str, ok := useVal.(StringValue)
+	require.True(t, ok, "useContainer should resolve to file-local container, got %T", useVal)
+	require.Equal(t, "local", str.Val)
+}
+
 func TestRunDirImportsAreFileLocal(t *testing.T) {
 	// File A imports Dagger and uses an unqualified imported symbol.
 	// File B never imports Dagger and so cannot see container.

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -382,6 +382,36 @@ type Test {
 	require.Same(t, StringType, functionReturnType(t, print))
 }
 
+func TestRunDirSameFileImportAndDeclaration(t *testing.T) {
+	// A file that both imports and declares the same name should evaluate the
+	// local declaration, not the import — the file's own decl wins. This used
+	// to surface as a value/type mismatch (declared String! but evaluated to
+	// the imported Container).
+	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	})
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.dang"), []byte(`
+import Dagger
+
+pub container: String! = "from_a"
+pub use: String! = container
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.dang"), []byte(`
+pub other: String! = "from_b"
+`), 0o600))
+
+	env, err := RunDir(ctx, dir, false)
+	require.NoError(t, err)
+
+	useVal, found := requireEvalGet(t, env, "use")
+	require.True(t, found)
+	str, ok := useVal.(StringValue)
+	require.True(t, ok, "use should resolve to local container, got %T", useVal)
+	require.Equal(t, "from_a", str.Val)
+}
+
 func TestRunDirImportedValueDoesNotShadowLocalDeclaration(t *testing.T) {
 	// File-local imports must hold at runtime too: file A's `import Dagger`
 	// brings in an unqualified `container` value, but file B's `pub container`

--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -241,7 +241,10 @@ func TestDeclareLocalTypeRejectsQualifiedImportAlias(t *testing.T) {
 	require.Same(t, importedContainer, qualifiedContainer)
 }
 
-func TestRunDirDeclarationCannotShadowImportAlias(t *testing.T) {
+func TestRunDirDeclarationShadowsImportAlias(t *testing.T) {
+	// A local type declaration shadows an import of the same name. The
+	// reference to Dagger.Container then resolves through the local Dagger
+	// (which has no Container), surfacing as an unresolved-type error.
 	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
 		Name:   "Dagger",
 		Schema: schemaWithCoreShadowTypes(),
@@ -258,7 +261,7 @@ pub core: Dagger.Container! = Dagger.container
 `), 0o600))
 
 	_, err := RunDir(ctx, dir, false)
-	require.ErrorContains(t, err, `type "Dagger" conflicts with import alias`)
+	require.ErrorContains(t, err, "unresolved type: Container")
 }
 
 func TestRunDirDeclarationsShadowImportedTypes(t *testing.T) {
@@ -377,6 +380,51 @@ type Test {
 	print, found := testCtor.ClassType.LocalSchemeOf("print")
 	require.True(t, found)
 	require.Same(t, StringType, functionReturnType(t, print))
+}
+
+func TestRunDirImportsAreFileLocal(t *testing.T) {
+	// File A imports Dagger and uses an unqualified imported symbol.
+	// File B never imports Dagger and so cannot see container.
+	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	})
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a_uses_dagger.dang"), []byte(`
+import Dagger
+
+pub fromA: Dagger.Container! = Dagger.container
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b_no_import.dang"), []byte(`
+pub fromB: String! = container.value
+`), 0o600))
+
+	_, err := RunDir(ctx, dir, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "container")
+}
+
+func TestRunDirMultipleFilesCanImportSameSchema(t *testing.T) {
+	// Both files import Test independently. With file-local imports this is
+	// no longer an alias conflict; each file gets its own Test in scope.
+	ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+		Name:   "Dagger",
+		Schema: schemaWithCoreShadowTypes(),
+	})
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.dang"), []byte(`
+import Dagger
+
+pub fromA: Dagger.Container! = Dagger.container
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.dang"), []byte(`
+import Dagger
+
+pub fromB: Dagger.Container! = Dagger.container
+`), 0o600))
+
+	_, err := RunDir(ctx, dir, false)
+	require.NoError(t, err)
 }
 
 func TestRunDirImplementingPreludeInterfaceDoesNotMutatePrelude(t *testing.T) {

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -2000,49 +2000,48 @@ func InjectAutoImports(ctx context.Context, forms []Node) []Node {
 	return append(injected, forms...)
 }
 
-func parseDirForms(ctx context.Context, dirPath string) (context.Context, []Node, int, error) {
-	// Load project config (dang.toml) if not already in context.
+// parseDirBlocks parses every .dang file in dirPath into a *ModuleBlock and
+// returns them in deterministic order. Files keep their own forms so that
+// downstream callers can apply file-scoped policy (e.g. file-local imports).
+func parseDirBlocks(ctx context.Context, dirPath string) (context.Context, []*ModuleBlock, error) {
 	ctx, err := ensureProjectImports(ctx, dirPath)
 	if err != nil {
-		return ctx, nil, 0, fmt.Errorf("loading project config: %w", err)
+		return ctx, nil, fmt.Errorf("loading project config: %w", err)
 	}
 
-	// Discover all .dang files in the directory.
 	dangFiles, err := filepath.Glob(filepath.Join(dirPath, "*.dang"))
 	if err != nil {
-		return ctx, nil, 0, fmt.Errorf("failed to find .dang files in directory %s: %w", dirPath, err)
+		return ctx, nil, fmt.Errorf("failed to find .dang files in directory %s: %w", dirPath, err)
 	}
 
 	if len(dangFiles) == 0 {
-		return ctx, nil, 0, nil
+		return ctx, nil, nil
 	}
 
-	// Sort files for deterministic order.
 	sort.Strings(dangFiles)
 
-	var allForms []Node
+	blocks := make([]*ModuleBlock, 0, len(dangFiles))
 	for _, filePath := range dangFiles {
 		parsed, err := ParseFileWithRecovery(filePath, GlobalStore("filePath", filePath))
 		if err != nil {
-			return ctx, nil, len(dangFiles), fmt.Errorf("failed to parse file %s: %w", filePath, err)
+			return ctx, nil, fmt.Errorf("failed to parse file %s: %w", filePath, err)
 		}
-
-		moduleBlock := parsed.(*ModuleBlock)
-		allForms = append(allForms, moduleBlock.Forms...)
+		block, ok := parsed.(*ModuleBlock)
+		if !ok {
+			return ctx, nil, fmt.Errorf("parsed result for %s is not a ModuleBlock", filePath)
+		}
+		blocks = append(blocks, block)
 	}
 
-	// Auto-inject imports for any import configs in context that aren't
-	// already explicitly imported. This allows SDKs (e.g. Dagger) to make
-	// their import available without requiring module authors to write it.
-	allForms = InjectAutoImports(ctx, allForms)
-
-	return ctx, allForms, len(dangFiles), nil
+	return ctx, blocks, nil
 }
 
 // DeclareDir declares all .dang files in a directory as a single module and
 // returns an evaluation environment containing only declared API-shape values.
 // It resolves imports and signatures, but it does not infer or evaluate
-// function bodies, computed variables, or non-declaration expressions.
+// function bodies, computed variables, or non-declaration expressions. Each
+// file's imports are file-local: a sibling file's `import X` does not make X
+// visible here.
 func DeclareDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) {
 	// Ensure service registry exists for cleanup.
 	ctx, services := ensureServiceRegistry(ctx)
@@ -2050,34 +2049,57 @@ func DeclareDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, err
 		defer services.StopAll()
 	}
 
-	ctx, allForms, fileCount, err := parseDirForms(ctx, dirPath)
+	ctx, blocks, err := parseDirBlocks(ctx, dirPath)
 	if err != nil {
 		return nil, err
 	}
-	if len(allForms) == 0 {
+	if len(blocks) == 0 {
 		return NewEvalEnv(NewPreludeEnv("")), nil
 	}
 
 	if isDebug {
+		var totalForms int
+		for _, b := range blocks {
+			totalForms += len(b.Forms)
+		}
 		fmt.Printf("Declaring directory: %s\n", dirPath)
-		fmt.Printf("Found %d .dang files with %d total forms\n", fileCount, len(allForms))
+		fmt.Printf("Found %d .dang files with %d total forms\n", len(blocks), totalForms)
 	}
 
 	typeEnv := NewPreludeEnv("")
 	fresh := hm.NewSimpleFresher()
-	if _, err := DeclareFormsWithPhases(ctx, allForms, typeEnv, fresh); err != nil {
+	if err := declareDirectoryFiles(ctx, blocks, typeEnv, fresh); err != nil {
 		return nil, ConvertInferError(err)
 	}
 
 	evalEnv := NewEvalEnv(typeEnv)
-	if _, err := EvaluateDeclaredFormsWithPhases(ctx, allForms, evalEnv); err != nil {
-		return nil, err
+	for _, block := range blocks {
+		if _, err := EvaluateDeclaredFormsWithPhases(ctx, block.Forms, evalEnv); err != nil {
+			return nil, err
+		}
 	}
 
 	return evalEnv, nil
 }
 
-// RunDir evaluates all .dang files in a directory as a single module
+// declareDirectoryFiles runs only the declaration phases across files (no body
+// inference). It is the DeclareDir counterpart to InferDirectoryFiles. Mutates
+// block.Forms to prepend auto-imports so later evaluation reuses the same
+// *ImportDecl nodes inferred here.
+func declareDirectoryFiles(ctx context.Context, files []*ModuleBlock, dirEnv Env, fresh hm.Fresher) error {
+	overall := &InferenceErrors{}
+	scopes := prepareFileScopes(ctx, files, dirEnv, fresh, overall)
+	runDirectoryPhases(ctx, scopes, fresh, overall, declarationPhases)
+
+	if overall.HasErrors() {
+		return overall
+	}
+	return nil
+}
+
+// RunDir evaluates all .dang files in a directory as a single module. Each
+// file's imports are file-local during type inference: a sibling file's
+// `import X` does not make X visible here.
 func RunDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) {
 	// Ensure service registry exists for cleanup
 	ctx, services := ensureServiceRegistry(ctx)
@@ -2085,85 +2107,52 @@ func RunDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) 
 		defer services.StopAll()
 	}
 
-	// Load project config (dang.toml) if not already in context
-	ctx, err := ensureProjectImports(ctx, dirPath)
+	ctx, blocks, err := parseDirBlocks(ctx, dirPath)
 	if err != nil {
-		return nil, fmt.Errorf("loading project config: %w", err)
+		return nil, err
 	}
-
-	// Discover all .dang files in the directory
-	dangFiles, err := filepath.Glob(filepath.Join(dirPath, "*.dang"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find .dang files in directory %s: %w", dirPath, err)
-	}
-
-	if len(dangFiles) == 0 {
+	if len(blocks) == 0 {
 		return nil, fmt.Errorf("no .dang files found in directory: %s", dirPath)
 	}
 
-	// Sort files for deterministic order
-	sort.Strings(dangFiles)
-
-	// Parse all files and collect their blocks
-	var allForms []Node
-
-	for _, filePath := range dangFiles {
-		// Parse the file
-		parsed, err := ParseFileWithRecovery(filePath, GlobalStore("filePath", filePath))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse file %s: %w", filePath, err)
-		}
-
-		moduleBlock := parsed.(*ModuleBlock)
-		// Add all forms from this file to the combined block
-		allForms = append(allForms, moduleBlock.Forms...)
-	}
-
-	// Auto-inject imports for any import configs in context that aren't
-	// already explicitly imported. This allows SDKs (e.g. Dagger) to make
-	// their import available without requiring module authors to write it.
-	allForms = InjectAutoImports(ctx, allForms)
-
-	// Create a master ModuleBlock containing all forms from all files
-	// The phased approach will handle dependency ordering
-	masterBlock := &ModuleBlock{
-		Forms:  allForms,
-		Inline: true,
-	}
-
 	if isDebug {
+		var totalForms int
+		for _, b := range blocks {
+			totalForms += len(b.Forms)
+		}
 		fmt.Printf("Evaluating directory: %s\n", dirPath)
-		fmt.Printf("Found %d .dang files with %d total forms\n", len(dangFiles), len(masterBlock.Forms))
-		// pretty.Println(masterBlock)
+		fmt.Printf("Found %d .dang files with %d total forms\n", len(blocks), totalForms)
 	}
 
-	// Create type environment
 	typeEnv := NewPreludeEnv("")
+	fresh := hm.NewSimpleFresher()
 
-	// Run type inference using phased approach
 	if isDebug {
 		fmt.Println("Running phased inference...")
 	}
 
-	inferred, err := Infer(ctx, typeEnv, masterBlock, true)
-	if err != nil {
+	if err := InferDirectoryFiles(ctx, blocks, typeEnv, fresh); err != nil {
 		return nil, ConvertInferError(err)
 	}
 
-	slog.Debug("directory type inference completed", "type", inferred, "dir", dirPath)
+	slog.Debug("directory type inference completed", "dir", dirPath)
 
-	// Create evaluation environment
 	evalEnv := NewEvalEnv(typeEnv)
 
-	// Evaluate the combined block using phased evaluation
 	if isDebug {
 		fmt.Println("Running phased evaluation...")
 	}
 
-	// Create an eval context for error reporting. Since we're evaluating
-	// forms from multiple files, we don't provide a source string here.
-	// The error formatter will read individual source files as needed.
 	evalCtx := NewEvalContext(dirPath, "")
+
+	// InferDirectoryFiles already prepended auto-imports into each block. The
+	// shared evalEnv is the cross-file declaration store; per-file imports are
+	// evaluated in source order with the rest of each file's forms.
+	var allForms []Node
+	for _, block := range blocks {
+		allForms = append(allForms, block.Forms...)
+	}
+	masterBlock := &ModuleBlock{Forms: allForms, Inline: true}
 
 	result, err := EvalNodeWithContext(ctx, evalEnv, masterBlock, evalCtx)
 	if err != nil {

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -2144,28 +2144,188 @@ func RunDir(ctx context.Context, dirPath string, isDebug bool) (EvalEnv, error) 
 	}
 
 	evalCtx := NewEvalContext(dirPath, "")
+	ctx = WithEvalContext(ctx, evalCtx)
 
-	// InferDirectoryFiles already prepended auto-imports into each block. The
-	// shared evalEnv is the cross-file declaration store; per-file imports are
-	// evaluated in source order with the rest of each file's forms.
-	var allForms []Node
-	for _, block := range blocks {
-		allForms = append(allForms, block.Forms...)
-	}
-	masterBlock := &ModuleBlock{Forms: allForms, Inline: true}
-
-	result, err := EvalNodeWithContext(ctx, evalEnv, masterBlock, evalCtx)
-	if err != nil {
+	// Per-file evaluation matches type inference: each file's imports populate
+	// a fresh per-file env, composed with the shared evalEnv so cross-file
+	// declarations stay visible to siblings while imported names don't leak.
+	if err := evaluateDirectoryFiles(ctx, blocks, evalEnv); err != nil {
 		if translated, ok := translateBoundaryEvalError(err, evalCtx); ok {
 			return nil, translated
 		}
 		return nil, err
 	}
 
-	slog.Debug("directory evaluation completed", "result", result.String(), "dir", dirPath)
+	slog.Debug("directory evaluation completed", "dir", dirPath)
 
 	return evalEnv, nil
 }
+
+// evaluateDirectoryFiles evaluates each file's forms with file-local imports
+// composed over the shared evalEnv, mirroring InferDirectoryFiles' per-file
+// scoping. Phases run in lockstep across files so cross-file references resolve
+// regardless of file order.
+//
+// A single-file directory has no sibling to leak imports to, so its forms are
+// evaluated directly against evalEnv — the imports end up reachable from the
+// returned env, which is what callers like RunDir's single-file tests rely on.
+func evaluateDirectoryFiles(ctx context.Context, blocks []*ModuleBlock, evalEnv EvalEnv) error {
+	if len(blocks) == 1 {
+		_, err := EvaluateFormsWithPhases(ctx, blocks[0].Forms, evalEnv)
+		return err
+	}
+
+	type fileEvalScope struct {
+		classified ClassifiedForms
+		env        EvalEnv
+	}
+
+	scopes := make([]fileEvalScope, 0, len(blocks))
+	for _, block := range blocks {
+		imports, rest := partitionImports(block.Forms)
+
+		// Install imports into a fresh per-file env. Using Derive (rather than
+		// a sibling ModuleValue) keeps the prelude reachable for any lookups
+		// the imports phase performs during installation.
+		importsEnv := evalEnv.Derive(true)
+		for _, imp := range imports {
+			if _, err := EvalNode(ctx, importsEnv, imp); err != nil {
+				return err
+			}
+		}
+
+		fileEnv := &CompositeEvalEnv{primary: evalEnv, lexical: importsEnv}
+		scopes = append(scopes, fileEvalScope{
+			classified: classifyForms(rest),
+			env:        fileEnv,
+		})
+	}
+
+	// Phase order matches EvaluateFormsWithPhases (minus imports, which we
+	// already ran per file above): directives, constants, types, functions,
+	// variables (as lazy slots), then non-declarations.
+	for _, scope := range scopes {
+		for _, form := range scope.classified.Directives {
+			if _, err := EvalNode(ctx, scope.env, form); err != nil {
+				return fmt.Errorf("directive evaluation failed: %w", err)
+			}
+		}
+	}
+	for _, scope := range scopes {
+		for _, form := range scope.classified.Constants {
+			if _, err := EvalNode(ctx, scope.env, form); err != nil {
+				return fmt.Errorf("constant evaluation failed: %w", err)
+			}
+		}
+	}
+	for _, scope := range scopes {
+		for _, form := range scope.classified.Types {
+			if _, err := EvalNode(ctx, scope.env, form); err != nil {
+				return fmt.Errorf("type evaluation failed: %w", err)
+			}
+		}
+	}
+	for _, scope := range scopes {
+		for _, form := range scope.classified.Functions {
+			if _, err := EvalNode(ctx, scope.env, form); err != nil {
+				return fmt.Errorf("function evaluation failed: %w", err)
+			}
+		}
+	}
+	for _, scope := range scopes {
+		if len(scope.classified.Variables) > 0 {
+			if err := installAndForceLazyVariables(ctx, scope.classified.Variables, scope.env); err != nil {
+				return fmt.Errorf("variable evaluation failed: %w", err)
+			}
+		}
+	}
+	for _, scope := range scopes {
+		for _, form := range scope.classified.NonDeclarations {
+			if _, err := EvalNode(ctx, scope.env, form); err != nil {
+				return fmt.Errorf("non-declaration evaluation failed: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// CompositeEvalEnv overlays a file-local evaluation env onto a shared
+// directory env. Writes (Bind/BindLazy/Update) go to primary so cross-file
+// declarations are visible to siblings; reads check primary first so local
+// declarations correctly shadow imported names, then fall through to lexical
+// (where the file's imports live).
+//
+// This is the runtime analogue of dang.CompositeModule: it preserves the
+// file-scoped semantics of imports during evaluation, so a file's `import X`
+// doesn't bleed `X.foo` into siblings' runtime scope.
+type CompositeEvalEnv struct {
+	primary EvalEnv
+	lexical EvalEnv
+}
+
+var _ EvalEnv = (*CompositeEvalEnv)(nil)
+
+func (c *CompositeEvalEnv) Type() hm.Type  { return c.primary.Type() }
+func (c *CompositeEvalEnv) String() string { return c.primary.String() }
+
+func (c *CompositeEvalEnv) Lookup(ctx context.Context, name string) (Value, bool, error) {
+	if val, found, err := c.primary.Lookup(ctx, name); err != nil {
+		return nil, false, err
+	} else if found {
+		return val, true, nil
+	}
+	return c.lexical.Lookup(ctx, name)
+}
+
+func (c *CompositeEvalEnv) Has(name string) bool {
+	return c.primary.Has(name) || c.lexical.Has(name)
+}
+
+func (c *CompositeEvalEnv) LookupLocal(name string) (Value, bool) {
+	if val, ok := c.primary.LookupLocal(name); ok {
+		return val, true
+	}
+	return c.lexical.LookupLocal(name)
+}
+
+func (c *CompositeEvalEnv) Bindings(vis Visibility) []Keyed[Value] {
+	primary := c.primary.Bindings(vis)
+	seen := make(map[string]struct{}, len(primary))
+	for _, b := range primary {
+		seen[b.Key] = struct{}{}
+	}
+	for _, b := range c.lexical.Bindings(vis) {
+		if _, dup := seen[b.Key]; dup {
+			continue
+		}
+		primary = append(primary, b)
+	}
+	return primary
+}
+
+func (c *CompositeEvalEnv) Bind(name string, value Value, vis Visibility) {
+	c.primary.Bind(name, value, vis)
+}
+
+func (c *CompositeEvalEnv) BindLazy(name string, init func(ctx context.Context) (Value, error), vis Visibility) {
+	c.primary.BindLazy(name, init, vis)
+}
+
+func (c *CompositeEvalEnv) Update(name string, value Value) { c.primary.Update(name, value) }
+
+func (c *CompositeEvalEnv) Visibility(name string) Visibility { return c.primary.Visibility(name) }
+
+func (c *CompositeEvalEnv) Derive(sealed bool) EvalEnv {
+	return &CompositeEvalEnv{
+		primary: c.primary.Derive(sealed),
+		lexical: c.lexical,
+	}
+}
+
+func (c *CompositeEvalEnv) Self() (Value, bool)    { return c.primary.Self() }
+func (c *CompositeEvalEnv) MutateSelf(value Value) { c.primary.MutateSelf(value) }
+func (c *CompositeEvalEnv) EnterSelf(value Value)  { c.primary.EnterSelf(value) }
 
 // EvalNode evaluates any AST node (legacy interface)
 func EvalNode(ctx context.Context, env EvalEnv, node Node) (Value, error) {

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -2283,10 +2283,10 @@ func (c *CompositeEvalEnv) Has(name string) bool {
 }
 
 func (c *CompositeEvalEnv) LookupLocal(name string) (Value, bool) {
-	if val, ok := c.primary.LookupLocal(name); ok {
-		return val, true
-	}
-	return c.lexical.LookupLocal(name)
+	// Only consult primary: lexical holds file-scoped imports, which must not
+	// be treated as already-defined "local" bindings by SlotDecl.Eval — that
+	// would silently swallow declarations that share a name with an import.
+	return c.primary.LookupLocal(name)
 }
 
 func (c *CompositeEvalEnv) Bindings(vis Visibility) []Keyed[Value] {

--- a/pkg/lsp/diagnostics_test.go
+++ b/pkg/lsp/diagnostics_test.go
@@ -164,6 +164,25 @@ pub bad_add = "hello" + 42
 	require.Empty(t, diagnostics, "sibling body errors should not surface on the active buffer")
 }
 
+func (LSPSuite) TestDiagnosticsResolvesUnannotatedSiblingVars(ctx context.Context, t *testctx.T) {
+	// A sibling's `pub answer = expr` has no type annotation, so the variable
+	// signatures phase doesn't publish a type — body inference does. The
+	// focused inference path runs the variables phase across all scopes so
+	// the active file's reference still resolves.
+	root := t.TempDir()
+	writeDangFile(t, filepath.Join(root, "defs.dang"), `pub answer = "ok".toUpper
+`)
+	mainPath := filepath.Join(root, "main.dang")
+	writeDangFile(t, mainPath, `pub use: String! = answer
+`)
+
+	h := newLSPHarness(ctx, t, root)
+	uri := h.open(ctx, t, mainPath)
+	diagnostics := h.waitForDiagnostics(ctx, t, uri)
+
+	require.Empty(t, diagnostics, "unannotated sibling exports should publish their inferred types")
+}
+
 func (LSPSuite) TestDiagnosticsLoadsSiblingFiles(ctx context.Context, t *testctx.T) {
 	root := t.TempDir()
 	writeDangFile(t, filepath.Join(root, "defs.dang"), `type Template {

--- a/pkg/lsp/diagnostics_test.go
+++ b/pkg/lsp/diagnostics_test.go
@@ -143,6 +143,27 @@ func (LSPSuite) TestDiagnosticsReportsFileErrors(ctx context.Context, t *testctx
 	)
 }
 
+func (LSPSuite) TestDiagnosticsIgnoresSiblingBodyErrors(ctx context.Context, t *testctx.T) {
+	// Active file inference is "focused": siblings contribute only their
+	// declarations (so cross-file references resolve), and their bodies are
+	// not inferred. Diagnostics for the open buffer therefore reflect only
+	// the open buffer's own errors.
+	root := t.TempDir()
+	writeDangFile(t, filepath.Join(root, "broken.dang"), `pub helper: String! { "ok" }
+
+pub bad_add = "hello" + 42
+`)
+	mainPath := filepath.Join(root, "main.dang")
+	writeDangFile(t, mainPath, `pub greeting: String! { helper }
+`)
+
+	h := newLSPHarness(ctx, t, root)
+	uri := h.open(ctx, t, mainPath)
+	diagnostics := h.waitForDiagnostics(ctx, t, uri)
+
+	require.Empty(t, diagnostics, "sibling body errors should not surface on the active buffer")
+}
+
 func (LSPSuite) TestDiagnosticsLoadsSiblingFiles(ctx context.Context, t *testctx.T) {
 	root := t.TempDir()
 	writeDangFile(t, filepath.Join(root, "defs.dang"), `type Template {

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -284,8 +284,14 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 	if err := dang.InferDirectoryFilesFocused(ctx, blocks, currentBlock, typeEnv, fresh); err != nil {
 		analysis.Diagnostics = append(analysis.Diagnostics, h.errorToDiagnosticsForPath(err, uri, fp)...)
 	}
-	// Store the type environment in the File for later use (e.g., hover).
-	analysis.TypeEnv = typeEnv
+	// The block's Env composes the shared dirEnv with the file's own imports,
+	// so editor features see exactly what inference saw — including the file's
+	// unqualified imported symbols, which only live in the file-local env.
+	if currentBlock.Env != nil {
+		analysis.TypeEnv = currentBlock.Env
+	} else {
+		analysis.TypeEnv = typeEnv
+	}
 
 	return analysis, nil
 }

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -222,7 +222,7 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 	}
 
 	var parsedFiles []directoryFile
-	var allForms []dang.Node
+	var blocks []*dang.ModuleBlock
 	var currentBlock *dang.ModuleBlock
 
 	for _, path := range files {
@@ -256,7 +256,7 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 			URI:   fileURI,
 			Block: block,
 		})
-		allForms = append(allForms, block.Forms...)
+		blocks = append(blocks, block)
 	}
 
 	if currentBlock == nil {
@@ -275,16 +275,12 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 		ctx = dang.ContextWithImportConfigs(ctx, importConfigs...)
 	}
 
-	// Inject auto-imports (e.g. Dagger) before inference. Keep each file's AST
-	// forms untouched so editor features work against user-written source only.
-	allForms = dang.InjectAutoImports(ctx, allForms)
-
-	// Run type inference over every .dang file in the directory, matching the
-	// interpreter's directory-module semantics.
+	// Run type inference per file with file-local import scopes. Cross-file
+	// declarations resolve through the shared dirEnv; siblings' imports do not
+	// leak into this file's lookups.
 	typeEnv := dang.NewPreludeEnv("")
 	fresh := hm.NewSimpleFresher()
-	_, err = dang.InferFormsWithPhases(ctx, allForms, typeEnv, fresh)
-	if err != nil {
+	if err := dang.InferDirectoryFiles(ctx, blocks, typeEnv, fresh); err != nil {
 		analysis.Diagnostics = append(analysis.Diagnostics, h.errorToDiagnosticsForPath(err, uri, fp)...)
 	}
 	// Store the type environment in the File for later use (e.g., hover).

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -25,6 +25,7 @@ func NewHandler(rootCtx context.Context) *langHandler {
 		files:         make(map[DocumentURI]*File),
 		loadedEnvDirs: make(map[string]bool),
 		importCache:   make(map[string][]dang.ImportConfig),
+		parseCache:    make(map[string]parsedFile),
 		mu:            new(sync.Mutex),
 	}
 
@@ -51,8 +52,22 @@ type langHandler struct {
 	// a new dagger session on every keystroke.
 	importCache map[string][]dang.ImportConfig
 
+	// Cached file parses keyed by absolute file path. Sibling files in the
+	// same directory don't change on every keystroke, so reusing their parse
+	// trees turns directory analysis from O(files) into O(1) parses.
+	parseCache map[string]parsedFile
+
 	// TODO?: make per-file or something
 	mu *sync.Mutex
+}
+
+// parsedFile is a cache entry for a single .dang file's parse output. The
+// block is reused across analyzeDirectory calls when text is unchanged; its
+// ImportDecls' inferred schema modules are also cached on the nodes, so the
+// imports phase runs in O(1) on cache hit.
+type parsedFile struct {
+	text  string
+	block *dang.ModuleBlock
 }
 
 // File is
@@ -232,18 +247,12 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 			return nil, err
 		}
 
-		parsed, err := dang.ParseWithRecovery(path, []byte(fileText), dang.GlobalStore("filePath", path))
+		block, err := h.parseFileCached(path, fileText)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to parse Dang code for LSP", "path", path, "error", err)
 			if sameFile(path, fp) {
 				analysis.Diagnostics = append(analysis.Diagnostics, h.errorToDiagnostics(err, uri)...)
 			}
-			continue
-		}
-
-		block, ok := parsed.(*dang.ModuleBlock)
-		if !ok {
-			slog.WarnContext(ctx, "parsed result is not a ModuleBlock", "path", path, "type", fmt.Sprintf("%T", parsed))
 			continue
 		}
 
@@ -359,6 +368,38 @@ func (h *langHandler) directoryDangFiles(dir string) ([]string, error) {
 
 	sort.Strings(dangFiles)
 	return dangFiles, nil
+}
+
+// parseFileCached parses the .dang file at path against the given text,
+// reusing the cached *ModuleBlock when text is unchanged from the previous
+// call. The cache is keyed by absolute path; siblings unchanged between
+// keystrokes return their previous parse immediately. ImportDecl nodes in
+// reused blocks keep their cached schema modules, so subsequent imports
+// phases skip schema introspection.
+//
+// Auto-imports prepended into block.Forms by InferDirectoryFiles persist
+// across calls; prependAutoImports is idempotent.
+func (h *langHandler) parseFileCached(path, text string) (*dang.ModuleBlock, error) {
+	h.mu.Lock()
+	cached, ok := h.parseCache[path]
+	h.mu.Unlock()
+	if ok && cached.text == text {
+		return cached.block, nil
+	}
+
+	parsed, err := dang.ParseWithRecovery(path, []byte(text), dang.GlobalStore("filePath", path))
+	if err != nil {
+		return nil, err
+	}
+	block, ok := parsed.(*dang.ModuleBlock)
+	if !ok {
+		return nil, fmt.Errorf("parsed result for %s is not a ModuleBlock", path)
+	}
+
+	h.mu.Lock()
+	h.parseCache[path] = parsedFile{text: text, block: block}
+	h.mu.Unlock()
+	return block, nil
 }
 
 func (h *langHandler) textForPath(path string) (string, error) {

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -275,12 +275,13 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 		ctx = dang.ContextWithImportConfigs(ctx, importConfigs...)
 	}
 
-	// Run type inference per file with file-local import scopes. Cross-file
-	// declarations resolve through the shared dirEnv; siblings' imports do not
-	// leak into this file's lookups.
+	// Run type inference focused on the active buffer: full body inference for
+	// the open file, declarations only for siblings. Cross-file declarations
+	// still resolve through the shared dirEnv; sibling body errors do not run
+	// on every keystroke.
 	typeEnv := dang.NewPreludeEnv("")
 	fresh := hm.NewSimpleFresher()
-	if err := dang.InferDirectoryFiles(ctx, blocks, typeEnv, fresh); err != nil {
+	if err := dang.InferDirectoryFilesFocused(ctx, blocks, currentBlock, typeEnv, fresh); err != nil {
 		analysis.Diagnostics = append(analysis.Diagnostics, h.errorToDiagnosticsForPath(err, uri, fp)...)
 	}
 	// Store the type environment in the File for later use (e.g., hover).

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/url"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"slices"
 	"sort"
 	"sync"
+	"time"
 	"unicode"
 
 	"github.com/creachadair/jrpc2"
@@ -62,12 +64,19 @@ type langHandler struct {
 }
 
 // parsedFile is a cache entry for a single .dang file's parse output. The
-// block is reused across analyzeDirectory calls when text is unchanged; its
-// ImportDecls' inferred schema modules are also cached on the nodes, so the
-// imports phase runs in O(1) on cache hit.
+// block is reused across analyzeDirectory calls when the file's content is
+// unchanged; its ImportDecls' inferred schema modules are also cached on the
+// nodes, so the imports phase runs in O(1) on cache hit.
+//
+// For files on disk, mtime+size is used as the fingerprint so cache hits skip
+// the disk read entirely. For open buffers (no mtime), text is the
+// fingerprint.
 type parsedFile struct {
-	text  string
 	block *dang.ModuleBlock
+	text  string // populated only when sourced from an open buffer
+	mtime time.Time
+	size  int64
+	open  bool // true if sourced from an open buffer
 }
 
 // File is
@@ -242,13 +251,17 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 
 	for _, path := range files {
 		fileURI := toURI(path)
-		fileText, err := h.textForPath(path)
-		if err != nil {
-			return nil, err
-		}
 
-		block, err := h.parseFileCached(path, fileText)
+		block, err := h.parseFileCached(path)
 		if err != nil {
+			// IO errors (missing file, permission denied, broken symlink)
+			// are fatal — bail out so the caller can surface them. Parse
+			// errors are reported as diagnostics for the active buffer and
+			// otherwise skipped so the rest of the directory still analyzes.
+			var pathErr *fs.PathError
+			if errors.As(err, &pathErr) {
+				return nil, err
+			}
 			slog.WarnContext(ctx, "failed to parse Dang code for LSP", "path", path, "error", err)
 			if sameFile(path, fp) {
 				analysis.Diagnostics = append(analysis.Diagnostics, h.errorToDiagnostics(err, uri)...)
@@ -370,23 +383,50 @@ func (h *langHandler) directoryDangFiles(dir string) ([]string, error) {
 	return dangFiles, nil
 }
 
-// parseFileCached parses the .dang file at path against the given text,
-// reusing the cached *ModuleBlock when text is unchanged from the previous
-// call. The cache is keyed by absolute path; siblings unchanged between
-// keystrokes return their previous parse immediately. ImportDecl nodes in
-// reused blocks keep their cached schema modules, so subsequent imports
-// phases skip schema introspection.
+// parseFileCached returns the parsed *ModuleBlock for path. When the file is
+// unchanged from the cached entry, the cached block is returned without
+// re-parsing. For files on disk, the fingerprint is mtime+size — a stat call
+// is enough to know if the cache is still good, avoiding even the file read.
+// For open buffers, the fingerprint is the buffer's text.
 //
 // Auto-imports prepended into block.Forms by InferDirectoryFiles persist
-// across calls; prependAutoImports is idempotent.
-func (h *langHandler) parseFileCached(path, text string) (*dang.ModuleBlock, error) {
+// across calls; prependAutoImports is idempotent. ImportDecl nodes in cached
+// blocks keep their inferred schema modules, so the imports phase doesn't
+// re-introspect on cache hit.
+func (h *langHandler) parseFileCached(path string) (*dang.ModuleBlock, error) {
+	uri := toURI(path)
+
 	h.mu.Lock()
-	cached, ok := h.parseCache[path]
+	openFile := h.files[uri]
+	cached, hit := h.parseCache[path]
 	h.mu.Unlock()
-	if ok && cached.text == text {
+
+	if openFile != nil {
+		openFile.mu.Lock()
+		text := openFile.Text
+		openFile.mu.Unlock()
+		if hit && cached.open && cached.text == text {
+			return cached.block, nil
+		}
+		return h.parseAndStore(path, text, parsedFile{open: true, text: text})
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if hit && !cached.open && cached.mtime.Equal(info.ModTime()) && cached.size == info.Size() {
 		return cached.block, nil
 	}
 
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return h.parseAndStore(path, string(contents), parsedFile{mtime: info.ModTime(), size: info.Size()})
+}
+
+func (h *langHandler) parseAndStore(path, text string, entry parsedFile) (*dang.ModuleBlock, error) {
 	parsed, err := dang.ParseWithRecovery(path, []byte(text), dang.GlobalStore("filePath", path))
 	if err != nil {
 		return nil, err
@@ -395,31 +435,11 @@ func (h *langHandler) parseFileCached(path, text string) (*dang.ModuleBlock, err
 	if !ok {
 		return nil, fmt.Errorf("parsed result for %s is not a ModuleBlock", path)
 	}
-
+	entry.block = block
 	h.mu.Lock()
-	h.parseCache[path] = parsedFile{text: text, block: block}
+	h.parseCache[path] = entry
 	h.mu.Unlock()
 	return block, nil
-}
-
-func (h *langHandler) textForPath(path string) (string, error) {
-	uri := toURI(path)
-
-	h.mu.Lock()
-	openFile := h.files[uri]
-	h.mu.Unlock()
-
-	if openFile != nil {
-		openFile.mu.Lock()
-		defer openFile.mu.Unlock()
-		return openFile.Text, nil
-	}
-
-	contents, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("failed to read source file %s: %w", path, err)
-	}
-	return string(contents), nil
 }
 
 func (h *langHandler) buildDirectorySymbolTable(files []directoryFile, currentURI DocumentURI) *SymbolTable {

--- a/pkg/lsp/lsp_test.go
+++ b/pkg/lsp/lsp_test.go
@@ -153,6 +153,24 @@ func testFile(t *testctx.T, client *nvim.Nvim, file string) {
 		return err == nil && b
 	}, 5*time.Second, 10*time.Millisecond)
 
+	// Wait for the initial didOpen analysis to finish before driving any
+	// tests. The completion handler blocks on the file's processing flag;
+	// firing <C-x><C-o> while analysis is still in flight races Neovim's
+	// synchronous omnifunc (1s default). A synchronous hover probe goes
+	// through the same waitForFile() path, so once it returns the server
+	// is caught up.
+	require.Eventually(t, func() bool {
+		var ok bool
+		err := client.ExecLua(`
+			local params = {
+				textDocument = { uri = vim.uri_from_bufnr(0) },
+				position = { line = 0, character = 0 },
+			}
+			return vim.lsp.buf_request_sync(0, 'textDocument/hover', params, 500) ~= nil
+		`, &ok)
+		return err == nil && ok
+	}, 5*time.Second, 50*time.Millisecond)
+
 	lineCount, err := client.BufferLineCount(testBuf)
 	require.NoError(t, err)
 

--- a/pkg/lsp/testdata/complete.dang
+++ b/pkg/lsp/testdata/complete.dang
@@ -12,8 +12,13 @@ hom # test: ^Ea<C-x><C-o> => homepage┃
 Test.ser # test: ^Ea<C-x><C-o> => Test.serverInfo┃
 Test.hom # test: ^Ea<C-x><C-o> => Test.homepage┃
 
+# cross-file: pub addNums(...) is declared in gd.dang
+addN # test: ^Ea<C-x><C-o> => addNums┃
+# cross-file: pub multiply(...) is declared in hover.dang
+mult # test: ^Ea<C-x><C-o> => multiply┃
+
 # lexical bindings (function parameters)
-pub foo(jxkqv: Int!): [Int!] {
+pub paramScope(jxkqv: Int!): [Int!] {
   [] # test: ^ajx<C-x><C-o> => [jxkqv┃]
 }
 

--- a/pkg/lsp/testdata/config.lua
+++ b/pkg/lsp/testdata/config.lua
@@ -7,10 +7,11 @@ vim.cmd('runtime! ftdetect/*.lua')
 -- Load and configure the plugin
 require('dang').setup()
 
--- All keymaps used by tests are Neovim 0.11 defaults:
---   gd   -> vim.lsp.buf.definition()
---   K    -> vim.lsp.buf.hover()
---   grn  -> vim.lsp.buf.rename()
+-- Keymaps used by tests:
+--   K    -> vim.lsp.buf.hover()    (Neovim default)
+--   grn  -> vim.lsp.buf.rename()   (Neovim default)
+--   gd   -> vim.lsp.buf.definition() (bound here; Neovim 0.12 has no default)
 -- Omnicompletion (C-x C-o) uses omnifunc set automatically by LSP.
+vim.keymap.set('n', 'gd', function() vim.lsp.buf.definition() end)
 
 vim.lsp.log.set_level('trace')

--- a/pkg/lsp/testdata/gd.dang
+++ b/pkg/lsp/testdata/gd.dang
@@ -1,9 +1,12 @@
 # local binding
-let hello = 42
+let bound = 42
 
-hello # test: gd => ┃hello = 42
+bound # test: gd => ┃bound = 42
 
 # function definition
+"""
+Adds two numbers.
+"""
 pub addNums(x: Int!, y: Int!): Int! {
   x + y # test: ^gd => pub addNums(┃x: Int!, y: Int!): Int! {
 }
@@ -27,3 +30,6 @@ type Person {
 }
 
 Person # test: ^gd => type ┃Person {
+
+# cross-file: pub multiply(...) is declared in hover.dang
+multiply # test: ^gd => pub ┃multiply(x: Int!, y: Int!): Int! {

--- a/pkg/lsp/testdata/hover.dang
+++ b/pkg/lsp/testdata/hover.dang
@@ -26,15 +26,11 @@ let greeting = 42
 
 greeting # test: K => hover: Int!
 
-# function hover
-"""
-Adds two numbers.
-"""
-pub addNums(x: Int!, y: Int!): Int! {
-  x + y
-}
-
+# function hover (cross-file: pub addNums declared in gd.dang)
 addNums # test: K => hover: (x: Int!, y: Int!): Int!
+
+# function docs hover (cross-file: gd.dang's addNums has a docstring)
+addNums # test: K => hover: Adds two numbers
 
 # function with docs
 """

--- a/pkg/lsp/testdata/hover.dang
+++ b/pkg/lsp/testdata/hover.dang
@@ -43,6 +43,9 @@ pub multiply(x: Int!, y: Int!): Int! {
 
 multiply # test: K => hover: Multiplies two numbers together
 
+# unqualified imported value hover (file-local: composite reads lexical)
+serverInfo # test: K => hover: ServerInfo!
+
 # qualified type hover
 Test.serverInfo # test: ^wwK => hover: ServerInfo!
 

--- a/pkg/lsp/testdata/rename.dang
+++ b/pkg/lsp/testdata/rename.dang
@@ -1,7 +1,7 @@
 # local variable rename
-let hello = 42
+let renamable = 42
 
-hello # test: ^grn<C-u>world<CR> => ┃world
+renamable # test: ^grn<C-u>world<CR> => ┃world
 
 # function parameter rename
 pub add(x: Int!, y: Int!): Int! { x + y } # test: ^fxgrn<C-u>a<CR> => pub add(┃a: Int!, y: Int!): Int! { a + y }
@@ -12,6 +12,6 @@ pub sub(x: Int!, y: Int!): Int! { x - y } # test: ^wgrn<C-u>minus<CR> => pub ┃
 add
 
 # multiple occurrences
-let foo = 10
+let occurrences = 10
 
-foo + foo + foo # test: ^grn<C-u>bar<CR> => ┃bar + bar + bar
+occurrences + occurrences + occurrences # test: ^grn<C-u>bar<CR> => ┃bar + bar + bar


### PR DESCRIPTION
## Summary

Started as an investigation into [TestNeovimCompletion flakiness](https://github.com/vito/dang/blob/main/pkg/lsp/lsp_test.go) and turned into a deeper restructuring of how directory-scoped Dang modules are inferred and how the LSP analyzes files between keystrokes.

### Language change: file-local imports

Previously every \`.dang\` file in a directory had its forms flattened and inferred together, so \`import X\` in one file leaked into siblings' scopes. Multiple files importing the same schema would trip \`checkAliasConflicts\` and silently fail.

Now each file's imports live in a per-file env composed with the shared directory env via the existing \`CompositeModule\` overlay (writes flow to \`dirEnv\`; lookups check \`dirEnv\` first so local declarations naturally shadow imports). Phases run in lockstep across files so cross-file references in signatures and bodies still resolve regardless of file order.

### LSP performance

- **Focused inference**: \`analyzeDirectory\` now does full body inference only for the active buffer. Siblings contribute their declarations to the shared env but their bodies aren't re-inferred on every keystroke (so e.g. \`diagnostics.dang\`'s intentional body errors no longer fire on every keystroke when editing a different file).
- **Parse cache**: parsed \`*ModuleBlock\`s are cached per path. Unchanged siblings skip re-parsing and \`ImportDecl\`s reuse their cached schema modules.
- **Mtime fingerprint**: cached entries for disk files are keyed by mtime+size, so cache hits skip the file read entirely — only a stat call per unchanged sibling.

### Test infrastructure

- Synchronous hover probe before the neovim test loop to close the race where the first \`<C-x><C-o>\` raced the initial didOpen analysis (Neovim's omnifunc has a 1s default timeout).
- Renamed colliding bindings in \`pkg/lsp/testdata/\` (three different \`let hello = 42\`, two \`pub addNums\`, \`foo\` declared as both a function and a variable) and added cross-file coverage exercising the directory-wide env.
- Switched the test config's \`gd\` from Vim's builtin (local-only) to \`vim.lsp.buf.definition()\` — Neovim 0.12 dropped the default LSP \`gd\` mapping that 0.11 had.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`dagger check\` clean (lint + test:go + test:treesitter)
- [x] 20×4 stress run of \`TestLSP\` clean