### PR TITLE
fix(docs): repair broken Ctrl+K search

### DIFF
--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -85,9 +85,12 @@
     trigger.innerHTML =
       "<span>Search</span><span class=\"kbd\">" + (isMac ? "⌘K" : "Ctrl K") + "</span>";
     trigger.addEventListener("click", open);
-    var brand = sidebar.querySelector(".brand");
-    if (brand && brand.nextSibling) {
-      sidebar.insertBefore(trigger, brand.nextSibling);
+    // Place the trigger just above the nav list. `.brand` is nested inside
+    // `.sidebar-head`, so inserting relative to it on `sidebar` would throw
+    // ("Child to insert before is not a child of this node").
+    var nav = sidebar.querySelector(".sidebar-nav");
+    if (nav) {
+      sidebar.insertBefore(trigger, nav);
     } else {
       sidebar.appendChild(trigger);
     }


### PR DESCRIPTION
## Problem

Docs search was completely broken — the browser console showed:

```
Uncaught DOMException: Node.insertBefore: Child to insert before is not a child of this node
    search.js:90
```

## Root cause

`docs/js/search.js` inserted the search trigger with:

```js
sidebar.insertBefore(trigger, brand.nextSibling);
```

But `.brand` is nested inside `.sidebar-head` (`docs/html/page.tmpl`), not directly under `nav.sidebar`. So `brand.nextSibling` is the toggle `<label>` — a child of `.sidebar-head`, not of `sidebar` — and `insertBefore` rejects it. The thrown exception aborted the search IIFE, disabling Ctrl+K / search entirely.

## Fix

Anchor the insert to a real child of `sidebar`, the `.sidebar-nav` div, placing the trigger just above the nav links, with an `appendChild` fallback if it's absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)