### PR TITLE
fix(dang): point GraphQL errors at the failing field

### DIFF
--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vito/dang/pkg/hm"
 	"github.com/vito/dang/pkg/introspection"
 	"github.com/vito/dang/pkg/querybuilder"
@@ -1937,11 +1939,84 @@ func (o *ObjectSelection) evalGraphQLSelection(gqlVal GraphQLValue, ctx context.
 	var result any
 	err = query.Client(gqlVal.Client).Bind(&result).Execute(ctx)
 	if err != nil {
+		// If the server reports which field failed, highlight that specific
+		// field in the source rather than the whole selection.
+		if field := o.locateErrorField(graphqlErrorFieldPath(err)); field != nil {
+			return nil, CreateEvalError(ctx, fmt.Errorf("executing GraphQL query: %w", err), field)
+		}
 		return nil, fmt.Errorf("ObjectSelection.evalGraphQLSelection: executing GraphQL query: %w", err)
 	}
 
 	// Convert GraphQL result to Object
 	return o.convertGraphQLResultToModule(result, o.Fields, gqlVal.Schema, gqlVal.Field, gqlVal.TypeScope)
+}
+
+// graphqlErrorFieldPath extracts the field path from a GraphQL execution error
+// (e.g. ["viewer", "repositories"]). List indices are ignored since they don't
+// correspond to selected fields. Returns nil if the error carries no path.
+func graphqlErrorFieldPath(err error) []string {
+	var list gqlerror.List
+	if !errors.As(err, &list) {
+		return nil
+	}
+	for _, e := range list {
+		if e == nil || len(e.Path) == 0 {
+			continue
+		}
+		var names []string
+		for _, seg := range e.Path {
+			if name, ok := seg.(ast.PathName); ok {
+				names = append(names, string(name))
+			}
+		}
+		if len(names) > 0 {
+			return names
+		}
+	}
+	return nil
+}
+
+// locateErrorField walks the selection tree to find the deepest field matching
+// the given GraphQL error path, so its source location can be highlighted. The
+// path is absolute from the query root, so any leading segments that don't
+// match a selected field (such as the receiver) are skipped. Returns nil if no
+// field matches.
+func (o *ObjectSelection) locateErrorField(path []string) *FieldSelection {
+	if len(path) == 0 {
+		return nil
+	}
+
+	findField := func(fields []*FieldSelection, name string) *FieldSelection {
+		for _, f := range fields {
+			if f.Name == name {
+				return f
+			}
+		}
+		return nil
+	}
+
+	fields := o.Fields
+
+	// Skip leading path segments (e.g. the receiver) until one matches a
+	// selected field at this level.
+	start := 0
+	for start < len(path) && findField(fields, path[start]) == nil {
+		start++
+	}
+
+	var deepest *FieldSelection
+	for i := start; i < len(path); i++ {
+		f := findField(fields, path[i])
+		if f == nil {
+			break
+		}
+		deepest = f
+		if f.Selection == nil {
+			break
+		}
+		fields = f.Selection.Fields
+	}
+	return deepest
 }
 
 func (o *ObjectSelection) buildGraphQLQuery(ctx context.Context, scope ValueScope, baseQuery *querybuilder.Selection, fields []*FieldSelection) (*querybuilder.Selection, error) {

--- a/pkg/dang/graphql_error_test.go
+++ b/pkg/dang/graphql_error_test.go
@@ -1,0 +1,78 @@
+package dang
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func TestGraphQLErrorFieldPath(t *testing.T) {
+	t.Run("extracts names and skips indices", func(t *testing.T) {
+		err := gqlerror.List{{
+			Message: "boom",
+			Path:    ast.Path{ast.PathName("viewer"), ast.PathName("repositories"), ast.PathIndex(2), ast.PathName("name")},
+		}}
+		require.Equal(t, []string{"viewer", "repositories", "name"}, graphqlErrorFieldPath(err))
+	})
+
+	t.Run("wrapped error", func(t *testing.T) {
+		err := fmt.Errorf("executing GraphQL query: %w", gqlerror.List{{
+			Path: ast.Path{ast.PathName("viewer"), ast.PathName("repositories")},
+		}})
+		require.Equal(t, []string{"viewer", "repositories"}, graphqlErrorFieldPath(err))
+	})
+
+	t.Run("no path", func(t *testing.T) {
+		require.Nil(t, graphqlErrorFieldPath(gqlerror.List{{Message: "boom"}}))
+	})
+
+	t.Run("not a gqlerror", func(t *testing.T) {
+		require.Nil(t, graphqlErrorFieldPath(fmt.Errorf("plain error")))
+	})
+}
+
+func TestLocateErrorField(t *testing.T) {
+	// viewer.{ login, repositories(first: 3).{ nodes.{ name, stargazerCount } } }
+	name := &FieldSelection{Name: "name", Loc: &SourceLocation{Line: 7}}
+	nodes := &FieldSelection{
+		Name:      "nodes",
+		Loc:       &SourceLocation{Line: 6},
+		Selection: &ObjectSelection{Fields: []*FieldSelection{name}},
+	}
+	repositories := &FieldSelection{
+		Name:      "repositories",
+		Loc:       &SourceLocation{Line: 5},
+		Selection: &ObjectSelection{Fields: []*FieldSelection{nodes}},
+	}
+	sel := &ObjectSelection{Fields: []*FieldSelection{
+		{Name: "login", Loc: &SourceLocation{Line: 4}},
+		repositories,
+	}}
+
+	t.Run("skips receiver prefix and matches field", func(t *testing.T) {
+		got := sel.locateErrorField([]string{"viewer", "repositories"})
+		require.Same(t, repositories, got)
+	})
+
+	t.Run("descends into nested selections", func(t *testing.T) {
+		got := sel.locateErrorField([]string{"viewer", "repositories", "nodes", "name"})
+		require.Same(t, name, got)
+	})
+
+	t.Run("stops at deepest known field", func(t *testing.T) {
+		// 'stargazerCount' isn't selected, so the deepest match is 'nodes'.
+		got := sel.locateErrorField([]string{"viewer", "repositories", "nodes", "stargazerCount"})
+		require.Same(t, nodes, got)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		require.Nil(t, sel.locateErrorField([]string{"viewer", "followers"}))
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		require.Nil(t, sel.locateErrorField(nil))
+	})
+}

--- a/tests/errors/graphql_field_error.dang
+++ b/tests/errors/graphql_field_error.dang
@@ -1,0 +1,10 @@
+# When the server reports an error for a specific field, the error should
+# highlight that field in the source, not the whole object selection. Here
+# `alwaysFails` errors server-side while sibling `name` is fine, so the error
+# must point at `alwaysFails`.
+import Test
+
+user(id: "1").{
+  name,
+  alwaysFails
+}

--- a/tests/gqlserver/generated.go
+++ b/tests/gqlserver/generated.go
@@ -127,13 +127,14 @@ type ComplexityRoot struct {
 	}
 
 	User struct {
-		Age    func(childComplexity int) int
-		Emails func(childComplexity int) int
-		ID     func(childComplexity int) int
-		Name   func(childComplexity int) int
-		Posts  func(childComplexity int, first *int, after *string, last *int, before *string) int
-		Status func(childComplexity int) int
-		Sync   func(childComplexity int) int
+		Age         func(childComplexity int) int
+		AlwaysFails func(childComplexity int) int
+		Emails      func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
+		Posts       func(childComplexity int, first *int, after *string, last *int, before *string) int
+		Status      func(childComplexity int) int
+		Sync        func(childComplexity int) int
 	}
 
 	UserProfile struct {
@@ -187,6 +188,7 @@ type QueryResolver interface {
 type UserResolver interface {
 	Posts(ctx context.Context, obj *User, first *int, after *string, last *int, before *string) (*PostConnection, error)
 	Sync(ctx context.Context, obj *User) (string, error)
+	AlwaysFails(ctx context.Context, obj *User) (string, error)
 }
 
 type executableSchema struct {
@@ -645,6 +647,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.User.Age(childComplexity), true
+	case "User.alwaysFails":
+		if e.complexity.User.AlwaysFails == nil {
+			break
+		}
+
+		return e.complexity.User.AlwaysFails(childComplexity), true
 	case "User.emails":
 		if e.complexity.User.Emails == nil {
 			break
@@ -1241,6 +1249,8 @@ func (ec *executionContext) fieldContext_Mutation_createUser(ctx context.Context
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1298,6 +1308,8 @@ func (ec *executionContext) fieldContext_Mutation_updateUser(ctx context.Context
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1598,6 +1610,8 @@ func (ec *executionContext) fieldContext_Post_author(_ context.Context, field gr
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1793,6 +1807,8 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1839,6 +1855,8 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1895,6 +1913,8 @@ func (ec *executionContext) fieldContext_Query_primaryUser(_ context.Context, fi
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1940,6 +1960,8 @@ func (ec *executionContext) fieldContext_Query_secondaryUser(_ context.Context, 
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -2894,6 +2916,8 @@ func (ec *executionContext) fieldContext_Query_usersByStatus(ctx context.Context
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -2951,6 +2975,8 @@ func (ec *executionContext) fieldContext_Query_sortedUsers(ctx context.Context, 
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -3534,6 +3560,35 @@ func (ec *executionContext) fieldContext_User_sync(_ context.Context, field grap
 	return fc, nil
 }
 
+func (ec *executionContext) _User_alwaysFails(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_alwaysFails,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.User().AlwaysFails(ctx, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_alwaysFails(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserProfile_user(ctx context.Context, field graphql.CollectedField, obj *UserProfile) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3572,6 +3627,8 @@ func (ec *executionContext) fieldContext_UserProfile_user(_ context.Context, fie
 				return ec.fieldContext_User_posts(ctx, field)
 			case "sync":
 				return ec.fieldContext_User_sync(ctx, field)
+			case "alwaysFails":
+				return ec.fieldContext_User_alwaysFails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -6508,6 +6565,42 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 					}
 				}()
 				res = ec._User_sync(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "alwaysFails":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_alwaysFails(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/tests/gqlserver/models_gen.go
+++ b/tests/gqlserver/models_gen.go
@@ -87,13 +87,14 @@ type UpdateUserInput struct {
 }
 
 type User struct {
-	ID     string          `json:"id"`
-	Name   string          `json:"name"`
-	Emails []string        `json:"emails"`
-	Age    *int            `json:"age,omitempty"`
-	Status Status          `json:"status"`
-	Posts  *PostConnection `json:"posts"`
-	Sync   string          `json:"sync"`
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Emails      []string        `json:"emails"`
+	Age         *int            `json:"age,omitempty"`
+	Status      Status          `json:"status"`
+	Posts       *PostConnection `json:"posts"`
+	Sync        string          `json:"sync"`
+	AlwaysFails string          `json:"alwaysFails"`
 }
 
 func (User) IsNode()            {}

--- a/tests/gqlserver/resolvers.go
+++ b/tests/gqlserver/resolvers.go
@@ -392,6 +392,11 @@ func (r *userResolver) Sync(ctx context.Context, obj *User) (string, error) {
 	return obj.ID, nil
 }
 
+// AlwaysFails is the resolver for the alwaysFails field.
+func (r *userResolver) AlwaysFails(ctx context.Context, obj *User) (string, error) {
+	return "", fmt.Errorf("this field always fails")
+}
+
 // Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
 

--- a/tests/gqlserver/schema.graphqls
+++ b/tests/gqlserver/schema.graphqls
@@ -87,6 +87,9 @@ type User implements Node {
   status: Status!
   posts(first: Int, after: String, last: Int, before: String): PostConnection! @goField(forceResolver: true)
   sync: ID! @expectedType(name: "User") @goField(forceResolver: true)
+  # Always returns a server-side error; used to test error reporting for a
+  # field nested inside an object selection.
+  alwaysFails: String! @goField(forceResolver: true)
 }
 
 type Post implements Node & Timestamped {

--- a/tests/testdata/graphql_field_error.golden
+++ b/tests/testdata/graphql_field_error.golden
@@ -1,0 +1,12 @@
+[1m[31mError:[0m executing GraphQL query: input: user.alwaysFails this field always fails
+
+  [2m[34m--> errors/graphql_field_error.dang:9:3[0m
+ [2m    |[0m
+ [2m  7 | user(id: "1").{[0m
+ [2m  8 |   name,[0m
+ [2m[34m[1m  9 | [0m  alwaysFails
+[2m         [31m^^^^^^^^^^^[0m
+ [2m 10 | }[0m
+ [2m 11 | [0m
+ [2m    |[0m
+


### PR DESCRIPTION
Stacked on #89 — review/merge that first; GitHub will retarget this to `main` once it lands.

## Problem

When a GraphQL query built from an object selection failed, the error highlighted the whole selection (the receiver's `.{`) instead of the field the server actually rejected:

```
non-declaration evaluation failed: Error: ObjectSelection.evalGraphQLSelection: executing GraphQL query: input:1:27: viewer.repositories Requesting 500 records ... exceeds the `first` limit of 100 records.

  --> main.dang:3:8
   3 | viewer.{
              ^
```

The caret points at `viewer.{` (line 3), but the offending field is `repositories` several lines down.

## Fix

GraphQL execution errors carry a machine-readable `path` (`["viewer", "repositories"]`). `evalGraphQLSelection` now:

1. Extracts that path from the `gqlerror.List` (`graphqlErrorFieldPath`).
2. Walks the selection tree to find the deepest matching field (`locateErrorField`), skipping leading segments like the receiver.
3. Attaches that field's source location, so the error highlights the offending field. The internal `ObjectSelection.evalGraphQLSelection:` prefix also drops away for this case.

When the error carries no path, the previous behaviour is preserved.

Now:
```
  --> main.dang:5:3
   5 |   repositories(first: 500).{nodes.{name}}
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Tests

- `pkg/dang/graphql_error_test.go` — unit tests for path extraction (names, indices, wrapping) and the tree walk (receiver skip, nested descent, deepest-known-field, no match).
- `tests/errors/graphql_field_error.dang` + golden — end-to-end error test. Backed by a new `alwaysFails` field on the test server's `User` type so a field *nested inside a selection* can fail server-side. Verified the golden points at the whole selection (with the noisy prefix) before the fix and at `alwaysFails` after.

`go test ./...` passes.