### PR TITLE
docs(overview): drop two low-value bullets from "what's not in the language"

### DIFF
--- a/docs/lit/language/overview.md
+++ b/docs/lit/language/overview.md
@@ -36,6 +36,4 @@
 ## What's *not* in the language
 
 - no inheritance (only `implements` for interfaces — see [#interfaces-unions])
-- errors aren't control flow — `raise`/`try`/`catch` are for genuine failures, not branching ([#errors])
 - no metaprogramming / macros
-- no implicit scalar coercion outside `::` type ascription ([#types])

--- a/docs/lit/language/overview.md
+++ b/docs/lit/language/overview.md
@@ -38,4 +38,4 @@
 - no inheritance (only `implements` for interfaces — see [#interfaces-unions])
 - errors aren't control flow — `raise`/`try`/`catch` are for genuine failures, not branching ([#errors])
 - no metaprogramming / macros
-- no implicit scalar coercion outside `::` type ascription (the `TypeHint` form; also drives `fromJSON`/`fromYAML` materialization — see [#json-yaml])
+- no implicit scalar coercion outside `::` type ascription ([#types])

--- a/docs/lit/language/overview.md
+++ b/docs/lit/language/overview.md
@@ -36,6 +36,6 @@
 ## What's *not* in the language
 
 - no inheritance (only `implements` for interfaces — see [#interfaces-unions])
-- no exceptions for control flow — `raise`/`try`/`catch` exist but are deliberate, not flow control ([#errors])
+- errors aren't control flow — `raise`/`try`/`catch` exist, but `return` covers early exit and null-tracking covers expected absence, so exceptions stay reserved for genuine failures ([#errors])
 - no metaprogramming / macros
 - no implicit scalar coercion outside `::` type ascription (the `TypeHint` form; also drives `fromJSON`/`fromYAML` materialization — see [#json-yaml])

--- a/docs/lit/language/overview.md
+++ b/docs/lit/language/overview.md
@@ -36,6 +36,6 @@
 ## What's *not* in the language
 
 - no inheritance (only `implements` for interfaces — see [#interfaces-unions])
-- errors aren't control flow — `raise`/`try`/`catch` exist, but `return` covers early exit and null-tracking covers expected absence, so exceptions stay reserved for genuine failures ([#errors])
+- errors aren't control flow — `raise`/`try`/`catch` are for genuine failures, not branching ([#errors])
 - no metaprogramming / macros
 - no implicit scalar coercion outside `::` type ascription (the `TypeHint` form; also drives `fromJSON`/`fromYAML` materialization — see [#json-yaml])


### PR DESCRIPTION
Trims the **"What's *not* in the language"** list on `/overview` down to the
broad, orienting absences.

A reader flagged the errors bullet:

> no exceptions for control flow — `raise`/`try`/`catch` exist but are deliberate, not flow control

> This is confusing - how could something that the USER decides whether to do be "not in the language"?

They're right that it's miscategorized — exceptions *are* in the language; not
using them for flow is a design stance, not an absence. Rather than reword it,
we cut it: the errors page already leads with exactly this point. The adjacent
`no implicit scalar coercion` bullet goes too — a narrow detail better left to
the types page, not a mental-model seed.

The section keeps the genuinely broad absences (`no inheritance`,
`no metaprogramming / macros`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
