### PR TITLE
fix(docs): restore spacing between blockquote paragraphs

### DIFF
--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -65,6 +65,7 @@ blockquote, .inset{
   padding:.6rem .9rem !important;margin:.75rem 0 !important;border-radius:0 4px 4px 0;font-size:.85rem;
 }
 blockquote p, .inset p{color:var(--fg2);margin:0}
+blockquote p + p, .inset p + p{margin-top:.6rem}
 blockquote strong, .inset strong{color:var(--accent2)}
 
 pre{


### PR DESCRIPTION
## Docs feedback

> The spacing between these paragraphs is missing - please fix

Page `/`, near the front-page disclaimer ("Apologies in advance for any
nonsense...").

## Cause

The "NOTE FROM A HUMAN" blockquote on the landing page has two paragraphs,
but `blockquote p` was styled with `margin:0`. That rule exists so a
single-paragraph blockquote hugs its padding, but it also collapsed the
vertical gap between consecutive paragraphs, so the two ran together.

## Fix

Add `blockquote p + p { margin-top:.6rem }` (and the same for `.inset`) so
adjacent paragraphs get vertical spacing. Single-paragraph blockquotes are
unaffected — the leading paragraph still sits flush against the top padding.
