### PR TITLE
feat(docs): add interactive Dang WASM REPL component

### DIFF
--- a/cmd/dang-playground/main.go
+++ b/cmd/dang-playground/main.go
@@ -2,25 +2,39 @@
 
 // Command dang-playground is a WebAssembly module that evaluates Dang source
 // entirely client-side in the browser. It backs the interactive code snippets
-// on the documentation site.
+// and REPL on the documentation site.
 //
-// It exposes a single global function, dangEval(source, token), which parses,
-// type-checks, and evaluates a Dang program with the standard library in
-// scope, returning a Promise that resolves to a result object.
+// It exposes these global functions:
 //
-// When token is a non-empty string, a live `import GitHub` is wired into the
-// program: a GraphQL client pointed at https://api.github.com/graphql with the
-// token as a bearer credential. The schema is introspected on first use (and
-// cached for the life of the module) so `import GitHub` resolves to GitHub's
-// real types and root fields — `viewer`, `repository`, and so on. Introspection
-// and queries are ordinary cross-origin fetches; GitHub's GraphQL endpoint
-// permits CORS, so no proxy is involved.
+//   - dangEval(source, token) parses, type-checks, and evaluates a Dang program
+//     with the standard library in scope, returning a Promise that resolves to
+//     a result object. When token is a non-empty string, a live `import GitHub`
+//     is wired into the program: a GraphQL client pointed at
+//     https://api.github.com/graphql with the token as a bearer credential. The
+//     schema is introspected on first use (and cached for the life of the
+//     module) so `import GitHub` resolves to GitHub's real types and root fields
+//     — `viewer`, `repository`, and so on. Introspection and queries are
+//     ordinary cross-origin fetches; GitHub's GraphQL endpoint permits CORS, so
+//     no proxy is involved.
 //
-// dangEval returns a Promise (not a plain value) because that GitHub traffic is
-// network I/O: a synchronous js.Func cannot block on a fetch without deadlocking
-// the single-threaded wasm event loop, so the work runs in a goroutine that
-// resolves the Promise when it finishes. Snippets with no token never touch the
-// network but still resolve through the same Promise for a single call shape.
+//     dangEval returns a Promise (not a plain value) because that GitHub traffic
+//     is network I/O: a synchronous js.Func cannot block on a fetch without
+//     deadlocking the single-threaded wasm event loop, so the work runs in a
+//     goroutine that resolves the Promise when it finishes. Snippets with no
+//     token never touch the network but still resolve through the same Promise
+//     for a single call shape.
+//
+//   - dangReplEval(sessionID, source) evaluates one REPL entry against a
+//     persistent, long-running session identified by sessionID. The session's
+//     scopes are kept alive between calls and mutated in place, so each entry is
+//     type-checked and evaluated incrementally against accumulated state —
+//     nothing is re-parsed or re-run. This mirrors the native CLI REPL
+//     (cmd/dang/repl_tuist.go), which reuses one scope pair for the whole
+//     session rather than replaying history. The browser REPL runs the core
+//     language only (no GraphQL imports), so it stays synchronous.
+//
+//   - dangReplReset(sessionID) discards a session's accumulated state, so the
+//     next dangReplEval starts from fresh standard-library scopes.
 //
 // Build with:
 //
@@ -49,12 +63,14 @@ const githubEndpoint = "https://api.github.com/graphql"
 
 func main() {
 	js.Global().Set("dangEval", js.FuncOf(dangEval))
+	js.Global().Set("dangReplEval", js.FuncOf(dangReplEval))
+	js.Global().Set("dangReplReset", js.FuncOf(dangReplReset))
 	// dangReady lets the page know the module has finished initializing.
 	js.Global().Set("dangReady", js.ValueOf(true))
 	if cb := js.Global().Get("onDangReady"); cb.Type() == js.TypeFunction {
 		cb.Invoke()
 	}
-	// Block forever so the exported function stays callable.
+	// Block forever so the exported functions stay callable.
 	select {}
 }
 
@@ -166,6 +182,113 @@ func evalSource(source, token string) map[string]any {
 		value = fmt.Sprint(last.String())
 	}
 	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
+}
+
+// ── REPL sessions ───────────────────────────────────────────────────────────
+
+// replSession is one long-running REPL: a scope pair kept alive across entries.
+type replSession struct {
+	typeScope  dang.TypeScope
+	valueScope dang.ValueScope
+}
+
+// replSessions holds the live sessions keyed by the handle the frontend assigns
+// to each REPL component on the page (a different REPL gets a different handle,
+// so their state never bleeds together). The WASM module is single-threaded —
+// one goroutine services every JS call — so a plain map needs no locking.
+var replSessions = map[int]*replSession{}
+
+// session returns the session for id, lazily creating it from fresh scopes on
+// first use (or after a reset). This is the persistent state the REPL
+// accumulates into; subsequent entries mutate these scopes in place.
+func session(id int) *replSession {
+	s := replSessions[id]
+	if s == nil {
+		typeScope, valueScope := dang.BuildScopesFromImports("", nil)
+		s = &replSession{typeScope: typeScope, valueScope: valueScope}
+		replSessions[id] = s
+	}
+	return s
+}
+
+// evalForms parses, type-checks, and evaluates source against the given scopes,
+// writing any stdout/stderr through ctx. It returns the stringified value of
+// the last form, or a non-nil error and the failing stage ("parse" | "type" |
+// "eval"). The scopes are mutated in place, so passing the same scopes to
+// successive calls accumulates session state.
+func evalForms(ctx context.Context, source string, typeScope dang.TypeScope, valueScope dang.ValueScope, fresh hm.Fresher) (string, error, string) {
+	parsed, err := dang.ParseWithRecovery("playground", []byte(source))
+	if err != nil {
+		return "", err, "parse"
+	}
+	file, ok := parsed.(*dang.FileBlock)
+	if !ok {
+		return "", fmt.Errorf("unexpected parse result"), "parse"
+	}
+	forms := file.Forms
+
+	if _, err := dang.InferFormsWithPhases(ctx, forms, typeScope, fresh); err != nil {
+		return "", err, "type"
+	}
+
+	var last dang.Value
+	for _, node := range forms {
+		val, err := dang.EvalNode(ctx, valueScope, node)
+		if err != nil {
+			return "", err, "eval"
+		}
+		last = val
+	}
+
+	value := ""
+	if last != nil {
+		value = fmt.Sprint(last.String())
+	}
+	return value, nil, ""
+}
+
+// dangReplEval evaluates one REPL entry: dangReplEval(sessionID, source).
+//
+// The entry is type-checked and evaluated against the session's persistent
+// scopes, which are mutated in place so definitions accumulate (`let greeting =
+// "world"` then `` `hello, ${greeting}!` `` works) without re-parsing or
+// re-running any earlier entry. Only this entry's output and result are
+// returned. The browser REPL is core-language only (no GraphQL imports), so
+// unlike dangEval it never touches the network and stays synchronous.
+//
+// Like the native CLI REPL, a single scope pair lives for the whole session.
+// The tradeoff is that an entry which fails partway (a type error, or a runtime
+// error after some forms have already bound) can leave partial state behind;
+// dangReplReset clears it. A fresh Fresher is required per call — its type-
+// variable counter is monotonic — but that's unrelated to the session state.
+func dangReplEval(_ js.Value, args []js.Value) any {
+	if len(args) < 2 || args[0].Type() != js.TypeNumber || args[1].Type() != js.TypeString {
+		return result("", "", "dangReplEval expects (sessionID, source)", "parse")
+	}
+	sess := session(args[0].Int())
+	source := args[1].String()
+
+	fresh := hm.NewSimpleFresher()
+
+	var out bytes.Buffer
+	ctx := ioctx.StdoutToContext(context.Background(), &out)
+	ctx = ioctx.StderrToContext(ctx, &out)
+
+	value, err, stage := evalForms(ctx, source, sess.typeScope, sess.valueScope, fresh)
+	if err != nil {
+		return result("", strings.TrimRight(out.String(), "\n"), err.Error(), stage)
+	}
+	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
+}
+
+// dangReplReset(sessionID) discards a session so the next dangReplEval starts
+// from fresh scopes. It's a no-op for an unknown id (session() recreates lazily).
+func dangReplReset(_ js.Value, args []js.Value) any {
+	if len(args) < 1 || args[0].Type() != js.TypeNumber {
+		return false
+	}
+	delete(replSessions, args[0].Int())
+	return true
 }
 
 // GitHub schema cache, keyed by the token it was introspected with. The wasm

--- a/docs/go/plugin.go
+++ b/docs/go/plugin.go
@@ -116,6 +116,25 @@ func (p Plugin) DangGithubPlayground(code booklit.Content) booklit.Content {
 	}
 }
 
+// DangRepl renders an interactive Dang REPL that evaluates entries
+// client-side via the WebAssembly module (see cmd/dang-playground). State
+// accumulates across entries within a session, just like the CLI REPL. The
+// code is the seed for the first input, passed verbatim so braces and quotes
+// survive:
+//
+//	\dang-repl{{{
+//	[1, 2, 3].map { x => x * 2 }
+//	}}}
+//
+// Without JavaScript it degrades to a plain (non-highlighted) code block.
+func (p Plugin) DangRepl(code booklit.Content) booklit.Content {
+	return booklit.Styled{
+		Style:   "dang-repl",
+		Content: code,
+		Block:   true,
+	}
+}
+
 // HeaderLinks renders a horizontal row of navigation links.
 //
 //	\header-links{

--- a/docs/html/dang-repl.tmpl
+++ b/docs/html/dang-repl.tmpl
@@ -1,0 +1,3 @@
+<div class="dang-repl" data-dang-repl>
+<pre class="dang-repl-fallback">{{.Content | render}}</pre>
+</div>

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -70,7 +70,7 @@ blockquote strong, .inset strong{color:var(--accent2)}
 
 pre{
   background:var(--code-bg);border:1px solid var(--code-border);border-radius:6px;
-  padding:1rem 1.25rem !important;font-size:.8rem;line-height:1.65;overflow-x:auto;margin:.75rem 0;
+  padding:1rem 1.25rem;font-size:.8rem;line-height:1.65;overflow-x:auto;margin:.75rem 0;
 }
 pre code{display:block}
 

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -114,17 +114,18 @@ pre code{display:block}
   color:transparent;caret-color:#c9d1d9;background:transparent;outline:none;
 }
 .dang-playground-input::selection{background:rgba(110,140,220,.35)}
-/* token colors — mirror the chroma "dang" palette used elsewhere on the site */
-.dang-playground-highlight .tok-keyword{color:#ff7b72}
-.dang-playground-highlight .tok-type{color:#79c0ff}
-.dang-playground-highlight .tok-string{color:#a5d6ff}
-.dang-playground-highlight .tok-number{color:#79c0ff}
-.dang-playground-highlight .tok-function{color:#d2a8ff}
-.dang-playground-highlight .tok-operator{color:#ff7b72}
-.dang-playground-highlight .tok-label{color:#7ee787}
-.dang-playground-highlight .tok-comment{color:#6e7681;font-style:italic}
-.dang-playground-highlight .tok-variable,
-.dang-playground-highlight .tok-punct{color:#c9d1d9}
+/* token colors — mirror the chroma "dang" palette used elsewhere on the site.
+   Shared by the playground and the REPL (both highlight on a dark code area). */
+.tok-keyword{color:#ff7b72}
+.tok-type{color:#79c0ff}
+.tok-string{color:#a5d6ff}
+.tok-number{color:#79c0ff}
+.tok-function{color:#d2a8ff}
+.tok-operator{color:#ff7b72}
+.tok-label{color:#7ee787}
+.tok-comment{color:#6e7681;font-style:italic}
+.tok-variable,
+.tok-punct{color:#c9d1d9}
 .dang-playground-output{
   border-top:1px solid var(--code-border);padding:.7rem 1.25rem;
   font-family:'JetBrains Mono',monospace;font-size:.78rem;line-height:1.6;
@@ -135,6 +136,64 @@ pre code{display:block}
 .dang-playground-result{color:var(--green);white-space:pre-wrap}
 .dang-playground-error{color:var(--pink);white-space:pre-wrap}
 .dang-playground-fallback{
+  background:var(--code-bg);color:var(--fg);font-family:'JetBrains Mono',monospace;
+  font-size:.8rem;line-height:1.65;padding:1rem 1.25rem;margin:0;white-space:pre;overflow-x:auto;
+}
+
+/* ── interactive REPL ────────────────────────────────────────────────── */
+.dang-repl{
+  background:var(--code-bg);border:1px solid var(--code-border);border-radius:6px;
+  margin:1rem 0;overflow:hidden;
+}
+.dang-repl-bar{
+  display:flex;align-items:center;gap:.5rem;padding:.45rem .6rem .45rem .9rem;
+  background:var(--bg2);border-bottom:1px solid var(--code-border);
+}
+.dang-repl-label{font-size:.72rem;color:var(--fg3);letter-spacing:.02em}
+/* The code area is fixed-dark to match the site's (always dark) code blocks. */
+.dang-repl-body{background:#0d1117}
+.dang-repl-entry{border-bottom:1px solid rgba(48,54,61,.4)}
+/* prompt + highlighted source, and prompt + input, share these metrics so the
+   transcript and the live line align into one column. */
+.dang-repl-code,
+.dang-repl-inputrow{display:flex;gap:.5rem;align-items:flex-start;padding:.5rem 1.25rem}
+.dang-repl-code{padding-bottom:.2rem}
+.dang-repl-prompt{
+  flex-shrink:0;user-select:none;color:var(--accent);
+  font-family:'JetBrains Mono',monospace;font-size:.8rem;line-height:1.65;
+}
+.dang-repl-codehl{
+  flex:1;margin:0;padding:0;border:0;background:transparent;color:#c9d1d9;
+  font-family:'JetBrains Mono',monospace;font-size:.8rem;line-height:1.65;
+  white-space:pre-wrap;word-break:break-word;overflow-wrap:break-word;
+}
+/* Result/output sits flush under the prompt, matching the CLI REPL's "=>". */
+.dang-repl-out{
+  padding:.1rem 1.25rem .5rem;
+  font-family:'JetBrains Mono',monospace;font-size:.78rem;line-height:1.6;
+  color:var(--fg2);white-space:pre-wrap;word-break:break-word;
+}
+.dang-repl-out.is-empty{display:none}
+/* Live input row: a transparent textarea over a highlighted layer, like the
+   playground's editor, but seamless with the transcript above it. */
+.dang-repl-editor{position:relative;flex:1}
+.dang-repl-highlight,
+.dang-repl-input{
+  margin:0;border:0;box-sizing:border-box;
+  font-family:'JetBrains Mono',monospace;font-size:.8rem;line-height:1.65;
+  padding:0;tab-size:2;white-space:pre-wrap;word-break:break-word;overflow-wrap:break-word;
+}
+.dang-repl-highlight{
+  position:absolute;inset:0;pointer-events:none;overflow:hidden;
+  color:#c9d1d9;background:transparent;
+}
+.dang-repl-input{
+  position:relative;z-index:1;display:block;width:100%;resize:none;overflow:hidden;
+  color:transparent;caret-color:#c9d1d9;background:transparent;outline:none;
+}
+.dang-repl-input::selection{background:rgba(110,140,220,.35)}
+.dang-repl-input:disabled{cursor:default}
+.dang-repl-fallback{
   background:var(--code-bg);color:var(--fg);font-family:'JetBrains Mono',monospace;
   font-size:.8rem;line-height:1.65;padding:1rem 1.25rem;margin:0;white-space:pre;overflow-x:auto;
 }

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -105,9 +105,13 @@
     dangPromise = loadWasmExec().then(function () {
       return new Promise(function (resolve, reject) {
       var go = new Go();
-      // main() calls window.onDangReady once dangEval is registered.
+      // main() calls window.onDangReady once the exports are registered.
       window.onDangReady = function () {
-        resolve(window.dangEval);
+        resolve({
+          eval: window.dangEval,
+          replEval: window.dangReplEval,
+          replReset: window.dangReplReset,
+        });
       };
       fetch(asset("dang.wasm"))
         .then(function (resp) {
@@ -387,9 +391,9 @@
       output.className = "dang-playground-output";
       output.textContent = isGitHub ? "Querying GitHub…" : "Compiling…";
       loadDang()
-        .then(function (dangEval) {
-          // dangEval returns a Promise (it may hit the network for GitHub).
-          return dangEval(editor.value, token);
+        .then(function (dang) {
+          // dang.eval returns a Promise (it may hit the network for GitHub).
+          return dang.eval(editor.value, token);
         })
         .then(function (res) {
           output.textContent = "";
@@ -408,9 +412,264 @@
     runBtn.addEventListener("click", run);
   }
 
+  // ── REPL ──────────────────────────────────────────────────────────────────
+  //
+  // A read-eval-print loop layered on the same wasm + highlighting stack as the
+  // playground. Each accepted entry is appended to a transcript and evaluated
+  // against a persistent, long-running session held in the wasm module (see
+  // dangReplEval in cmd/dang-playground) — definitions accumulate without
+  // re-running earlier entries. The prompt and "=>" result match the CLI REPL
+  // so the two feel like the same tool.
+
+  // Each REPL component gets a distinct session id so multiple REPLs on one
+  // page keep independent state. The wasm side creates the session lazily.
+  var nextReplSession = 0;
+
+  // Heuristic: is the bracket nesting of src balanced? Used to decide whether a
+  // bare Enter should evaluate (balanced) or insert a continuation newline. We
+  // skip over string and comment contents so their brackets don't count. It's
+  // best-effort — Shift+Enter always inserts a newline and Ctrl/Cmd+Enter (and
+  // the Run button) always evaluate, so a wrong guess is never a dead end.
+  function bracketsBalanced(src) {
+    var depth = 0, i = 0, n = src.length;
+    while (i < n) {
+      var c = src[i];
+      if (c === "#") { // line comment
+        while (i < n && src[i] !== "\n") i++;
+        continue;
+      }
+      if (c === '"' || c === "`") { // string literal (opaque, incl. interpolation)
+        var q = c;
+        i++;
+        while (i < n && src[i] !== q) { if (src[i] === "\\") i++; i++; }
+        i++;
+        continue;
+      }
+      if (c === "(" || c === "[" || c === "{") depth++;
+      else if (c === ")" || c === "]" || c === "}") depth--;
+      i++;
+    }
+    return depth <= 0;
+  }
+
+  // Render one REPL entry's result into its output element. Like renderOutput,
+  // but a successful entry with no value and no output shows nothing (so plain
+  // declarations don't leave a bare "=>").
+  function renderReplOutput(out, res) {
+    out.innerHTML = "";
+    out.classList.remove("is-error", "is-empty");
+    if (res.output) {
+      var pre = document.createElement("div");
+      pre.className = "dang-playground-stdout";
+      pre.textContent = res.output;
+      out.appendChild(pre);
+    }
+    if (res.ok) {
+      if (res.value !== "") {
+        var line = document.createElement("div");
+        line.className = "dang-playground-result";
+        line.textContent = "=> " + res.value;
+        out.appendChild(line);
+      }
+    } else {
+      out.classList.add("is-error");
+      var err = document.createElement("div");
+      err.className = "dang-playground-error";
+      var label = STAGE_LABEL[res.stage] || "Error";
+      err.textContent = label + ": " + res.error;
+      out.appendChild(err);
+    }
+    if (!out.firstChild) out.classList.add("is-empty");
+  }
+
+  function enhanceRepl(container) {
+    var fallback = container.querySelector(".dang-repl-fallback");
+    if (!fallback) return;
+    var seed = fallback.cloneNode(true);
+    seed.querySelectorAll(".dang-fb").forEach(function (n) { n.remove(); });
+    var seedSource = seed.textContent.replace(/\s+$/, "");
+    container.innerHTML = "";
+
+    // Toolbar.
+    var bar = document.createElement("div");
+    bar.className = "dang-repl-bar";
+    var label = document.createElement("span");
+    label.className = "dang-repl-label";
+    label.textContent = "Dang REPL · Enter to run · Shift+Enter for newline";
+    var spacer = document.createElement("span");
+    spacer.style.flex = "1";
+    var resetBtn = document.createElement("button");
+    resetBtn.className = "dang-playground-btn dang-repl-reset";
+    resetBtn.type = "button";
+    resetBtn.textContent = "Reset";
+    var runBtn = document.createElement("button");
+    runBtn.className = "dang-playground-btn dang-playground-run dang-repl-run";
+    runBtn.type = "button";
+    runBtn.textContent = "Run ▶";
+    bar.appendChild(label);
+    bar.appendChild(spacer);
+    bar.appendChild(resetBtn);
+    bar.appendChild(runBtn);
+
+    // Body: a scrolling transcript followed by the live input row.
+    var body = document.createElement("div");
+    body.className = "dang-repl-body";
+
+    var transcript = document.createElement("div");
+    transcript.className = "dang-repl-transcript";
+
+    var inputRow = document.createElement("div");
+    inputRow.className = "dang-repl-inputrow";
+    var prompt = document.createElement("span");
+    prompt.className = "dang-repl-prompt";
+    prompt.textContent = "dang>";
+    var editorWrap = document.createElement("div");
+    editorWrap.className = "dang-repl-editor";
+    var highlight = document.createElement("pre");
+    highlight.className = "dang-repl-highlight";
+    highlight.setAttribute("aria-hidden", "true");
+    var input = document.createElement("textarea");
+    input.className = "dang-repl-input";
+    input.spellcheck = false;
+    input.setAttribute("autocomplete", "off");
+    input.setAttribute("autocapitalize", "off");
+    input.setAttribute("autocorrect", "off");
+    input.setAttribute("rows", "1");
+    input.value = seedSource;
+    editorWrap.appendChild(highlight);
+    editorWrap.appendChild(input);
+    inputRow.appendChild(prompt);
+    inputRow.appendChild(editorWrap);
+
+    body.appendChild(transcript);
+    body.appendChild(inputRow);
+    container.appendChild(bar);
+    container.appendChild(body);
+
+    // Handle for this REPL's persistent wasm-side session.
+    var sessionId = nextReplSession++;
+
+    function rehighlight() {
+      highlight.innerHTML = highlightHtml(input.value);
+    }
+    function autosize() {
+      input.style.height = "auto";
+      input.style.height = input.scrollHeight + "px";
+    }
+    rehighlight();
+    autosize();
+    input.addEventListener("input", function () {
+      rehighlight();
+      autosize();
+    });
+    loadTreeSitter().then(function () { rehighlight(); });
+
+    // Append a finished entry (highlighted source + its result) to the
+    // transcript. Returns the result element so callers can fill it in.
+    function appendEntry(src, res) {
+      var entry = document.createElement("div");
+      entry.className = "dang-repl-entry";
+
+      var code = document.createElement("div");
+      code.className = "dang-repl-code";
+      var p = document.createElement("span");
+      p.className = "dang-repl-prompt";
+      p.textContent = "dang>";
+      var hl = document.createElement("pre");
+      hl.className = "dang-repl-codehl";
+      hl.innerHTML = highlightHtml(src);
+      code.appendChild(p);
+      code.appendChild(hl);
+
+      var out = document.createElement("div");
+      out.className = "dang-repl-out";
+      renderReplOutput(out, res);
+
+      entry.appendChild(code);
+      entry.appendChild(out);
+      transcript.appendChild(entry);
+      // Keep the live input in view as the transcript grows.
+      input.scrollIntoView({ block: "nearest" });
+      return entry;
+    }
+
+    var running = false;
+    function evalEntry() {
+      if (running) return;
+      var src = input.value.replace(/\s+$/, "");
+      if (!src) return;
+      running = true;
+      runBtn.disabled = true;
+      input.disabled = true;
+      var pending = appendEntry(src, { ok: true, value: "", output: "" });
+      var pendingOut = pending.querySelector(".dang-repl-out");
+      pendingOut.classList.remove("is-empty");
+      pendingOut.textContent = "Running…";
+      loadDang()
+        .then(function (dang) {
+          var res = dang.replEval(sessionId, src);
+          renderReplOutput(pendingOut, res);
+          input.value = "";
+          rehighlight();
+          autosize();
+        })
+        .catch(function (err) {
+          renderReplOutput(pendingOut, {
+            ok: false, stage: "", value: "", output: "",
+            error: "Failed to load REPL: " + (err && err.message ? err.message : err),
+          });
+        })
+        .then(function () {
+          running = false;
+          runBtn.disabled = false;
+          input.disabled = false;
+          input.focus();
+        });
+    }
+
+    input.addEventListener("keydown", function (e) {
+      if (e.key === "Tab") {
+        e.preventDefault();
+        var s = input.selectionStart, en = input.selectionEnd;
+        input.value = input.value.slice(0, s) + "  " + input.value.slice(en);
+        input.selectionStart = input.selectionEnd = s + 2;
+        rehighlight();
+        autosize();
+        return;
+      }
+      if (e.key === "Enter") {
+        // Shift+Enter: force a newline (continuation). Ctrl/Cmd+Enter: force
+        // run. Bare Enter: run when the input looks complete, else newline.
+        if (e.shiftKey) return; // default inserts the newline
+        if (e.metaKey || e.ctrlKey || bracketsBalanced(input.value)) {
+          e.preventDefault();
+          evalEntry();
+        }
+      }
+    });
+
+    runBtn.addEventListener("click", evalEntry);
+    resetBtn.addEventListener("click", function () {
+      // Drop the persistent session's state. Only touch the module if it's
+      // already loaded — a reset before the first Run has nothing to clear and
+      // shouldn't pull the wasm down early.
+      if (window.dangReady) {
+        loadDang().then(function (dang) { dang.replReset(sessionId); });
+      }
+      transcript.innerHTML = "";
+      input.value = seedSource;
+      input.disabled = false;
+      rehighlight();
+      autosize();
+      input.focus();
+    });
+  }
+
   function init() {
     var blocks = document.querySelectorAll("[data-dang-playground]");
     for (var i = 0; i < blocks.length; i++) enhance(blocks[i]);
+    var repls = document.querySelectorAll("[data-dang-repl]");
+    for (var j = 0; j < repls.length; j++) enhanceRepl(repls[j]);
   }
 
   // Capture any OAuth token handed back in the fragment before enhancing, so

--- a/docs/lit/getting-started.md
+++ b/docs/lit/getting-started.md
@@ -21,6 +21,17 @@ print(message("world"))
 
 - `dang hello.dang` to run
 
+No install needed to get a feel for it — this REPL runs Dang in your browser.
+State carries across entries, so define something and use it on the next line:
+
+\dang-repl{{{
+let greeting = "world"
+}}}
+
+> Note: the browser REPL runs the core language only — no GraphQL imports, so
+> `GitHub`, `Dagger`, and friends aren't available here. Install the CLI for
+> those.
+
 ## A first GraphQL call
 
 Dang is designed for GraphQL APIs. To configure them, add a [#dang.toml]:


### PR DESCRIPTION
## What

Adds a `\dang-repl` Booklit component: an interactive, in-browser read-eval-print loop for Dang, built on the same tech stack as the existing `\dang-playground` (the `cmd/dang-playground` WASM module + tree-sitter highlighting) but presented as a REPL — a transcript of evaluated entries with a live input — instead of a single editor.

This addresses the docs-feedback request to "implement a Dang WASM REPL, building on the existing Dang playground… another type of component, but [on] the same tech stack: user-editable, treesitter-highlighted, but as a REPL."

## How it works

- **An actual long-running session.** The WASM module gains two exports, `dangReplEval(sessionID, source)` and `dangReplReset(sessionID)`. Each session keeps a scope pair (type scope + value scope) alive inside the module and mutates it **in place** on every entry, so each input is type-checked and evaluated incrementally against the accumulated state — nothing is re-parsed or re-run. This mirrors the native CLI REPL (`cmd/dang/repl_tuist.go`), which reuses one scope pair for the whole session rather than replaying history. A fresh `Fresher` is allocated per call (its type-variable counter is monotonic), but that's independent of the session state.
- **Per-component isolation.** Sessions are keyed by a handle the frontend assigns to each REPL on the page, so multiple REPLs never share state. The module creates a session lazily on first use, and `dangReplReset` drops it (the next eval starts from fresh standard-library scopes). The browser REPL is core-language only (no GraphQL imports), so unlike `dangEval` it never touches the network and stays synchronous.
- **Tradeoff.** Because state is mutated in place, an entry that fails partway (a type error, or a runtime error after some forms have already bound) can leave partial state behind — exactly as the native CLI REPL behaves. The Reset button clears it.
- **Shared internals.** The REPL's parse/infer/eval path lives in `evalForms`, distinct from the playground's GitHub-aware `evalSource`. The frontend lives in the existing `playground.js`, reusing the asset resolver, lazy WASM loader, and tree-sitter highlighter; `loadDang()` now resolves to all three exports.
- **REPL input.** Bare Enter evaluates when bracket nesting looks balanced (so multi-line `type { … }` entries keep accepting newlines until closed), Shift+Enter forces a newline, and Ctrl/Cmd+Enter or the Run button always evaluate. The `dang>` prompt and `=>` result mirror the CLI REPL documented in Getting Started.
- **Styling.** Token colors are de-scoped from `.dang-playground-highlight` to plain `.tok-*` so the playground and REPL share one palette.

## Demo

Getting Started gains a small REPL seeded with `let greeting = "world"`, with a note that the browser REPL runs the core language only (no GraphQL imports).

No JS → it degrades to a plain code block, same as the playground. The built `dang.wasm` is produced by `docs/build.sh` (gitignored, built in CI), so no binary churn here.

## Verification

`GOOS=js GOARCH=wasm` build + `go vet` pass. A native harness exercising the real `dang` API against one persistent scope pair confirmed the session semantics: binding carry-over, string interpolation against prior bindings, `type` declarations persisting and constructing across entries (e.g. `type Point { … }` then `Point(x: 3).x`), `print` output capture, and a type error leaving the session intact (a later entry still resolves earlier bindings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
