### PR TITLE
feat(docs): add GitHub GraphQL playground page

### DIFF
--- a/cmd/dang-playground/main.go
+++ b/cmd/dang-playground/main.go
@@ -4,9 +4,23 @@
 // entirely client-side in the browser. It backs the interactive code snippets
 // on the documentation site.
 //
-// It exposes a single global function, dangEval(source), which parses,
+// It exposes a single global function, dangEval(source, token), which parses,
 // type-checks, and evaluates a Dang program with the standard library in
-// scope (no GraphQL imports), returning a result object to JavaScript.
+// scope, returning a Promise that resolves to a result object.
+//
+// When token is a non-empty string, a live `import GitHub` is wired into the
+// program: a GraphQL client pointed at https://api.github.com/graphql with the
+// token as a bearer credential. The schema is introspected on first use (and
+// cached for the life of the module) so `import GitHub` resolves to GitHub's
+// real types and root fields — `viewer`, `repository`, and so on. Introspection
+// and queries are ordinary cross-origin fetches; GitHub's GraphQL endpoint
+// permits CORS, so no proxy is involved.
+//
+// dangEval returns a Promise (not a plain value) because that GitHub traffic is
+// network I/O: a synchronous js.Func cannot block on a fetch without deadlocking
+// the single-threaded wasm event loop, so the work runs in a goroutine that
+// resolves the Promise when it finishes. Snippets with no token never touch the
+// network but still resolve through the same Promise for a single call shape.
 //
 // Build with:
 //
@@ -17,13 +31,21 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
+	"sync"
 	"syscall/js"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/vito/dang/pkg/dang"
 	"github.com/vito/dang/pkg/hm"
+	"github.com/vito/dang/pkg/introspection"
 	"github.com/vito/dang/pkg/ioctx"
 )
+
+// githubEndpoint is GitHub's GraphQL API. Queries and introspection both go here
+// directly from the browser; the endpoint sends permissive CORS headers.
+const githubEndpoint = "https://api.github.com/graphql"
 
 func main() {
 	js.Global().Set("dangEval", js.FuncOf(dangEval))
@@ -40,9 +62,10 @@ func main() {
 //
 //	{ ok: bool, value: string, output: string, error: string, stage: string }
 //
-// stage is "" on success, or "parse" | "type" | "eval" identifying which
-// phase failed.
-func result(value, output, errMsg, stage string) any {
+// stage is "" on success, or "parse" | "type" | "eval" | "auth" identifying
+// which phase failed. "auth" covers GitHub introspection failures (e.g. an
+// expired or unauthorized token).
+func result(value, output, errMsg, stage string) map[string]any {
 	return map[string]any{
 		"ok":     errMsg == "",
 		"value":  value,
@@ -52,12 +75,43 @@ func result(value, output, errMsg, stage string) any {
 	}
 }
 
-// dangEval is the JS-facing entry point: dangEval(source) -> result object.
+// dangEval is the JS-facing entry point: dangEval(source, token) -> Promise of
+// a result object. token is optional; when present and non-empty, an
+// `import GitHub` in the source resolves against the live GitHub schema.
 func dangEval(_ js.Value, args []js.Value) any {
-	if len(args) < 1 || args[0].Type() != js.TypeString {
+	source := ""
+	if len(args) >= 1 && args[0].Type() == js.TypeString {
+		source = args[0].String()
+	}
+	token := ""
+	if len(args) >= 2 && args[1].Type() == js.TypeString {
+		token = args[1].String()
+	}
+
+	// Run the (potentially network-bound) evaluation in a goroutine and report
+	// the outcome by resolving a Promise. See the package doc for why this
+	// can't be synchronous.
+	executor := js.FuncOf(func(_ js.Value, pargs []js.Value) any {
+		resolve := pargs[0]
+		go func() {
+			resolve.Invoke(evalSource(source, token))
+		}()
+		return nil
+	})
+	// The Promise constructor invokes the executor synchronously, so once New
+	// returns the executor won't be called again and can be released. The
+	// goroutine keeps its own reference to resolve.
+	defer executor.Release()
+	return js.Global().Get("Promise").New(executor)
+}
+
+// evalSource parses, type-checks, and evaluates one snippet, returning the
+// result map. It runs on its own goroutine, so it may block on network I/O
+// (GitHub introspection/queries) freely.
+func evalSource(source, token string) map[string]any {
+	if source == "" {
 		return result("", "", "dangEval expects a source string", "parse")
 	}
-	source := args[0].String()
 
 	// Parse.
 	parsed, err := dang.ParseWithRecovery("playground", []byte(source))
@@ -70,19 +124,32 @@ func dangEval(_ js.Value, args []js.Value) any {
 	}
 	forms := file.Forms
 
+	// Build the context carrying any GraphQL imports. With a token, `import
+	// GitHub` resolves; without one, the context is bare and only the standard
+	// library is in scope. The same context backs both inference and
+	// evaluation so the import's schema-module identity is shared between them.
+	baseCtx := context.Background()
+	if token != "" {
+		cfg, err := githubImport(baseCtx, token)
+		if err != nil {
+			return result("", "", err.Error(), "auth")
+		}
+		baseCtx = dang.ContextWithImportConfigs(baseCtx, cfg)
+	}
+
 	// Fresh standard-library scopes per run, so re-running a snippet is
 	// idempotent and never leaks state between evaluations.
 	typeScope, valueScope := dang.BuildScopesFromImports("", nil)
 
 	// Type-check.
 	fresh := hm.NewSimpleFresher()
-	if _, err := dang.InferFormsWithPhases(context.Background(), forms, typeScope, fresh); err != nil {
+	if _, err := dang.InferFormsWithPhases(baseCtx, forms, typeScope, fresh); err != nil {
 		return result("", "", err.Error(), "type")
 	}
 
 	// Evaluate, capturing anything written to stdout/stderr (e.g. log()).
 	var out bytes.Buffer
-	ctx := ioctx.StdoutToContext(context.Background(), &out)
+	ctx := ioctx.StdoutToContext(baseCtx, &out)
 	ctx = ioctx.StderrToContext(ctx, &out)
 
 	var last dang.Value
@@ -99,4 +166,53 @@ func dangEval(_ js.Value, args []js.Value) any {
 		value = fmt.Sprint(last.String())
 	}
 	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
+}
+
+// GitHub schema cache, keyed by the token it was introspected with. The wasm
+// instance lives for the page's lifetime, so introspecting once (a multi-MB
+// fetch) and reusing the schema keeps subsequent Runs fast. A different token
+// (re-auth) forces a fresh introspection.
+var (
+	ghMu     sync.Mutex
+	ghSchema *introspection.Schema
+	ghToken  string
+)
+
+// githubImport builds the GitHub ImportConfig, introspecting the schema on
+// first use and serving it from cache thereafter.
+func githubImport(ctx context.Context, token string) (dang.ImportConfig, error) {
+	client := graphql.NewClient(githubEndpoint, &http.Client{
+		Transport: bearerTransport{token: token, base: http.DefaultTransport},
+	})
+
+	ghMu.Lock()
+	defer ghMu.Unlock()
+	if ghSchema == nil || ghToken != token {
+		// dagger=false: GitHub is a plain GraphQL endpoint, so use the standard
+		// introspection query rather than Dagger's variant.
+		schema, err := dang.IntrospectSchema(ctx, client, false)
+		if err != nil {
+			return dang.ImportConfig{}, fmt.Errorf("GitHub introspection failed (check that you're signed in): %w", err)
+		}
+		ghSchema = schema
+		ghToken = token
+	}
+
+	return dang.ImportConfig{
+		Name:   "GitHub",
+		Client: client,
+		Schema: ghSchema,
+	}, nil
+}
+
+// bearerTransport attaches the GitHub bearer token to every request.
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+t.token)
+	return t.base.RoundTrip(req)
 }

--- a/docs/functions/github/callback.js
+++ b/docs/functions/github/callback.js
@@ -1,0 +1,112 @@
+// Cloudflare Pages Function handling GET /github/callback.
+//
+// Step two of the GitHub OAuth web flow (see functions/github/login.js): GitHub
+// redirects here with ?code & ?state. We verify the state against the cookie
+// login.js set, exchange the code for an access token using the client secret,
+// then bounce the visitor back to the page they started from with the token in
+// the URL fragment (#gh_token=…). The fragment is never sent to a server, and
+// playground.js immediately stashes it in sessionStorage and strips it from
+// the URL.
+//
+// Secrets (encrypted): GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET. See login.js.
+
+const STATE_COOKIE = "gh_oauth";
+
+// Clears the state cookie; sent on every response so it never lingers.
+const CLEAR_COOKIE =
+  STATE_COOKIE + "=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax";
+
+export async function onRequestGet({ request, env }) {
+  if (!env.GITHUB_CLIENT_ID || !env.GITHUB_CLIENT_SECRET) {
+    return fail("github auth is not configured", 503);
+  }
+
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state) {
+    return fail("missing code or state", 400);
+  }
+
+  // Verify CSRF state and recover the return path from the cookie login.js set.
+  const cookie = parseCookie(request.headers.get("Cookie") || "")[STATE_COOKIE];
+  if (!cookie) {
+    return fail("missing or expired login state", 400);
+  }
+  const dot = cookie.indexOf(".");
+  const cookieState = dot === -1 ? cookie : cookie.slice(0, dot);
+  if (!timingSafeEqual(cookieState, state)) {
+    return fail("state mismatch", 400);
+  }
+  let returnTo = dot === -1 ? "/" : b64urlDecode(cookie.slice(dot + 1));
+  if (!returnTo.startsWith("/") || returnTo.startsWith("//")) {
+    returnTo = "/";
+  }
+
+  // Exchange the code for an access token.
+  let token;
+  try {
+    const res = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: { Accept: "application/json", "content-type": "application/json" },
+      body: JSON.stringify({
+        client_id: env.GITHUB_CLIENT_ID,
+        client_secret: env.GITHUB_CLIENT_SECRET,
+        code: code,
+        redirect_uri: url.origin + "/github/callback",
+      }),
+    });
+    const data = await res.json();
+    if (data.error || !data.access_token) {
+      return fail("token exchange failed: " + (data.error_description || data.error || "no token"), 502);
+    }
+    token = data.access_token;
+  } catch (e) {
+    return fail("could not reach GitHub to exchange the code", 502);
+  }
+
+  // Hand the token back via the fragment and clear the state cookie.
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: url.origin + returnTo + "#gh_token=" + encodeURIComponent(token),
+      "Set-Cookie": CLEAR_COOKIE,
+    },
+  });
+}
+
+// fail returns an error response that also clears the state cookie.
+function fail(message, status) {
+  return new Response(message, {
+    status: status,
+    headers: { "Set-Cookie": CLEAR_COOKIE },
+  });
+}
+
+function parseCookie(header) {
+  const out = {};
+  header.split(";").forEach(function (part) {
+    const i = part.indexOf("=");
+    if (i === -1) return;
+    out[part.slice(0, i).trim()] = part.slice(i + 1).trim();
+  });
+  return out;
+}
+
+// timingSafeEqual compares two strings without short-circuiting on length/char.
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function b64urlDecode(s) {
+  s = s.replace(/-/g, "+").replace(/_/g, "/");
+  while (s.length % 4) s += "=";
+  try {
+    return atob(s);
+  } catch (e) {
+    return "/";
+  }
+}

--- a/docs/functions/github/callback.js
+++ b/docs/functions/github/callback.js
@@ -17,8 +17,11 @@ const CLEAR_COOKIE =
   STATE_COOKIE + "=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax";
 
 export async function onRequestGet({ request, env }) {
-  if (!env.GITHUB_CLIENT_ID || !env.GITHUB_CLIENT_SECRET) {
-    return fail("github auth is not configured", 503);
+  const missing = [];
+  if (!env.GITHUB_CLIENT_ID) missing.push("GITHUB_CLIENT_ID");
+  if (!env.GITHUB_CLIENT_SECRET) missing.push("GITHUB_CLIENT_SECRET");
+  if (missing.length) {
+    return fail("github auth is not configured; missing in this environment: " + missing.join(", "), 503);
   }
 
   const url = new URL(request.url);

--- a/docs/functions/github/login.js
+++ b/docs/functions/github/login.js
@@ -26,8 +26,18 @@
 const STATE_COOKIE = "gh_oauth";
 
 export async function onRequestGet({ request, env }) {
-  if (!env.GITHUB_CLIENT_ID) {
-    return new Response("github auth is not configured", { status: 503 });
+  const missing = [];
+  if (!env.GITHUB_CLIENT_ID) missing.push("GITHUB_CLIENT_ID");
+  if (!env.GITHUB_CLIENT_SECRET) missing.push("GITHUB_CLIENT_SECRET");
+  if (missing.length) {
+    // Name the unset vars so misconfiguration is obvious. Remember Cloudflare
+    // scopes vars per environment: a branch deploy reads the Preview set, not
+    // Production.
+    return new Response(
+      "github auth is not configured; missing in this environment: " +
+        missing.join(", "),
+      { status: 503 },
+    );
   }
 
   const url = new URL(request.url);

--- a/docs/functions/github/login.js
+++ b/docs/functions/github/login.js
@@ -1,0 +1,75 @@
+// Cloudflare Pages Function handling GET /github/login.
+//
+// Step one of the GitHub OAuth web flow for the GraphQL playground: redirect
+// the visitor to GitHub's authorize screen. The matching callback
+// (functions/github/callback.js) completes the exchange.
+//
+// Why a server hop at all, when we want everything client-side? Only the
+// code↔token exchange needs the OAuth client secret, which a static site
+// can't hold. These two tiny functions own the secret; the resulting token is
+// handed to the browser, which then talks to api.github.com directly (GitHub's
+// GraphQL endpoint permits CORS), so introspection and queries stay
+// client-side as intended.
+//
+// Configure secrets (encrypted, not plaintext):
+//   GITHUB_CLIENT_ID      — the OAuth app's client ID
+//   GITHUB_CLIENT_SECRET  — the OAuth app's client secret (used by callback.js)
+// Optional:
+//   GITHUB_OAUTH_SCOPE    — space-separated scopes (default "read:user")
+//
+// The OAuth app's "Authorization callback URL" must be <site>/github/callback.
+//
+// Local dev: `npx wrangler pages dev docs` with a docs/.dev.vars file holding
+// GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET (register a throwaway OAuth app whose
+// callback URL is http://localhost:8788/github/callback).
+
+const STATE_COOKIE = "gh_oauth";
+
+export async function onRequestGet({ request, env }) {
+  if (!env.GITHUB_CLIENT_ID) {
+    return new Response("github auth is not configured", { status: 503 });
+  }
+
+  const url = new URL(request.url);
+  // Only same-site relative paths are honored, so the flow can't be abused as
+  // an open redirector. Anything else falls back to the site root.
+  let returnTo = url.searchParams.get("return") || "/";
+  if (!returnTo.startsWith("/") || returnTo.startsWith("//")) {
+    returnTo = "/";
+  }
+
+  // CSRF token: a random value echoed by GitHub and re-checked in the callback.
+  // The return path rides along in the same cookie so the callback knows where
+  // to send the visitor back.
+  const state = randomState();
+  const cookieValue = state + "." + b64urlEncode(returnTo);
+
+  const authorize = new URL("https://github.com/login/oauth/authorize");
+  authorize.searchParams.set("client_id", env.GITHUB_CLIENT_ID);
+  authorize.searchParams.set("redirect_uri", url.origin + "/github/callback");
+  authorize.searchParams.set("scope", env.GITHUB_OAUTH_SCOPE || "read:user");
+  authorize.searchParams.set("state", state);
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: authorize.toString(),
+      // Lax so the cookie rides the top-level GET redirect back from GitHub.
+      "Set-Cookie":
+        STATE_COOKIE +
+        "=" +
+        cookieValue +
+        "; Path=/; Max-Age=600; HttpOnly; Secure; SameSite=Lax",
+    },
+  });
+}
+
+function randomState() {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return b64urlEncode(String.fromCharCode.apply(null, bytes));
+}
+
+function b64urlEncode(s) {
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/docs/go/plugin.go
+++ b/docs/go/plugin.go
@@ -98,6 +98,24 @@ func (p Plugin) DangPlayground(code booklit.Content) booklit.Content {
 	}
 }
 
+// DangGitHubPlayground renders a playground that can `import GitHub`. It behaves
+// like \dang-playground but adds a "Sign in with GitHub" control; once the
+// reader authorizes (OAuth web flow, see docs/functions/github), the snippet's
+// `import GitHub` resolves against the live GitHub GraphQL schema, queried
+// straight from the browser.
+//
+//	\dang-github-playground{{{
+//	import GitHub
+//	viewer.{ login, name }
+//	}}}
+func (p Plugin) DangGithubPlayground(code booklit.Content) booklit.Content {
+	return booklit.Styled{
+		Style:   "dang-github-playground",
+		Content: code,
+		Block:   true,
+	}
+}
+
 // HeaderLinks renders a horizontal row of navigation links.
 //
 //	\header-links{

--- a/docs/html/dang-github-playground.tmpl
+++ b/docs/html/dang-github-playground.tmpl
@@ -1,0 +1,3 @@
+<div class="dang-playground" data-dang-playground data-dang-github>
+<pre class="dang-playground-fallback">{{.Content | render}}</pre>
+</div>

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -93,6 +93,7 @@ pre code{display:block}
 .dang-playground-run{background:var(--accent);color:var(--on-accent);border-color:var(--accent)}
 .dang-playground-run:hover{background:var(--accent2);border-color:var(--accent2);color:var(--on-accent)}
 .dang-playground-run:disabled{opacity:.6;cursor:default}
+.dang-playground-github{border-color:var(--fg3)}
 /* Overlay editor: a transparent textarea over a highlighted layer. Both
    share identical metrics so the caret lines up with the colored text. The
    code area is fixed-dark to match the site's (always dark) code blocks. */

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -10,6 +10,12 @@
 // editable, runnable widget backed by the Dang WebAssembly module
 // (js/dang.wasm, built from cmd/dang-playground). The wasm is fetched lazily
 // on the first Run so the page stays light.
+//
+// A block additionally marked data-dang-github gains a "Sign in with GitHub"
+// control. After the OAuth web flow (see docs/functions/github/*), the access
+// token is handed back in the URL fragment, stashed in sessionStorage, and
+// passed to dangEval so an `import GitHub` in the snippet resolves against the
+// live GitHub schema — introspection and queries run straight from the browser.
 
 (function () {
   "use strict";
@@ -22,6 +28,52 @@
       return new URL(name, SELF || document.baseURI).href;
     } catch (e) {
       return "js/" + name;
+    }
+  }
+
+  // ── GitHub auth (for data-dang-github playgrounds) ────────────────────────
+  //
+  // The token only ever lives in sessionStorage — cleared when the tab closes,
+  // never sent anywhere but GitHub's own API. The OAuth code↔token exchange
+  // (which needs the client secret) happens in the /github/* Cloudflare
+  // Functions; everything here is just plumbing the resulting token around.
+
+  var GH_TOKEN_KEY = "dang.gh_token";
+
+  function ghToken() {
+    try {
+      return sessionStorage.getItem(GH_TOKEN_KEY) || "";
+    } catch (e) {
+      return "";
+    }
+  }
+
+  function ghSetToken(t) {
+    try {
+      if (t) sessionStorage.setItem(GH_TOKEN_KEY, t);
+      else sessionStorage.removeItem(GH_TOKEN_KEY);
+    } catch (e) { /* sessionStorage unavailable; sign-in just won't persist */ }
+  }
+
+  // Kick off the OAuth web flow, returning to this page afterwards.
+  function ghSignIn() {
+    window.location.href =
+      "/github/login?return=" + encodeURIComponent(window.location.pathname);
+  }
+
+  // On load, capture a token handed back in the URL fragment (#gh_token=…),
+  // persist it, then strip the fragment so it doesn't linger in the URL/history.
+  function ghCaptureToken() {
+    var hash = window.location.hash || "";
+    if (hash.indexOf("gh_token=") === -1) return;
+    var params = new URLSearchParams(hash.replace(/^#/, ""));
+    var t = params.get("gh_token");
+    if (t) ghSetToken(t);
+    var clean = window.location.pathname + window.location.search;
+    try {
+      window.history.replaceState(null, "", clean);
+    } catch (e) {
+      window.location.hash = "";
     }
   }
 
@@ -157,7 +209,7 @@
 
   // ── output rendering ──────────────────────────────────────────────────────
 
-  var STAGE_LABEL = { parse: "Parse error", type: "Type error", eval: "Runtime error" };
+  var STAGE_LABEL = { parse: "Parse error", type: "Type error", eval: "Runtime error", auth: "GitHub error" };
 
   function renderOutput(out, res) {
     out.innerHTML = "";
@@ -193,6 +245,7 @@
     var seed = fallback.cloneNode(true);
     seed.querySelectorAll(".dang-fb").forEach(function (n) { n.remove(); });
     var source = seed.textContent.replace(/\s+$/, "");
+    var isGitHub = container.hasAttribute("data-dang-github");
     container.innerHTML = "";
 
     // Toolbar.
@@ -203,6 +256,33 @@
     label.textContent = "Dang · runs in your browser";
     var spacer = document.createElement("span");
     spacer.style.flex = "1";
+    // GitHub auth control (only on data-dang-github blocks). updateAuth()
+    // reflects the current sign-in state; it's re-run after sign-in/out.
+    var authBtn = null;
+    function updateAuth() {
+      if (!authBtn) return;
+      if (ghToken()) {
+        authBtn.textContent = "Sign out of GitHub";
+        authBtn.title = "Signed in. Click to forget the token.";
+      } else {
+        authBtn.textContent = "Sign in with GitHub";
+        authBtn.title = "Authorize so `import GitHub` can reach the API.";
+      }
+    }
+    if (isGitHub) {
+      authBtn = document.createElement("button");
+      authBtn.className = "dang-playground-btn dang-playground-github";
+      authBtn.type = "button";
+      authBtn.addEventListener("click", function () {
+        if (ghToken()) {
+          ghSetToken("");
+          updateAuth();
+        } else {
+          ghSignIn();
+        }
+      });
+      updateAuth();
+    }
     var resetBtn = document.createElement("button");
     resetBtn.className = "dang-playground-btn dang-playground-reset";
     resetBtn.type = "button";
@@ -213,6 +293,7 @@
     runBtn.textContent = "Run ▶";
     bar.appendChild(label);
     bar.appendChild(spacer);
+    if (authBtn) bar.appendChild(authBtn);
     bar.appendChild(resetBtn);
     bar.appendChild(runBtn);
 
@@ -289,15 +370,29 @@
     var running = false;
     function run() {
       if (running) return;
+      var token = isGitHub ? ghToken() : "";
+      if (isGitHub && !token) {
+        // Don't bother compiling: `import GitHub` can't resolve without a token.
+        output.className = "dang-playground-output is-error";
+        output.innerHTML = "";
+        var hint = document.createElement("div");
+        hint.className = "dang-playground-error";
+        hint.textContent = "Sign in with GitHub first — `import GitHub` needs an authorized token.";
+        output.appendChild(hint);
+        return;
+      }
       running = true;
       runBtn.disabled = true;
       runBtn.textContent = "Running…";
       output.className = "dang-playground-output";
-      output.textContent = "Compiling…";
+      output.textContent = isGitHub ? "Querying GitHub…" : "Compiling…";
       loadDang()
         .then(function (dangEval) {
+          // dangEval returns a Promise (it may hit the network for GitHub).
+          return dangEval(editor.value, token);
+        })
+        .then(function (res) {
           output.textContent = "";
-          var res = dangEval(editor.value);
           renderOutput(output, res);
         })
         .catch(function (err) {
@@ -317,6 +412,10 @@
     var blocks = document.querySelectorAll("[data-dang-playground]");
     for (var i = 0; i < blocks.length; i++) enhance(blocks[i]);
   }
+
+  // Capture any OAuth token handed back in the fragment before enhancing, so
+  // the first paint of a GitHub block already reflects the signed-in state.
+  ghCaptureToken();
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);

--- a/docs/lit/github-playground.md
+++ b/docs/lit/github-playground.md
@@ -1,0 +1,50 @@
+\use-plugin{dang}
+
+# GraphQL + Dang playground {#github-playground}
+
+> Meta: the live payoff of [#graphql] — "schema-as-stdlib" against a real API the
+> reader already has an account on. Keep it concrete: sign in, run, see your own
+> data. Don't re-teach selection syntax (that's [#graphql]); show it working.
+> Honesty: the only thing not client-side is the OAuth token exchange, and the
+> token stays in the tab. Say that plainly, don't oversell.
+
+Every other playground in these docs runs the standard library alone. This one
+wires in a *live* GraphQL schema: sign in with GitHub and `import GitHub` brings
+GitHub's real types and root fields into scope, queried straight from your
+browser.
+
+## Sign in, then run
+
+Hit **Sign in with GitHub** in the toolbar below and authorize the app. You come
+back to this page signed in; now run the snippet.
+
+\dang-github-playground{{{
+import GitHub
+
+# `viewer` is GitHub's root field for the authenticated user. The selection
+# desugars to one GraphQL query — see the GraphQL interop page.
+viewer.{
+  login
+  name
+  repositories(first: 3).{ nodes.{ name, stargazerCount } }
+}
+}}}
+
+- `import GitHub` introspects GitHub's schema the first time you run (a few
+  seconds — it's a big schema), then caches it for the rest of the session
+- root `Query` fields like `viewer` and `repository` become callable functions
+- `.{ ... }` selections, nested fields, and arguments all work as in [#graphql]
+
+## What's actually happening
+
+- introspection and every query are ordinary requests from your browser to
+  `api.github.com` — GitHub's GraphQL endpoint allows cross-origin calls, so no
+  proxy sits in between
+- the only server step is the OAuth code-for-token exchange, which needs a
+  client secret a static site can't hold; a small function does just that and
+  hands the token back
+- that token lives only in this tab's `sessionStorage` — it's never stored
+  server-side and is forgotten when you close the tab. **Sign out of GitHub**
+  clears it immediately
+- the sign-in requests read-only access (`read:user`); you're querying your own
+  account, so only you see the results

--- a/docs/lit/index.md
+++ b/docs/lit/index.md
@@ -56,6 +56,7 @@ type Greeter {
 \include-section{./language/modules.md}
 \include-section{./language/directives.md}
 \include-section{./language/graphql.md}
+\include-section{./github-playground.md}
 \include-section{./language/collections.md}
 \include-section{./language/strings.md}
 \include-section{./language/json-yaml.md}


### PR DESCRIPTION
## What

Adds a **GraphQL + Dang playground** docs page (`/github-playground`) that builds
on the existing client-side WASM playground. Readers sign in with GitHub, then
run snippets that `import GitHub` against the live GitHub GraphQL API — types,
`viewer`, etc. all resolve from the real schema.

Follows up on docs feedback in Discord asking whether this was possible "in the
current scheme (statically deployed + Cloudflare Functions)." It is — confirmed
GitHub's GraphQL endpoint sends permissive CORS (`access-control-allow-origin: *`,
allowing `Authorization`/`Content-Type`), so introspection **and** queries run
straight from the browser with no proxy.

## How it fits the static + CF Functions model

- **Client-side everything except the secret.** Introspection and queries are
  ordinary cross-origin fetches from the WASM module to `api.github.com`.
- **Two tiny CF Pages Functions** own the only thing a static site can't hold —
  the OAuth client secret:
  - `GET /github/login` → redirect to GitHub authorize (sets a `SameSite=Lax`,
    HttpOnly CSRF-state cookie carrying the return path).
  - `GET /github/callback` → verify state, exchange `code` for a token, bounce
    back to the page with the token in the URL **fragment**.
- `playground.js` captures `#gh_token=…` into `sessionStorage` and strips it.
  The token lives only in the tab session and is never stored server-side.

## Runtime changes

- `dangEval(source, token)` now returns a **Promise** — the single-threaded wasm
  event loop can't block on the network from a synchronous `js.Func`. With a
  token it wires a GitHub `ImportConfig` into the eval context (schema
  introspected once, then cached for the page lifetime); without one, behavior
  is unchanged.
- New `\dang-github-playground` booklit tag → a block marked `data-dang-github`,
  which `playground.js` enhances with a sign-in/out control.

## Operator setup required before sign-in works

Mirrors the feedback webhook setup. Register a GitHub OAuth app with callback
URL `<site>/github/callback` and set encrypted secrets:

- `GITHUB_CLIENT_ID`
- `GITHUB_CLIENT_SECRET`
- `GITHUB_OAUTH_SCOPE` *(optional, defaults to `read:user`)*

## Verification

- `GOOS=js GOARCH=wasm go build ./cmd/dang-playground` ✅
- `go build ./...`, `go vet`, `gofmt` clean ✅
- `./docs/build.sh` renders `github-playground.html` with the right markup ✅
- The full OAuth round-trip needs a deployed OAuth app + secrets, so it's not
  exercised here — worth eyeballing on the Cloudflare preview once secrets are set.
