### PR TITLE
fix(dang): don't require id field for interface conformance

### DIFF
--- a/pkg/dang/fields.go
+++ b/pkg/dang/fields.go
@@ -651,6 +651,30 @@ func (c *ObjectDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (h
 	return c.ConstructorFnType, newBodyErr
 }
 
+// isReservedInterfaceField reports whether an interface field is provided by
+// the Dagger runtime rather than the implementer. Dagger synthesizes `id: ID!`
+// on every object and interface in a module's schema, so an imported interface
+// carries an `id` field that no user-defined type declares (and shouldn't have
+// to: Dagger supplies it for implementers too). Locally-declared interfaces
+// never have one. Skip it during conformance checks.
+func isReservedInterfaceField(field string, scheme *hm.Scheme) bool {
+	if field != "id" {
+		return false
+	}
+	t, ok := scheme.Type()
+	if !ok {
+		return false
+	}
+	// Interface fields are stored as `() -> T`; unwrap to the return type.
+	if fn, ok := t.(*hm.FunctionType); ok {
+		t = fn.Ret(false)
+	}
+	if nn, ok := t.(hm.NonNullType); ok {
+		t = nn.Type
+	}
+	return t.Name() == "ID"
+}
+
 // validateInterfaceImplementations checks that this type correctly implements all declared interfaces
 func (c *ObjectDecl) validateInterfaceImplementations(objectMod *Type, env TypeScope, ifaceSym *Symbol) error {
 	ifaceType, found := env.NamedType(ifaceSym.Name)
@@ -668,6 +692,9 @@ func (c *ObjectDecl) validateInterfaceImplementations(objectMod *Type, env TypeS
 	var missingFields []string
 	// Check that all interface fields are present in the object
 	for field, fieldScheme := range ifaceMod.Bindings(PrivateVisibility) {
+		if isReservedInterfaceField(field, fieldScheme) {
+			continue
+		}
 		objectFieldScheme, objectHasField := objectMod.SchemeOf(field)
 		if !objectHasField {
 			missingFields = append(missingFields, field)
@@ -1271,6 +1298,9 @@ func validateInterfaceExtension(child *Type, env TypeScope, parentSym *Symbol) e
 
 	var missingFields []string
 	for field, fieldScheme := range parentMod.Bindings(PrivateVisibility) {
+		if isReservedInterfaceField(field, fieldScheme) {
+			continue
+		}
 		childScheme, has := child.SchemeOf(field)
 		if !has {
 			missingFields = append(missingFields, field)

--- a/tests/errors/interface_wrong_field_type.dang
+++ b/tests/errors/interface_wrong_field_type.dang
@@ -1,10 +1,10 @@
 # Test that interface field types must match
 
 interface Identifiable {
-  pub id: ID!
+  pub ref: ID!
 }
 
 type User implements Identifiable {
-  pub id: String! # Wrong: should be ID!
+  pub ref: String! # Wrong: should be ID!
   pub name: String!
 }

--- a/tests/test_interface_id_not_required.dang
+++ b/tests/test_interface_id_not_required.dang
@@ -1,0 +1,15 @@
+# A type implementing an interface is NOT required to provide the synthesized
+# `id: ID!` field. Dagger reserves `id` and supplies it for every interface
+# implementer, so requiring the user to declare it would be wrong. Other
+# interface fields (like `name`) are still required.
+
+interface Identifiable {
+  pub id: ID!
+  pub name: String!
+}
+
+type User implements Identifiable {
+  pub name: String!
+}
+
+assert { User("alice").name == "alice" }

--- a/tests/testdata/interface_wrong_field_type.golden
+++ b/tests/testdata/interface_wrong_field_type.golden
@@ -1,11 +1,11 @@
-[1m[31mError:[0m field "id": type String! is not compatible with interface type ID!
+[1m[31mError:[0m field "ref": type String! is not compatible with interface type ID!
   [2m[34m--> errors/interface_wrong_field_type.dang:7:22[0m
  [2m    |[0m
  [2m  5 | }[0m
  [2m  6 | [0m
  [2m[34m[1m  7 | [0mtype User implements Identifiable {
 [2m                            [31m^^^^^^^^^^^^[0m
- [2m  8 |   pub id: String! # Wrong: should be ID![0m
+ [2m  8 |   pub ref: String! # Wrong: should be ID![0m
  [2m  9 |   pub name: String![0m
  [2m    |[0m
 


### PR DESCRIPTION
## Problem

Dagger synthesizes an `id: ID!` field on every interface in a module's GraphQL schema, and supplies it for implementers automatically. When a Dang module imports an interface from a **dependency** schema, that synthesized `id` field is included in the interface's bindings. Dang's conformance checks then iterate every interface binding and demand the implementer provide each one — so a user type that says `implements Foo` fails with:

```
class Hi is missing `id(): ID!`, required by interface Dagger.DepGreeter
```

Locally-declared interfaces never carried the field (their bindings only contain the fields the user wrote), so this only surfaced across module boundaries — e.g. implementing an interface defined in a Dagger module dependency.

## Fix

Skip the reserved `id: ID!` field in both conformance checks (`validateInterfaceImplementations` and `validateInterfaceExtension`) via a small `isReservedInterfaceField` helper. The guard is precise: it only exempts a field named `id` whose return type is the `ID` scalar, so a real `id: String!` field is still enforced. This matches Dagger's contract — `id` is reserved and runtime-synthesized for every implementer, so requiring the user to declare it is never correct.

## Tests

- `tests/test_interface_id_not_required.dang` — a type implementing an interface that declares `id: ID!` is allowed to omit `id`, while other interface fields (`name`) are still required. Verified to fail without the fix and pass with it.
- `tests/errors/interface_wrong_field_type.dang` — this existing field-type-mismatch test happened to use `id` as its example field, so it now uses a non-reserved field (`ref`) to keep exercising the type-compatibility checker. Golden updated accordingly.

Full suite green: `go test ./tests/ ./pkg/dang/`.
