### PR TITLE
fix(dang): send arguments on nested selection fields

### DIFF
--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vito/dang/pkg/hm"
 	"github.com/vito/dang/pkg/introspection"
 	"github.com/vito/dang/pkg/querybuilder"
@@ -1937,11 +1939,84 @@ func (o *ObjectSelection) evalGraphQLSelection(gqlVal GraphQLValue, ctx context.
 	var result any
 	err = query.Client(gqlVal.Client).Bind(&result).Execute(ctx)
 	if err != nil {
+		// If the server reports which field failed, highlight that specific
+		// field in the source rather than the whole selection.
+		if field := o.locateErrorField(graphqlErrorFieldPath(err)); field != nil {
+			return nil, CreateEvalError(ctx, fmt.Errorf("executing GraphQL query: %w", err), field)
+		}
 		return nil, fmt.Errorf("ObjectSelection.evalGraphQLSelection: executing GraphQL query: %w", err)
 	}
 
 	// Convert GraphQL result to Object
 	return o.convertGraphQLResultToModule(result, o.Fields, gqlVal.Schema, gqlVal.Field, gqlVal.TypeScope)
+}
+
+// graphqlErrorFieldPath extracts the field path from a GraphQL execution error
+// (e.g. ["viewer", "repositories"]). List indices are ignored since they don't
+// correspond to selected fields. Returns nil if the error carries no path.
+func graphqlErrorFieldPath(err error) []string {
+	var list gqlerror.List
+	if !errors.As(err, &list) {
+		return nil
+	}
+	for _, e := range list {
+		if e == nil || len(e.Path) == 0 {
+			continue
+		}
+		var names []string
+		for _, seg := range e.Path {
+			if name, ok := seg.(ast.PathName); ok {
+				names = append(names, string(name))
+			}
+		}
+		if len(names) > 0 {
+			return names
+		}
+	}
+	return nil
+}
+
+// locateErrorField walks the selection tree to find the deepest field matching
+// the given GraphQL error path, so its source location can be highlighted. The
+// path is absolute from the query root, so any leading segments that don't
+// match a selected field (such as the receiver) are skipped. Returns nil if no
+// field matches.
+func (o *ObjectSelection) locateErrorField(path []string) *FieldSelection {
+	if len(path) == 0 {
+		return nil
+	}
+
+	findField := func(fields []*FieldSelection, name string) *FieldSelection {
+		for _, f := range fields {
+			if f.Name == name {
+				return f
+			}
+		}
+		return nil
+	}
+
+	fields := o.Fields
+
+	// Skip leading path segments (e.g. the receiver) until one matches a
+	// selected field at this level.
+	start := 0
+	for start < len(path) && findField(fields, path[start]) == nil {
+		start++
+	}
+
+	var deepest *FieldSelection
+	for i := start; i < len(path); i++ {
+		f := findField(fields, path[i])
+		if f == nil {
+			break
+		}
+		deepest = f
+		if f.Selection == nil {
+			break
+		}
+		fields = f.Selection.Fields
+	}
+	return deepest
 }
 
 func (o *ObjectSelection) buildGraphQLQuery(ctx context.Context, scope ValueScope, baseQuery *querybuilder.Selection, fields []*FieldSelection) (*querybuilder.Selection, error) {

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -2055,80 +2055,48 @@ func (o *ObjectSelection) buildGraphQLQuery(ctx context.Context, scope ValueScop
 		if field.Selection == nil && len(field.Args) == 0 {
 			// Simple field - no arguments, no nested selection
 			simpleFields = append(simpleFields, field.Name)
-		} else {
-			// Field has arguments and/or a nested selection. Fold any
-			// arguments into the field-name string (e.g.
-			// "repositories(first: 3)") since SelectMixed renders
-			// subselection field names verbatim and has no separate slot for
-			// arguments on nested fields.
-			fieldName := field.Name
-			if len(field.Args) > 0 {
-				argStr, err := buildFieldArguments(ctx, scope, field.Args)
-				if err != nil {
-					return nil, err
-				}
-				fieldName += argStr
-			}
-
-			if field.Selection == nil {
-				// Field with arguments but no nested selection (e.g. a scalar
-				// field like avatarUrl(size: 200)).
-				simpleFields = append(simpleFields, fieldName)
-				continue
-			}
-
-			var nestedResult *querybuilder.Selection
-			var err error
-			if len(field.Selection.InlineFragments) > 0 {
-				// Nested inline fragments: build __typename + ... on Type { fields }
-				nestedResult, err = field.Selection.buildInlineFragmentQuery(querybuilder.Query())
-			} else {
-				nestedResult, err = field.Selection.buildGraphQLQuery(ctx, scope, querybuilder.Query(), field.Selection.Fields)
-			}
-			if err != nil {
-				return nil, err
-			}
-
-			fieldsWithSelections[fieldName] = nestedResult
+			continue
 		}
+
+		// Field has arguments and/or a nested selection. Build the
+		// sub-selection (if any) and attach arguments through the query
+		// builder, which owns argument marshalling and formatting.
+		var value *querybuilder.Selection
+		var err error
+		switch {
+		case field.Selection == nil:
+			// Scalar field that only takes arguments (e.g. avatarUrl(size:
+			// 200)); no sub-selection. An empty selection carries the args.
+			value = querybuilder.Query().SelectFields()
+		case len(field.Selection.InlineFragments) > 0:
+			// Nested inline fragments: build __typename + ... on Type { fields }
+			value, err = field.Selection.buildInlineFragmentQuery(querybuilder.Query())
+		default:
+			value, err = field.Selection.buildGraphQLQuery(ctx, scope, querybuilder.Query(), field.Selection.Fields)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		for _, arg := range field.Args {
+			argVal, err := EvalNode(ctx, scope, arg.Value)
+			if err != nil {
+				return nil, fmt.Errorf("evaluating argument %s: %w", arg.Key, err)
+			}
+			// Convert Dang value to Go value for GraphQL; the builder marshals it.
+			goVal, err := dangValueToGo(argVal)
+			if err != nil {
+				return nil, fmt.Errorf("converting argument %s: %w", arg.Key, err)
+			}
+			value = value.Arg(arg.Key, goVal)
+		}
+
+		fieldsWithSelections[field.Name] = value
 	}
 
 	builder = builder.SelectMixed(simpleFields, fieldsWithSelections)
 
 	return builder, nil
-}
-
-// buildFieldArguments renders a field's arguments as a GraphQL argument list
-// such as "(first: 3, after: \"x\")". It is used to fold arguments into a
-// nested field's name, since the mixed-selection query builder renders
-// subselection field names verbatim and has no slot for their arguments.
-func buildFieldArguments(ctx context.Context, scope ValueScope, args Record) (string, error) {
-	var b strings.Builder
-	b.WriteByte('(')
-	for i, arg := range args {
-		if i > 0 {
-			b.WriteString(", ")
-		}
-		val, err := EvalNode(ctx, scope, arg.Value)
-		if err != nil {
-			return "", fmt.Errorf("evaluating argument %s: %w", arg.Key, err)
-		}
-		// Convert Dang value to Go value for GraphQL, then marshal to a
-		// GraphQL literal.
-		goVal, err := dangValueToGo(val)
-		if err != nil {
-			return "", fmt.Errorf("converting argument %s: %w", arg.Key, err)
-		}
-		marshalled, err := querybuilder.MarshalGQL(ctx, goVal)
-		if err != nil {
-			return "", fmt.Errorf("marshalling argument %s: %w", arg.Key, err)
-		}
-		b.WriteString(arg.Key)
-		b.WriteString(": ")
-		b.WriteString(marshalled)
-	}
-	b.WriteByte(')')
-	return b.String(), nil
 }
 
 // buildInlineFragmentQuery builds a query with __typename and inline fragments

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -1981,50 +1981,79 @@ func (o *ObjectSelection) buildGraphQLQuery(ctx context.Context, scope ValueScop
 			// Simple field - no arguments, no nested selection
 			simpleFields = append(simpleFields, field.Name)
 		} else {
-			// Field has either arguments or nested selection (or both)
-			fieldBuilder := querybuilder.Query().Select(field.Name)
-
-			// Add arguments if present
+			// Field has arguments and/or a nested selection. Fold any
+			// arguments into the field-name string (e.g.
+			// "repositories(first: 3)") since SelectMixed renders
+			// subselection field names verbatim and has no separate slot for
+			// arguments on nested fields.
+			fieldName := field.Name
 			if len(field.Args) > 0 {
-				for _, arg := range field.Args {
-					val, err := EvalNode(ctx, scope, arg.Value)
-					if err != nil {
-						return nil, fmt.Errorf("evaluating argument %s: %w", arg.Key, err)
-					}
-					// Convert Dang value to Go value for GraphQL
-					goVal, err := dangValueToGo(val)
-					if err != nil {
-						return nil, fmt.Errorf("converting argument %s: %w", arg.Key, err)
-					}
-					fieldBuilder = fieldBuilder.Arg(arg.Key, goVal)
+				argStr, err := buildFieldArguments(ctx, scope, field.Args)
+				if err != nil {
+					return nil, err
 				}
+				fieldName += argStr
 			}
 
-			// Handle nested selections
-			if field.Selection != nil {
-				if len(field.Selection.InlineFragments) > 0 {
-					// Nested inline fragments: build __typename + ... on Type { fields }
-					nestedResult, err := field.Selection.buildInlineFragmentQuery(querybuilder.Query())
-					if err != nil {
-						return nil, err
-					}
-					fieldBuilder = nestedResult
-				} else {
-					nestedResult, err := field.Selection.buildGraphQLQuery(ctx, scope, querybuilder.Query(), field.Selection.Fields)
-					if err != nil {
-						return nil, err
-					}
-					fieldBuilder = nestedResult
-				}
+			if field.Selection == nil {
+				// Field with arguments but no nested selection (e.g. a scalar
+				// field like avatarUrl(size: 200)).
+				simpleFields = append(simpleFields, fieldName)
+				continue
 			}
 
-			fieldsWithSelections[field.Name] = fieldBuilder
+			var nestedResult *querybuilder.Selection
+			var err error
+			if len(field.Selection.InlineFragments) > 0 {
+				// Nested inline fragments: build __typename + ... on Type { fields }
+				nestedResult, err = field.Selection.buildInlineFragmentQuery(querybuilder.Query())
+			} else {
+				nestedResult, err = field.Selection.buildGraphQLQuery(ctx, scope, querybuilder.Query(), field.Selection.Fields)
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			fieldsWithSelections[fieldName] = nestedResult
 		}
 	}
 
 	builder = builder.SelectMixed(simpleFields, fieldsWithSelections)
 
 	return builder, nil
+}
+
+// buildFieldArguments renders a field's arguments as a GraphQL argument list
+// such as "(first: 3, after: \"x\")". It is used to fold arguments into a
+// nested field's name, since the mixed-selection query builder renders
+// subselection field names verbatim and has no slot for their arguments.
+func buildFieldArguments(ctx context.Context, scope ValueScope, args Record) (string, error) {
+	var b strings.Builder
+	b.WriteByte('(')
+	for i, arg := range args {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		val, err := EvalNode(ctx, scope, arg.Value)
+		if err != nil {
+			return "", fmt.Errorf("evaluating argument %s: %w", arg.Key, err)
+		}
+		// Convert Dang value to Go value for GraphQL, then marshal to a
+		// GraphQL literal.
+		goVal, err := dangValueToGo(val)
+		if err != nil {
+			return "", fmt.Errorf("converting argument %s: %w", arg.Key, err)
+		}
+		marshalled, err := querybuilder.MarshalGQL(ctx, goVal)
+		if err != nil {
+			return "", fmt.Errorf("marshalling argument %s: %w", arg.Key, err)
+		}
+		b.WriteString(arg.Key)
+		b.WriteString(": ")
+		b.WriteString(marshalled)
+	}
+	b.WriteByte(')')
+	return b.String(), nil
 }
 
 // buildInlineFragmentQuery builds a query with __typename and inline fragments

--- a/pkg/dang/graphql_error_test.go
+++ b/pkg/dang/graphql_error_test.go
@@ -1,0 +1,78 @@
+package dang
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func TestGraphQLErrorFieldPath(t *testing.T) {
+	t.Run("extracts names and skips indices", func(t *testing.T) {
+		err := gqlerror.List{{
+			Message: "boom",
+			Path:    ast.Path{ast.PathName("viewer"), ast.PathName("repositories"), ast.PathIndex(2), ast.PathName("name")},
+		}}
+		require.Equal(t, []string{"viewer", "repositories", "name"}, graphqlErrorFieldPath(err))
+	})
+
+	t.Run("wrapped error", func(t *testing.T) {
+		err := fmt.Errorf("executing GraphQL query: %w", gqlerror.List{{
+			Path: ast.Path{ast.PathName("viewer"), ast.PathName("repositories")},
+		}})
+		require.Equal(t, []string{"viewer", "repositories"}, graphqlErrorFieldPath(err))
+	})
+
+	t.Run("no path", func(t *testing.T) {
+		require.Nil(t, graphqlErrorFieldPath(gqlerror.List{{Message: "boom"}}))
+	})
+
+	t.Run("not a gqlerror", func(t *testing.T) {
+		require.Nil(t, graphqlErrorFieldPath(fmt.Errorf("plain error")))
+	})
+}
+
+func TestLocateErrorField(t *testing.T) {
+	// viewer.{ login, repositories(first: 3).{ nodes.{ name, stargazerCount } } }
+	name := &FieldSelection{Name: "name", Loc: &SourceLocation{Line: 7}}
+	nodes := &FieldSelection{
+		Name:      "nodes",
+		Loc:       &SourceLocation{Line: 6},
+		Selection: &ObjectSelection{Fields: []*FieldSelection{name}},
+	}
+	repositories := &FieldSelection{
+		Name:      "repositories",
+		Loc:       &SourceLocation{Line: 5},
+		Selection: &ObjectSelection{Fields: []*FieldSelection{nodes}},
+	}
+	sel := &ObjectSelection{Fields: []*FieldSelection{
+		{Name: "login", Loc: &SourceLocation{Line: 4}},
+		repositories,
+	}}
+
+	t.Run("skips receiver prefix and matches field", func(t *testing.T) {
+		got := sel.locateErrorField([]string{"viewer", "repositories"})
+		require.Same(t, repositories, got)
+	})
+
+	t.Run("descends into nested selections", func(t *testing.T) {
+		got := sel.locateErrorField([]string{"viewer", "repositories", "nodes", "name"})
+		require.Same(t, name, got)
+	})
+
+	t.Run("stops at deepest known field", func(t *testing.T) {
+		// 'stargazerCount' isn't selected, so the deepest match is 'nodes'.
+		got := sel.locateErrorField([]string{"viewer", "repositories", "nodes", "stargazerCount"})
+		require.Same(t, nodes, got)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		require.Nil(t, sel.locateErrorField([]string{"viewer", "followers"}))
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		require.Nil(t, sel.locateErrorField(nil))
+	})
+}

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -164,15 +164,48 @@ func (q *QueryBuilder) Client(c graphql.Client) *QueryBuilder {
 
 func (q *QueryBuilder) marshalArguments(ctx context.Context) error {
 	eg, gctx := errgroup.WithContext(ctx)
+	q.scheduleArgMarshalling(eg, gctx)
+	return eg.Wait()
+}
+
+// scheduleArgMarshalling queues marshalling for every argument reachable from
+// this selection. Arguments on nested fields live in subSelections, which are
+// not part of the linear path(), so they are visited recursively.
+func (q *QueryBuilder) scheduleArgMarshalling(eg *errgroup.Group, ctx context.Context) {
 	for _, sel := range q.path() {
 		for _, arg := range sel.args {
 			eg.Go(func() error {
-				return arg.marshal(gctx)
+				return arg.marshal(ctx)
 			})
 		}
+		for _, sub := range sel.subSelections {
+			sub.scheduleArgMarshalling(eg, ctx)
+		}
 	}
+}
 
-	return eg.Wait()
+// writeArgs renders a GraphQL argument list, e.g. (first:3, after:"x").
+func writeArgs(b *strings.Builder, args map[string]*argument) {
+	b.WriteRune('(')
+	i := 0
+	for name, arg := range args {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(name)
+		b.WriteRune(':')
+		b.WriteString(arg.marshalled)
+		i++
+	}
+	b.WriteRune(')')
+}
+
+// rendersSelectionSet reports whether Build emits a non-empty selection set
+// ("{...}") for this selection. A bare argument carrier — a field that takes
+// arguments but selects no sub-fields — emits nothing.
+func (q *QueryBuilder) rendersSelectionSet() bool {
+	return len(q.fields) > 0 || len(q.subSelections) > 0 ||
+		q.inlineFragment != "" || q.multiple || q.name != ""
 }
 
 func (q *QueryBuilder) Build(ctx context.Context) (string, error) {
@@ -208,13 +241,28 @@ func (q *QueryBuilder) Build(ctx context.Context) (string, error) {
 					b.WriteRune(' ')
 				}
 				b.WriteString(field)
-				// Build sub-selection
 				if subSel != nil {
-					subQuery, err := subSel.Build(ctx)
-					if err != nil {
-						return "", err
+					// Arguments on a nested field are rendered here: Build
+					// ignores them for multi-field nodes and would misplace
+					// them for others.
+					if len(subSel.args) > 0 {
+						writeArgs(&b, subSel.args)
 					}
-					b.WriteString(subQuery)
+					if subSel.rendersSelectionSet() {
+						// Render the selection set without the field's own
+						// arguments, already emitted above.
+						inner := subSel
+						if len(subSel.args) > 0 {
+							stripped := *subSel
+							stripped.args = nil
+							inner = &stripped
+						}
+						subQuery, err := inner.Build(ctx)
+						if err != nil {
+							return "", err
+						}
+						b.WriteString(subQuery)
+					}
 				}
 				needSpace = true
 			}
@@ -231,18 +279,7 @@ func (q *QueryBuilder) Build(ctx context.Context) (string, error) {
 			b.WriteString(sel.name)
 
 			if len(sel.args) > 0 {
-				b.WriteRune('(')
-				i := 0
-				for name, arg := range sel.args {
-					if i > 0 {
-						b.WriteString(", ")
-					}
-					b.WriteString(name)
-					b.WriteRune(':')
-					b.WriteString(arg.marshalled)
-					i++
-				}
-				b.WriteRune(')')
+				writeArgs(&b, sel.args)
 			}
 		}
 	}

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -326,10 +327,13 @@ func (q *QueryBuilder) Execute(ctx context.Context) error {
 		opName = "Mutation"
 	}
 
+	payload := opType + " " + opName + " " + query
+	slog.DebugContext(ctx, "executing GraphQL request", "query", payload)
+
 	var response any
 	err = q.client.MakeRequest(ctx,
 		&graphql.Request{
-			Query:  opType + " " + opName + " " + query,
+			Query:  payload,
 			OpName: opName,
 		},
 		&graphql.Response{Data: &response},

--- a/pkg/querybuilder/querybuilder_test.go
+++ b/pkg/querybuilder/querybuilder_test.go
@@ -246,6 +246,64 @@ func TestSelectMixed(t *testing.T) {
 	require.Contains(t, q, `pageInfo{hasNextPage endCursor}`)
 }
 
+func TestSelectMixedNestedArgs(t *testing.T) {
+	// A nested field within a mixed selection carries its own arguments, which
+	// must be rendered on the field, not dropped: e.g.
+	// viewer.{ login, repositories(first: 3).{ name } }.
+	repositories := Query().SelectFields("name", "stargazerCount").Arg("first", 3)
+
+	q, err := Query().
+		Select("viewer").
+		SelectMixed(
+			[]string{"login"},
+			map[string]*QueryBuilder{
+				"repositories": repositories,
+			},
+		).
+		Build(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, `{viewer{login repositories(first:3){name stargazerCount}}}`, q)
+}
+
+func TestSelectMixedScalarArgs(t *testing.T) {
+	// A scalar field that only takes arguments and selects no sub-fields must
+	// render as name(args) with no selection set: e.g. avatarUrl(size: 200).
+	avatar := Query().SelectFields().Arg("size", 200)
+
+	q, err := Query().
+		Select("viewer").
+		SelectMixed(
+			[]string{"login"},
+			map[string]*QueryBuilder{
+				"avatarUrl": avatar,
+			},
+		).
+		Build(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, `{viewer{login avatarUrl(size:200)}}`, q)
+}
+
+func TestSelectMixedInlineFragmentArgs(t *testing.T) {
+	// A nested field with both arguments and an inline-fragment selection must
+	// render the args once, on the field, and not inside the fragment.
+	node := Query().SelectMultiple("__typename", "... on User { name }").Arg("first", 1)
+
+	q, err := Query().
+		Select("search").
+		SelectMixed(
+			nil,
+			map[string]*QueryBuilder{
+				"node": node,
+			},
+		).
+		Build(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, `{search{node(first:1){__typename ... on User { name }}}}`, q)
+}
+
 func TestUnpackMixedFieldsAndSubselections(t *testing.T) {
 	type Post struct {
 		Title   string `json:"title"`

--- a/tests/errors/graphql_field_error.dang
+++ b/tests/errors/graphql_field_error.dang
@@ -1,0 +1,10 @@
+# When the server reports an error for a specific field, the error should
+# highlight that field in the source, not the whole object selection. Here
+# `alwaysFails` errors server-side while sibling `name` is fine, so the error
+# must point at `alwaysFails`.
+import Test
+
+user(id: "1").{
+  name,
+  alwaysFails
+}

--- a/tests/gqlserver/generated.go
+++ b/tests/gqlserver/generated.go
@@ -127,13 +127,14 @@ type ComplexityRoot struct {
 	}
 
 	User struct {
-		Age    func(childComplexity int) int
-		Emails func(childComplexity int) int
-		ID     func(childComplexity int) int
-		Name   func(childComplexity int) int
-		Posts  func(childComplexity int, first *int, after *string, last *int, before *string) int
-		Status func(childComplexity int) int
-		Sync   func(childComplexity int) int
+		Age         func(childComplexity int) int
+		AlwaysFails func(childComplexity int) int
+		Emails      func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
+		Posts       func(childComplexity int, first *int, after *string, last *int, before *string) int
+		Status      func(childComplexity int) int
+		Sync        func(childComplexity int) int
 	}
 
 	UserProfile struct {
@@ -187,6 +188,7 @@ type QueryResolver interface {
 type UserResolver interface {
 	Posts(ctx context.Context, obj *User, first *int, after *string, last *int, before *string) (*PostConnection, error)
 	Sync(ctx context.Context, obj *User) (string, error)
+	AlwaysFails(ctx context.Context, obj *User) (string, error)
 }
 
 type executableSchema struct {
@@ -645,6 +647,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.User.Age(childComplexity), true
+	case "User.alwaysFails":
+		if e.complexity.User.AlwaysFails == nil {
+			break
+		}
+
+		return e.complexity.User.AlwaysFails(childComplexity), true
 	case "User.emails":
 		if e.complexity.User.Emails == nil {
 			break
@@ -1241,6 +1249,8 @@ func (ec *executionContext) fieldContext_Mutation_createUser(ctx context.Context
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1298,6 +1308,8 @@ func (ec *executionContext) fieldContext_Mutation_updateUser(ctx context.Context
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1598,6 +1610,8 @@ func (ec *executionContext) fieldContext_Post_author(_ context.Context, field gr
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1793,6 +1807,8 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1839,6 +1855,8 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1895,6 +1913,8 @@ func (ec *executionContext) fieldContext_Query_primaryUser(_ context.Context, fi
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1940,6 +1960,8 @@ func (ec *executionContext) fieldContext_Query_secondaryUser(_ context.Context, 
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -2894,6 +2916,8 @@ func (ec *executionContext) fieldContext_Query_usersByStatus(ctx context.Context
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -2951,6 +2975,8 @@ func (ec *executionContext) fieldContext_Query_sortedUsers(ctx context.Context, 
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -3534,6 +3560,35 @@ func (ec *executionContext) fieldContext_User_sync(_ context.Context, field grap
 	return fc, nil
 }
 
+func (ec *executionContext) _User_alwaysFails(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_alwaysFails,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.User().AlwaysFails(ctx, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_alwaysFails(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserProfile_user(ctx context.Context, field graphql.CollectedField, obj *UserProfile) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3572,6 +3627,8 @@ func (ec *executionContext) fieldContext_UserProfile_user(_ context.Context, fie
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -6508,6 +6565,42 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 					}
 				}()
 				res = ec._User_sync(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "alwaysFails":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_alwaysFails(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/tests/gqlserver/models_gen.go
+++ b/tests/gqlserver/models_gen.go
@@ -87,13 +87,14 @@ type UpdateUserInput struct {
 }
 
 type User struct {
-	ID     string          `json:"id"`
-	Name   string          `json:"name"`
-	Emails []string        `json:"emails"`
-	Age    *int            `json:"age,omitempty"`
-	Status Status          `json:"status"`
-	Posts  *PostConnection `json:"posts"`
-	Sync   string          `json:"sync"`
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Emails      []string        `json:"emails"`
+	Age         *int            `json:"age,omitempty"`
+	Status      Status          `json:"status"`
+	Posts       *PostConnection `json:"posts"`
+	Sync        string          `json:"sync"`
+	AlwaysFails string          `json:"alwaysFails"`
 }
 
 func (User) IsNode()            {}

--- a/tests/gqlserver/resolvers.go
+++ b/tests/gqlserver/resolvers.go
@@ -392,6 +392,11 @@ func (r *userResolver) Sync(ctx context.Context, obj *User) (string, error) {
 	return obj.ID, nil
 }
 
+// AlwaysFails is the resolver for the alwaysFails field.
+func (r *userResolver) AlwaysFails(ctx context.Context, obj *User) (string, error) {
+	return "", fmt.Errorf("this field always fails")
+}
+
 // Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
 

--- a/tests/gqlserver/schema.graphqls
+++ b/tests/gqlserver/schema.graphqls
@@ -87,6 +87,9 @@ type User implements Node {
   status: Status!
   posts(first: Int, after: String, last: Int, before: String): PostConnection! @goField(forceResolver: true)
   sync: ID! @expectedType(name: "User") @goField(forceResolver: true)
+  # Always returns a server-side error; used to test error reporting for a
+  # field nested inside an object selection.
+  alwaysFails: String! @goField(forceResolver: true)
 }
 
 type Post implements Node & Timestamped {

--- a/tests/test_nested_field_args_paginate.dang
+++ b/tests/test_nested_field_args_paginate.dang
@@ -1,0 +1,23 @@
+# Regression test: arguments on a field nested inside an object selection must
+# be sent to the server, not dropped. The `first` argument limits how many
+# posts come back, so the result length proves the argument was transmitted.
+#
+# Previously buildGraphQLQuery overwrote the field builder (with its args) with
+# the nested selection builder, dropping the args. The bug was masked by the
+# test server's optional pagination args, but a real connection like GitHub's
+# rejects the query when `first` is missing.
+import Test
+
+# user "1" (John Doe) authored four posts, so each `first` value must come
+# back with exactly that many.
+pub one_post = user(id: "1").{
+  posts(first: 1).{posts.{title}}
+}
+assert { one_post.posts.posts.length == 1 }
+
+pub two_posts = user(id: "1").{
+  posts(first: 2).{posts.{title}}
+}
+assert { two_posts.posts.posts.length == 2 }
+
+print("Nested field arguments are sent to the server!")

--- a/tests/testdata/graphql_field_error.golden
+++ b/tests/testdata/graphql_field_error.golden
@@ -1,0 +1,12 @@
+[1m[31mError:[0m executing GraphQL query: input: user.alwaysFails this field always fails
+
+  [2m[34m--> errors/graphql_field_error.dang:9:3[0m
+ [2m    |[0m
+ [2m  7 | user(id: "1").{[0m
+ [2m  8 |   name,[0m
+ [2m[34m[1m  9 | [0m  alwaysFails
+[2m         [31m^^^^^^^^^^^[0m
+ [2m 10 | }[0m
+ [2m 11 | [0m
+ [2m    |[0m
+


### PR DESCRIPTION
## Problem

A field with **both** arguments and a nested selection inside an object selection had its arguments silently dropped. For example:

```dang
viewer.{
  login,
  repositories(first: 3).{nodes.{name, stargazerCount}}
}
```

produced the query `viewer{login repositories{nodes{...}}}` — note the missing `(first: 3)`. Against GitHub this fails outright, since the `repositories` connection requires `first` or `last`:

```
You must provide a `first` or `last` value to properly paginate the `repositories` connection.
```

## Root cause

In `ObjectSelection.buildGraphQLQuery`, the branch for a field with args + nested selection built a field builder carrying the args, then immediately overwrote it with the nested-selection builder (`fieldBuilder = nestedResult`), discarding the args. Structurally, `SelectMixed` keys subselections by field name and renders that key verbatim, with no slot for arguments on nested fields.

## Fix

Fold the arguments into the field-name string the builder renders verbatim, so the map key becomes `repositories(first: 3)`. A new `buildFieldArguments` helper marshals args via `querybuilder.MarshalGQL`. This also handles scalar fields that take arguments but have no nested selection.

Unpacking is unaffected because it is AST-driven and binds the response blob — it does not depend on the querybuilder's subselection keys.

## Why it wasn't caught

`test_multiselect_args_graphql.dang` exercises this exact pattern, but its assertions pass regardless because the test server's pagination arguments are all *optional* — dropping them still returns data. The new `test_nested_field_args_paginate.dang` asserts `posts(first: 1)` returns exactly one post (the author has four), so it fails when the argument is dropped and passes once it's sent.

## Also included

`feat(querybuilder): log GraphQL request at debug level` — logs each outgoing query payload via slog, which is how the dropped argument was spotted directly under `--debug`.

## Testing

`go test ./...` passes. Verified end-to-end against GitHub's API with the github demo.