### PR TITLE
docs(literals): fix butchered multi-line backtick example

### DIFF
--- a/docs/lit/language/literals.md
+++ b/docs/lit/language/literals.md
@@ -36,7 +36,7 @@
 ### Backtick templates
 
 - `` `hello ${name}!` `` — single-line, `${...}` interpolation
-- ``` ```...``` ``` — multi-line; same minimum-indent dedent as triple-quoted; fences grow (4+ backticks) to wrap shorter backtick blocks, and the close fence must match the open fence length
+- ```` ```...``` ```` — multi-line; same minimum-indent dedent as triple-quoted; fences grow (4+ backticks) to wrap shorter backtick blocks, and the close fence must match the open fence length
 - only escape is `\${` → literal `${`; every other backslash is literal (`` `\d+` `` stays `\d+`). A lone `$` not followed by `{` is literal.
 - interpolated expressions are auto-stringified like [#strings] `toString` (non-strings JSON-encode; `null` → `"null"`)
 - optional language tag (parsed but does not affect the value): ` ```go ... ``` `


### PR DESCRIPTION
Docs feedback (page `/literals`): a reader reported the multi-line backtick-template example got butchered because Dang's own backticks collide with the document's outer Markdown backticks.

**Cause:** the bullet wrapped its triple-backtick example in a *triple*-backtick inline-code span. CommonMark matched the inner triple backticks as the closing delimiter, rendering it as an empty `<code>` element with a stray `...` left outside the span.

**Fix:** grow the outer inline-code fence to four backticks so it encloses the inner triple-backtick run — the same longer-fence-wraps-shorter rule the example itself describes. Rebuilt the docs and confirmed it now renders correctly. The language-tag example on the following bullet already renders fine, so it's left untouched.

Kept it as a one-bullet inline example to match the section's `> Meta:` guidance (one short subsection per literal kind, one example each).