### PR TITLE
fix(docs): only show feedback button on prose

### DIFF
--- a/docs/js/feedback.js
+++ b/docs/js/feedback.js
@@ -298,10 +298,31 @@
     target.appendChild(link);
   }
 
+  // Only prose-bearing elements are worth commenting on. Skip navigational
+  // chrome that happens to match the selectors above:
+  //
+  //   - the table of contents, rendered as <nav>, so every TOC entry is a
+  //     <li> inside it;
+  //   - any element whose entire text is a single link (the GitHub /
+  //     pkg.go.dev header links, a bare "see [Page]" cross-ref, etc.) —
+  //     there's no prose to give feedback on, just a destination.
+  //
+  // A list item like "see <a>Functions</a> for the full set" keeps its link:
+  // its text is more than the link's, so it reads as prose.
+  function isProse(el) {
+    if (el.closest("nav")) return false;
+    var links = el.querySelectorAll("a");
+    if (links.length === 1) {
+      var linkText = links[0].textContent.trim().replace(/\s+/g, " ");
+      if (linkText && excerptOf(el) === linkText) return false;
+    }
+    return true;
+  }
+
   document.querySelectorAll(INLINE).forEach(function (el) {
-    attach(el, false);
+    if (isProse(el)) attach(el, false);
   });
   document.querySelectorAll(BLOCK).forEach(function (el) {
-    attach(el, true);
+    if (isProse(el)) attach(el, true);
   });
 })();


### PR DESCRIPTION
## Feedback

> These "GitHub", "pkg.go.dev", and all the list items / links in the table of contents below shouldn't have a "feedback" button — way too noisy. We only want a 'feedback' button for list items that contain prose. Can you find a good filter for detecting that?

(page: `/`)

## Change

The widget attached a feedback button to every `main li`/`main p`, so the GitHub / pkg.go.dev header links (rendered as `<p><a>…</a></p>`) and every table-of-contents entry got a button with nothing to comment on.

Added an `isProse()` filter applied before attaching. An element is skipped when:

- it lives inside a `<nav>` — that's the table of contents, so all TOC entries are covered at once; or
- its **entire** text is a single link (the GitHub / pkg.go.dev links, or a bare cross-ref).

A genuine prose item that *contains* a link is kept, since its text is more than the link's — e.g. `see <a>Functions</a> for the full set`. Verified against the built HTML: the only site-wide single-link items outside `<nav>` are exactly GitHub and pkg.go.dev.