### PR TITLE
fix(docs): yellow accent in dark mode, blue in light

### DIFF
--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -21,7 +21,7 @@
   :root{
     --bg:#ffffff;--bg2:#f6f8fa;--bg3:#eaeef2;
     --fg:#1f2328;--fg2:#57606a;--fg3:#818b98;
-    --accent:#e5a100;--accent2:#0044e5;
+    --accent:#195dff;--accent2:#0044e5;
     --green:#1a7f55;--cyan:#0b7285;--pink:#bf3989;--orange:#bc4c00;--yellow:#9a6700;
     --code-bg:#f6f8fa;--code-border:#d0d7de;
     --td-border:rgba(208,215,222,.6);

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -12,7 +12,7 @@
 :root{
   --bg:#0d0f14;--bg2:#13161d;--bg3:#1a1e28;
   --fg:#c9d1d9;--fg2:#8b949e;--fg3:#6e7681;
-  --accent:#7c6aef;--accent2:#a78bfa;
+  --accent:#fbbf24;--accent2:#fcd34d;
   --green:#34d399;--cyan:#22d3ee;--pink:#f472b6;--orange:#ffa657;--yellow:#fbbf24;
   --code-bg:#0d1117;--code-border:#30363d;
   --td-border:rgba(48,54,61,.3);
@@ -21,7 +21,7 @@
   :root{
     --bg:#ffffff;--bg2:#f6f8fa;--bg3:#eaeef2;
     --fg:#1f2328;--fg2:#57606a;--fg3:#818b98;
-    --accent:#7c6aef;--accent2:#6440d8;
+    --accent:#d9a400;--accent2:#9a6700;
     --green:#1a7f55;--cyan:#0b7285;--pink:#bf3989;--orange:#bc4c00;--yellow:#9a6700;
     --code-bg:#f6f8fa;--code-border:#d0d7de;
     --td-border:rgba(208,215,222,.6);

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -12,7 +12,7 @@
 :root{
   --bg:#0d0f14;--bg2:#13161d;--bg3:#1a1e28;
   --fg:#c9d1d9;--fg2:#8b949e;--fg3:#6e7681;
-  --accent:#ffbb19;--accent2:#ffcf5b;
+  --accent:#ffbb19;--accent2:#ffcf5b;--on-accent:#0d0f14;
   --green:#34d399;--cyan:#22d3ee;--pink:#f472b6;--orange:#ffa657;--yellow:#fbbf24;
   --code-bg:#0d1117;--code-border:#30363d;
   --td-border:rgba(48,54,61,.3);
@@ -21,7 +21,7 @@
   :root{
     --bg:#ffffff;--bg2:#f6f8fa;--bg3:#eaeef2;
     --fg:#1f2328;--fg2:#57606a;--fg3:#818b98;
-    --accent:#195dff;--accent2:#0044e5;
+    --accent:#195dff;--accent2:#0044e5;--on-accent:#ffffff;
     --green:#1a7f55;--cyan:#0b7285;--pink:#bf3989;--orange:#bc4c00;--yellow:#9a6700;
     --code-bg:#f6f8fa;--code-border:#d0d7de;
     --td-border:rgba(208,215,222,.6);

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -12,7 +12,7 @@
 :root{
   --bg:#0d0f14;--bg2:#13161d;--bg3:#1a1e28;
   --fg:#c9d1d9;--fg2:#8b949e;--fg3:#6e7681;
-  --accent:#fbbf24;--accent2:#fcd34d;
+  --accent:#ffbb19;--accent2:#ffbb19;
   --green:#34d399;--cyan:#22d3ee;--pink:#f472b6;--orange:#ffa657;--yellow:#fbbf24;
   --code-bg:#0d1117;--code-border:#30363d;
   --td-border:rgba(48,54,61,.3);
@@ -21,7 +21,7 @@
   :root{
     --bg:#ffffff;--bg2:#f6f8fa;--bg3:#eaeef2;
     --fg:#1f2328;--fg2:#57606a;--fg3:#818b98;
-    --accent:#d9a400;--accent2:#9a6700;
+    --accent:#e5a100;--accent2:#e5a100;
     --green:#1a7f55;--cyan:#0b7285;--pink:#bf3989;--orange:#bc4c00;--yellow:#9a6700;
     --code-bg:#f6f8fa;--code-border:#d0d7de;
     --td-border:rgba(208,215,222,.6);

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -12,7 +12,7 @@
 :root{
   --bg:#0d0f14;--bg2:#13161d;--bg3:#1a1e28;
   --fg:#c9d1d9;--fg2:#8b949e;--fg3:#6e7681;
-  --accent:#ffbb19;--accent2:#ffbb19;
+  --accent:#ffbb19;--accent2:#ffcf5b;
   --green:#34d399;--cyan:#22d3ee;--pink:#f472b6;--orange:#ffa657;--yellow:#fbbf24;
   --code-bg:#0d1117;--code-border:#30363d;
   --td-border:rgba(48,54,61,.3);
@@ -21,7 +21,7 @@
   :root{
     --bg:#ffffff;--bg2:#f6f8fa;--bg3:#eaeef2;
     --fg:#1f2328;--fg2:#57606a;--fg3:#818b98;
-    --accent:#e5a100;--accent2:#e5a100;
+    --accent:#e5a100;--accent2:#0044e5;
     --green:#1a7f55;--cyan:#0b7285;--pink:#bf3989;--orange:#bc4c00;--yellow:#9a6700;
     --code-bg:#f6f8fa;--code-border:#d0d7de;
     --td-border:rgba(208,215,222,.6);

--- a/docs/js/feedback.js
+++ b/docs/js/feedback.js
@@ -88,7 +88,7 @@
     ".dang-fb-send {",
     "  font: inherit; font-size: .8rem; cursor: pointer; padding: .3rem .8rem;",
     "  border-radius: 6px; border: 1px solid var(--accent);",
-    "  background: var(--accent); color: #0d0f14;",
+    "  background: var(--accent); color: var(--on-accent);",
     "}",
     ".dang-fb-send:disabled { opacity: .5; cursor: default; }",
     ".dang-fb-status { font-size: .78rem; color: var(--fg2); padding: .25rem 0; }",

--- a/docs/js/feedback.js
+++ b/docs/js/feedback.js
@@ -88,7 +88,7 @@
     ".dang-fb-send {",
     "  font: inherit; font-size: .8rem; cursor: pointer; padding: .3rem .8rem;",
     "  border-radius: 6px; border: 1px solid var(--accent);",
-    "  background: var(--accent); color: #fff;",
+    "  background: var(--accent); color: #0d0f14;",
     "}",
     ".dang-fb-send:disabled { opacity: .5; cursor: default; }",
     ".dang-fb-status { font-size: .78rem; color: var(--fg2); padding: .25rem 0; }",


### PR DESCRIPTION
## Feedback

> accent color should be yellow, not purple

## Change

The whole site's accent is driven by CSS variables in `page.tmpl`'s `:root`
(links, blockquote borders, nav current item, search highlights, and the
feedback widget). Replaced the purple pair, settling on yellow for dark mode
and blue for light mode (yellow text on white was too low-contrast):

- **Dark:** `--accent:#ffbb19` (fills/borders), `--accent2:#ffcf5b` (links/text).
- **Light:** `--accent:#195dff` (fills/borders), `--accent2:#0044e5` (links/text).

Also added `--on-accent` so the feedback widget's **Send** button text stays
readable over the accent fill in each scheme (dark text on yellow, white on
blue).