### PR TITLE
feat: add uniq to lists to filter repeating items

### DIFF
--- a/pkg/dang/builtins_test.go
+++ b/pkg/dang/builtins_test.go
@@ -21,7 +21,7 @@ func TestBuiltinRegistryClassifiesDefinitions(t *testing.T) {
 		}
 	}
 
-	for _, name := range []string{"map", "filter", "reduce"} {
+	for _, name := range []string{"map", "filter", "reduce", "uniq"} {
 		if _, ok := LookupMethod(ListTypeModule, name); !ok {
 			t.Fatalf("list method %q was not indexed", name)
 		}
@@ -142,7 +142,7 @@ func TestConcurrentLookupMethod(t *testing.T) {
 			defer wg.Done()
 			<-start
 
-			for _, name := range []string{"map", "filter", "reduce"} {
+			for _, name := range []string{"map", "filter", "reduce", "uniq"} {
 				if _, ok := LookupMethod(ListTypeModule, name); !ok {
 					misses <- name
 				}

--- a/pkg/dang/stdlib.go
+++ b/pkg/dang/stdlib.go
@@ -353,6 +353,33 @@ func registerStdlib() {
 			return BoolValue{Val: false}, nil
 		})
 
+	// List.uniq method: uniq -> [a]!
+	Method(ListTypeModule, "uniq").
+		Doc("returns a new list with duplicate elements removed, preserving first occurrence order").
+		Returns(NonNull(ListOf(TypeVar('a')))).
+		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
+			list := self.(ListValue)
+			result := make([]Value, 0, len(list.Elements))
+
+			for _, item := range list.Elements {
+				seen := false
+				for _, existing := range result {
+					if valuesEqual(existing, item) {
+						seen = true
+						break
+					}
+				}
+				if !seen {
+					result = append(result, item)
+				}
+			}
+
+			return ListValue{
+				Elements: result,
+				ElemType: list.ElemType,
+			}, nil
+		})
+
 	// List.reject method: reject(fn: \(a) -> Boolean!) -> [a]!
 	Method(ListTypeModule, "reject").
 		Doc("returns a new list excluding elements for which the predicate returns true").

--- a/tests/test_list_uniq.dang
+++ b/tests/test_list_uniq.dang
@@ -1,0 +1,23 @@
+# Test list.uniq method
+
+# Basic functionality with integers
+pub numbers: [Int!]! = [1, 2, 2, 3, 1, 4]
+assert { numbers.uniq == [1, 2, 3, 4] }
+
+# Basic functionality with strings
+pub words: [String!]! = ["red", "blue", "red", "green", "blue"]
+assert { words.uniq == ["red", "blue", "green"] }
+
+# Empty lists
+pub empty: [Int!]! = []
+assert { empty.uniq == [] }
+
+# Lists with nulls
+pub nullable: [Int]! = [1, null, 1, null, 2]
+assert { nullable.uniq == [1, null, 2] }
+
+# Nested lists are not Go-comparable, but Dang equality supports them
+pub nested: [[Int!]!]! = [[1, 2], [1, 2], [2, 1], [1, 2], [3]]
+assert { nested.uniq == [[1, 2], [2, 1], [3]] }
+
+print("List uniq tests passed!")


### PR DESCRIPTION
Note: uses two loops and `valuesEqual` to make comparison logic simpler (at the cost of some performance penalty).