### PR TITLE
feat(docs): runnable example REPL per stdlib entry

### DIFF
--- a/.agents/skills/builtin-dsl/SKILL.md
+++ b/.agents/skills/builtin-dsl/SKILL.md
@@ -26,6 +26,7 @@ Only add a global function when it doesn't naturally belong to one type
 ```go
 Builtin("print").
     Doc("prints a value to stdout").
+    Example(`print("hello, world")`).
     Params("value", TypeVar('a')).
     Returns(TypeVar('n')).
     Impl(func(ctx context.Context, args Args) (Value, error) {
@@ -41,6 +42,7 @@ Builtin("print").
 ```go
 Method(StringType, "toUpper").
     Doc("converts a string to uppercase").
+    Example(`"hello".toUpper`).
     Returns(NonNull(StringType)).
     Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
         str := self.(StringValue).Val
@@ -49,6 +51,19 @@ Method(StringType, "toUpper").
 ```
 
 Receiver types currently available: `StringType`, `IntType`, `BooleanType`.
+
+## Examples are required
+
+Every builtin must declare `.Example(...)`: a tiny, self-contained snippet of
+Dang that evaluates to something illustrative. The stdlib reference renders it
+as a pre-seeded, runnable REPL, and two tests enforce it
+(`pkg/dang/stdlib_examples_test.go`): one fails if any builtin lacks an example,
+the other parses + type-checks + evaluates every example so it can't drift from
+the implementation. Keep examples runnable in the core language only (no GraphQL
+imports), and write them as a reader would call the builtin — e.g.
+`` `"a,b,c".split(",")` ``, `` `[1, 2, 3].map { x => x * 2 }` ``,
+`` `Random.int(1, 7)` ``. A regex example needs a Go double-quoted string since
+Dang regex literals use backticks: `` Example("\"abc123\".containsMatch(`\\d+`)") ``.
 
 ## Optional parameters with defaults
 

--- a/docs/go/stdlib.go
+++ b/docs/go/stdlib.go
@@ -18,8 +18,9 @@ import (
 // The standard library reference is generated straight from the builtin
 // registry in pkg/dang (see stdlib.go, stdlib_random.go, stdlib_regexp.go,
 // assert.go). Each entry's signature comes from the registered parameter,
-// block, and return types; its description comes from the builtin's .Doc(...).
-// Editing a builtin updates this page — there is nothing to hand-maintain.
+// block, and return types; its description comes from the builtin's .Doc(...),
+// and its pre-seeded REPL from the builtin's .Example(...). Editing a builtin
+// updates this page — there is nothing to hand-maintain.
 //
 // The layout mirrors vito/bass's stdlib page: every definition becomes an
 // anchored card titled by its signature, and a long group is preceded by a
@@ -150,10 +151,16 @@ func (p Plugin) stdlibModule(defs []dang.BuiltinDef, prefix, key, qualifier stri
 			rowPartials["Description"] = desc
 		}
 
+		// A builtin's example becomes a pre-seeded, runnable REPL on the card
+		// (see exampleRepl). The index rows stay terse — signature + one-liner.
+		if d.Example != "" {
+			cardPartials["Example"] = exampleRepl(d.Example)
+		}
+
 		cards = append(cards, booklit.Styled{
 			Style:    "stdlib-entry",
 			Block:    true,
-			Content:  highlightSignature(sig),
+			Content:  highlightDang(sig),
 			Partials: cardPartials,
 		})
 		rows = append(rows, booklit.Styled{
@@ -192,19 +199,34 @@ func stdlibTag(key, name string) string {
 	return "stdlib-" + key + "-" + name
 }
 
-// highlightSignature renders a signature as syntax-highlighted HTML using the
-// same chroma "dang" lexer and style as the site's code blocks. It mirrors the
-// site's class/inline choice (baselit.HighlightWithClasses): in class mode the
-// colors and code background come from chroma.css, so the signature themes with
-// the rest of the page.
-func highlightSignature(sig string) booklit.Content {
-	plain := booklit.Styled{Style: booklit.StyleCodeFlow, Content: booklit.String(sig)}
+// exampleRepl renders a builtin's example as a pre-seeded, runnable REPL. The
+// snippet is chroma-highlighted at build time so it reads as a normal code
+// block (and stays useful without JavaScript); docs/js/playground.js upgrades
+// it into a live REPL — seeded with this code — on first Run. See the
+// "stdlib-example" template and \dang-repl.
+func exampleRepl(code string) booklit.Content {
+	return booklit.Styled{
+		Style:   "stdlib-example",
+		Block:   true,
+		Content: highlightDang(code),
+	}
+}
+
+// highlightDang renders a snippet of Dang as inline, syntax-highlighted HTML
+// using the same chroma "dang" lexer and style (styles.Fallback) as the site's
+// code blocks. It mirrors the site's class/inline choice
+// (baselit.HighlightWithClasses): in class mode the colors and code background
+// come from chroma.css, so the snippet themes with the rest of the page. It
+// backs both the signature cards and the example REPLs; the chroma regex lexer
+// tolerates partial declarations and whole expressions alike.
+func highlightDang(src string) booklit.Content {
+	plain := booklit.Styled{Style: booklit.StyleCodeFlow, Content: booklit.String(src)}
 
 	lexer := lexers.Get("dang")
 	if lexer == nil {
 		return plain
 	}
-	iterator, err := lexer.Tokenise(nil, sig)
+	iterator, err := lexer.Tokenise(nil, src)
 	if err != nil {
 		return plain
 	}

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -250,7 +250,7 @@ td{padding:.4rem .6rem;border-bottom:1px solid var(--td-border)}
    it into a live, pre-seeded REPL in place (docs/js/playground.js). The snippet
    keeps chroma's fixed-dark <code> background, like the signatures above it. */
 .stdlib-example{margin:.5rem 0 0 .85rem;border:1px solid var(--code-border);border-radius:6px;overflow:hidden}
-.stdlib-example .dang-repl-fallback{background:transparent;margin:0;padding:0;white-space:normal;overflow-x:auto}
+.stdlib-example .dang-repl-fallback{background:transparent;border:none;border-radius:0;margin:0;padding:0;white-space:normal;overflow-x:auto}
 .stdlib-example .dang-repl-fallback code{display:block;padding:.45rem .7rem;font-size:.8rem;white-space:pre-wrap;word-break:break-word}
 .stdlib-example-bar{display:flex;align-items:center;gap:.5rem;padding:.35rem .5rem .35rem .7rem;border-top:1px solid var(--code-border);background:var(--bg2)}
 .stdlib-example-label{font-size:.72rem;color:var(--fg3);letter-spacing:.02em}

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -246,6 +246,14 @@ td{padding:.4rem .6rem;border-bottom:1px solid var(--td-border)}
 .stdlib-sig:hover{border-left-color:var(--accent2)}
 .stdlib-entry>a[id]:target+.stdlib-sig{border-left-color:var(--accent2);box-shadow:0 0 0 2px var(--accent2)}
 .stdlib-desc{color:var(--fg2);font-size:.9rem;margin:.4rem 0 0 .85rem}
+/* A runnable example: a chroma-highlighted snippet with a Run bar that upgrades
+   it into a live, pre-seeded REPL in place (docs/js/playground.js). The snippet
+   keeps chroma's fixed-dark <code> background, like the signatures above it. */
+.stdlib-example{margin:.5rem 0 0 .85rem;border:1px solid var(--code-border);border-radius:6px;overflow:hidden}
+.stdlib-example .dang-repl-fallback{background:transparent;margin:0;padding:0;white-space:normal;overflow-x:auto}
+.stdlib-example .dang-repl-fallback code{display:block;padding:.45rem .7rem;font-size:.8rem;white-space:pre-wrap;word-break:break-word}
+.stdlib-example-bar{display:flex;align-items:center;gap:.5rem;padding:.35rem .5rem .35rem .7rem;border-top:1px solid var(--code-border);background:var(--bg2)}
+.stdlib-example-label{font-size:.72rem;color:var(--fg3);letter-spacing:.02em}
 
 .links p{margin:0}
 

--- a/docs/html/stdlib-entry.tmpl
+++ b/docs/html/stdlib-entry.tmpl
@@ -2,4 +2,5 @@
   {{- .Partial "Target" | render -}}
   <a class="stdlib-sig" href="{{(.Partial "Reference").Tag | url}}">{{.Content | render}}</a>
   {{with .Partial "Description"}}<p class="stdlib-desc">{{. | render}}</p>{{end}}
+  {{with .Partial "Example"}}{{. | render}}{{end}}
 </div>

--- a/docs/html/stdlib-example.tmpl
+++ b/docs/html/stdlib-example.tmpl
@@ -1,0 +1,3 @@
+<div class="stdlib-example" data-dang-repl-lazy>
+<pre class="dang-repl-fallback">{{.Content | render}}</pre>
+</div>

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -665,11 +665,47 @@
     });
   }
 
+  // A lazy REPL — used by the stdlib reference, one per builtin — stays a
+  // static, highlighted snippet (its fallback) until the reader clicks Run.
+  // Only then does it become a live REPL (enhanceRepl) seeded with the example,
+  // which it evaluates once. Deferring keeps a page full of examples cheap: no
+  // textareas or wasm until something is actually run.
+  function enhanceLazyRepl(container) {
+    var fallback = container.querySelector(".dang-repl-fallback");
+    if (!fallback) return;
+
+    var bar = document.createElement("div");
+    bar.className = "stdlib-example-bar";
+    var label = document.createElement("span");
+    label.className = "stdlib-example-label";
+    label.textContent = "Example";
+    var spacer = document.createElement("span");
+    spacer.style.flex = "1";
+    var runBtn = document.createElement("button");
+    runBtn.className = "dang-playground-btn dang-playground-run";
+    runBtn.type = "button";
+    runBtn.textContent = "Run ▶";
+    bar.appendChild(label);
+    bar.appendChild(spacer);
+    bar.appendChild(runBtn);
+    container.appendChild(bar);
+
+    runBtn.addEventListener("click", function () {
+      // enhanceRepl reads the fallback for its seed, wipes the container, and
+      // builds the live REPL; then we trigger its Run to show the result.
+      enhanceRepl(container);
+      var liveRun = container.querySelector(".dang-repl-run");
+      if (liveRun) liveRun.click();
+    });
+  }
+
   function init() {
     var blocks = document.querySelectorAll("[data-dang-playground]");
     for (var i = 0; i < blocks.length; i++) enhance(blocks[i]);
     var repls = document.querySelectorAll("[data-dang-repl]");
     for (var j = 0; j < repls.length; j++) enhanceRepl(repls[j]);
+    var lazies = document.querySelectorAll("[data-dang-repl-lazy]");
+    for (var k = 0; k < lazies.length; k++) enhanceLazyRepl(lazies[k]);
   }
 
   // Capture any OAuth token handed back in the fragment before enhancing, so

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -605,11 +605,26 @@
       return entry;
     }
 
+    // Command history: submitted sources, newest last. historyIndex points at
+    // the recalled entry; history.length means the live draft being typed.
+    var history = [];
+    var historyIndex = 0;
+    var draft = "";
+    function recall(val) {
+      input.value = val;
+      rehighlight();
+      autosize();
+      input.selectionStart = input.selectionEnd = val.length;
+    }
+
     var running = false;
     function evalEntry() {
       if (running) return;
       var src = input.value.replace(/\s+$/, "");
       if (!src) return;
+      if (history[history.length - 1] !== src) history.push(src);
+      historyIndex = history.length;
+      draft = "";
       running = true;
       runBtn.disabled = true;
       input.disabled = true;
@@ -652,6 +667,28 @@
         autosize();
         return;
       }
+      if (e.key === "ArrowUp" && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        // Recall older history — but only from the first line, so multi-line
+        // editing still moves the caret up a line as usual.
+        if (input.value.slice(0, input.selectionStart).indexOf("\n") !== -1) return;
+        if (historyIndex > 0) {
+          if (historyIndex === history.length) draft = input.value;
+          historyIndex--;
+          e.preventDefault();
+          recall(history[historyIndex]);
+        }
+        return;
+      }
+      if (e.key === "ArrowDown" && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        // Walk back toward the live draft, only from the last line.
+        if (input.value.slice(input.selectionEnd).indexOf("\n") !== -1) return;
+        if (historyIndex < history.length) {
+          historyIndex++;
+          e.preventDefault();
+          recall(historyIndex === history.length ? draft : history[historyIndex]);
+        }
+        return;
+      }
       if (e.key === "Enter") {
         // Shift+Enter: force a newline (continuation). Ctrl/Cmd+Enter: force
         // run. Bare Enter: run when the input looks complete, else newline.
@@ -672,6 +709,9 @@
         loadDang().then(function (dang) { dang.replReset(sessionId); });
       }
       transcript.innerHTML = "";
+      history = [];
+      historyIndex = 0;
+      draft = "";
       input.value = seedSource;
       input.disabled = false;
       rehighlight();

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -702,6 +702,21 @@
     bar.appendChild(runBtn);
     container.appendChild(bar);
 
+    // Warm the (shared, cached) tree-sitter highlighter on intent, so it's
+    // ready by the time the click lands. Without this the lazy example is the
+    // first thing on a stdlib page to load tree-sitter, and enhanceRepl below
+    // builds *and* runs the seed synchronously — before highlighting is ready —
+    // so the first transcript entry would paint plain. Still lazy: nothing
+    // loads on mere page load, only once the reader reaches for Run.
+    var warmed = false;
+    function warm() {
+      if (warmed) return;
+      warmed = true;
+      loadTreeSitter();
+    }
+    runBtn.addEventListener("pointerenter", warm);
+    runBtn.addEventListener("focus", warm);
+
     runBtn.addEventListener("click", function () {
       // enhanceRepl reads the fallback for its seed, wipes the container, and
       // builds the live REPL; then we trigger its Run to show the result.

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -617,13 +617,16 @@
       var pendingOut = pending.querySelector(".dang-repl-out");
       pendingOut.classList.remove("is-empty");
       pendingOut.textContent = "Running…";
+      // Clear the input now that the source is captured and shown in the
+      // transcript, rather than waiting for the (possibly slow) eval to finish —
+      // the prompt shouldn't keep showing what's already running.
+      input.value = "";
+      rehighlight();
+      autosize();
       loadDang()
         .then(function (dang) {
           var res = dang.replEval(sessionId, src);
           renderReplOutput(pendingOut, res);
-          input.value = "";
-          rehighlight();
-          autosize();
         })
         .catch(function (err) {
           renderReplOutput(pendingOut, {

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -552,6 +552,18 @@
     function rehighlight() {
       highlight.innerHTML = highlightHtml(input.value);
     }
+    // Re-highlight the live input plus any transcript entries rendered before
+    // tree-sitter finished loading. The lazy stdlib REPLs evaluate their seed
+    // synchronously on Run — before loadTreeSitter() resolves — so that first
+    // entry comes out as plain text and must be repainted once highlighting is
+    // ready. (Each codehl's textContent is exactly its source.)
+    function rehighlightAll() {
+      rehighlight();
+      var hls = transcript.querySelectorAll(".dang-repl-codehl");
+      for (var i = 0; i < hls.length; i++) {
+        hls[i].innerHTML = highlightHtml(hls[i].textContent);
+      }
+    }
     function autosize() {
       input.style.height = "auto";
       input.style.height = input.scrollHeight + "px";
@@ -562,7 +574,7 @@
       rehighlight();
       autosize();
     });
-    loadTreeSitter().then(function () { rehighlight(); });
+    loadTreeSitter().then(rehighlightAll);
 
     // Append a finished entry (highlighted source + its result) to the
     // transcript. Returns the result element so callers can fill it in.

--- a/docs/lit/reference/stdlib.md
+++ b/docs/lit/reference/stdlib.md
@@ -4,7 +4,7 @@
 
 > Meta: alphabetical reference, not a tutorial. Each entry: signature, one-line description, one tiny example. Group by module/receiver. Cross-link to the conceptual page that introduces the API.
 
-> This page is generated from the builtin registry in `pkg/dang` (`stdlib.go`, `stdlib_random.go`, `stdlib_regexp.go`, `assert.go`). Each entry's signature and one-line description come straight from the builtin's definition, so the reference can't drift from the implementation — to change an entry, edit the builtin's `.Doc(...)`.
+> This page is generated from the builtin registry in `pkg/dang` (`stdlib.go`, `stdlib_random.go`, `stdlib_regexp.go`, `assert.go`). Each entry's signature, one-line description, and example come straight from the builtin's definition, so the reference can't drift from the implementation — to change an entry, edit the builtin's `.Doc(...)` or `.Example(...)`. Each example is a live REPL: press **Run** to evaluate it (and then keep typing — state carries across entries, just like the CLI).
 
 ## Top-level functions
 

--- a/pkg/dang/assert.go
+++ b/pkg/dang/assert.go
@@ -11,6 +11,7 @@ import (
 func registerAssert() {
 	Builtin("assert").
 		Doc("asserts that the block evaluates to a truthy value, raising an AssertionError otherwise").
+		Example(`assert { 1 + 1 == 2 }`).
 		Params("message", StringType, NullValue{}).
 		Block(hm.NewFnType(NewRecordType(""), TypeVar('a'))).
 		Returns(TypeVar('n')).

--- a/pkg/dang/builtins.go
+++ b/pkg/dang/builtins.go
@@ -277,6 +277,12 @@ func (b *BuiltinBuilder) Doc(doc string) *BuiltinBuilder {
 	return b
 }
 
+// Example sets a runnable snippet of Dang demonstrating the function.
+func (b *BuiltinBuilder) Example(code string) *BuiltinBuilder {
+	b.def.Example = code
+	return b
+}
+
 // Params adds parameters to the function.
 //
 // Usage: Params("name", type) or
@@ -330,6 +336,12 @@ func (b *MethodBuilder) Doc(doc string) *MethodBuilder {
 	return b
 }
 
+// Example sets a runnable snippet of Dang demonstrating the method.
+func (b *MethodBuilder) Example(code string) *MethodBuilder {
+	b.def.Example = code
+	return b
+}
+
 // Params adds parameters to the method.
 func (b *MethodBuilder) Params(pairs ...any) *MethodBuilder {
 	b.def.ParamTypes = append(b.def.ParamTypes, parseParamDefs(pairs...)...)
@@ -377,6 +389,12 @@ func (b *StaticMethodBuilder) Doc(doc string) *StaticMethodBuilder {
 	return b
 }
 
+// Example sets a runnable snippet of Dang demonstrating the static method.
+func (b *StaticMethodBuilder) Example(code string) *StaticMethodBuilder {
+	b.def.Example = code
+	return b
+}
+
 // Params adds parameters to the static method.
 func (b *StaticMethodBuilder) Params(pairs ...any) *StaticMethodBuilder {
 	b.def.ParamTypes = append(b.def.ParamTypes, parseParamDefs(pairs...)...)
@@ -409,6 +427,10 @@ type BuiltinDef struct {
 	ReturnType   hm.Type
 	Impl         func(ctx context.Context, self Value, args Args) (Value, error)
 	Doc          string
+	// Example is a tiny, self-contained snippet of Dang that exercises the
+	// builtin. The docs reference renders it as a pre-seeded, runnable REPL,
+	// and a test evaluates every example to keep them honest.
+	Example string
 }
 
 // ParamDef defines a parameter with optional default value.

--- a/pkg/dang/stdlib.go
+++ b/pkg/dang/stdlib.go
@@ -21,6 +21,7 @@ func registerStdlib() {
 	// print function: print(value: a) -> Null
 	Builtin("print").
 		Doc("prints a value to stdout").
+		Example(`print("hello, world")`).
 		Params("value", TypeVar('a')).
 		Returns(TypeVar('n')).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
@@ -33,6 +34,7 @@ func registerStdlib() {
 	// toJSON function: toJSON(value: b) -> String!
 	Builtin("toJSON").
 		Doc("serializes a value to JSON").
+		Example(`toJSON([1, 2, 3])`).
 		Params("value", TypeVar('b')).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
@@ -47,6 +49,7 @@ func registerStdlib() {
 	// fromJSON function: fromJSON(data: String!) -> a
 	Builtin("fromJSON").
 		Doc("parses JSON into an opaque value that is materialized by an expected type").
+		Example(`fromJSON("[1, 2, 3]") :: [Int!]!`).
 		Params("data", NonNull(StringType)).
 		Returns(TypeVar('a')).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
@@ -73,6 +76,7 @@ func registerStdlib() {
 	// fromYAML function: fromYAML(data: String!) -> a
 	Builtin("fromYAML").
 		Doc("parses YAML into an opaque value that is materialized by an expected type").
+		Example(`fromYAML("[a, b, c]") :: [String!]!`).
 		Params("data", NonNull(StringType)).
 		Returns(TypeVar('a')).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
@@ -87,6 +91,7 @@ func registerStdlib() {
 	// toString function: toString(value: b) -> String!
 	Builtin("toString").
 		Doc("converts a value to a string, returning strings as-is and serializing other values to JSON").
+		Example(`toString(42)`).
 		Params("value", TypeVar('b')).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
@@ -108,6 +113,7 @@ func registerStdlib() {
 	// String.split method: split(separator: String!, limit: Int = 0) -> [String!]!
 	Method(StringType, "split").
 		Doc("splits a string by separator").
+		Example(`"a,b,c".split(",")`).
 		Params(
 			"separator", NonNull(StringType),
 			"limit", IntType, IntValue{Val: 0},
@@ -144,6 +150,7 @@ func registerStdlib() {
 	// String.toUpper method: toUpper() -> String!
 	Method(StringType, "toUpper").
 		Doc("converts a string to uppercase").
+		Example(`"hello".toUpper`).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			str := self.(StringValue).Val
@@ -153,6 +160,7 @@ func registerStdlib() {
 	// String.toLower method: toLower() -> String!
 	Method(StringType, "toLower").
 		Doc("converts a string to lowercase").
+		Example(`"HELLO".toLower`).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			str := self.(StringValue).Val
@@ -162,6 +170,7 @@ func registerStdlib() {
 	// String.trimPrefix method: trimPrefix(prefix: String!) -> String!
 	Method(StringType, "trimPrefix").
 		Doc("removes the specified prefix from the string if present").
+		Example(`"v1.2.3".trimPrefix("v")`).
 		Params("prefix", NonNull(StringType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -173,6 +182,7 @@ func registerStdlib() {
 	// String.trimSuffix method: trimSuffix(suffix: String!) -> String!
 	Method(StringType, "trimSuffix").
 		Doc("removes the specified suffix from the string if present").
+		Example(`"report.txt".trimSuffix(".txt")`).
 		Params("suffix", NonNull(StringType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -184,6 +194,7 @@ func registerStdlib() {
 	// String.trimSpace method: trimSpace() -> String!
 	Method(StringType, "trimSpace").
 		Doc("removes all leading and trailing whitespace from the string").
+		Example(`"  hi  ".trimSpace`).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			str := self.(StringValue).Val
@@ -193,6 +204,7 @@ func registerStdlib() {
 	// String.trim method: trim(cutset: String!) -> String!
 	Method(StringType, "trim").
 		Doc("removes all leading and trailing characters in cutset from the string").
+		Example(`"__hi__".trim("_")`).
 		Params("cutset", NonNull(StringType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -204,6 +216,7 @@ func registerStdlib() {
 	// String.trimLeft method: trimLeft(cutset: String!) -> String!
 	Method(StringType, "trimLeft").
 		Doc("removes all leading characters in cutset from the string").
+		Example(`"__hi__".trimLeft("_")`).
 		Params("cutset", NonNull(StringType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -215,6 +228,7 @@ func registerStdlib() {
 	// String.trimRight method: trimRight(cutset: String!) -> String!
 	Method(StringType, "trimRight").
 		Doc("removes all trailing characters in cutset from the string").
+		Example(`"__hi__".trimRight("_")`).
 		Params("cutset", NonNull(StringType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -226,6 +240,7 @@ func registerStdlib() {
 	// String.hasPrefix method: hasPrefix(prefix: String!) -> Boolean!
 	Method(StringType, "hasPrefix").
 		Doc("checks if the string starts with the specified prefix").
+		Example(`"dang".hasPrefix("da")`).
 		Params("prefix", NonNull(StringType)).
 		Returns(NonNull(BooleanType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -237,6 +252,7 @@ func registerStdlib() {
 	// String.hasSuffix method: hasSuffix(suffix: String!) -> Boolean!
 	Method(StringType, "hasSuffix").
 		Doc("checks if the string ends with the specified suffix").
+		Example(`"dang".hasSuffix("ng")`).
 		Params("suffix", NonNull(StringType)).
 		Returns(NonNull(BooleanType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -248,6 +264,7 @@ func registerStdlib() {
 	// String.contains method: contains(substring: String!) -> Boolean!
 	Method(StringType, "contains").
 		Doc("checks if the string contains the specified substring").
+		Example(`"dang".contains("an")`).
 		Params("substring", NonNull(StringType)).
 		Returns(NonNull(BooleanType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -259,6 +276,7 @@ func registerStdlib() {
 	// String.replace method: replace(old: String!, new: String!, count: Int = -1) -> String!
 	Method(StringType, "replace").
 		Doc("replaces occurrences of old with new in the string. The count parameter controls how many replacements to make: -1 (default) replaces all occurrences, 1 replaces only the first, etc.").
+		Example(`"a-b-c".replace("-", "_")`).
 		Params(
 			"old", NonNull(StringType),
 			"new", NonNull(StringType),
@@ -278,6 +296,7 @@ func registerStdlib() {
 	// String.padRight method: padRight(width: Int!) -> String!
 	Method(StringType, "padRight").
 		Doc("pads the string with spaces on the right to reach the specified width").
+		Example(`"hi".padRight(5) + "|"`).
 		Params("width", NonNull(IntType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -297,6 +316,7 @@ func registerStdlib() {
 	// String.padLeft method: padLeft(width: Int!) -> String!
 	Method(StringType, "padLeft").
 		Doc("pads the string with spaces on the left to reach the specified width").
+		Example(`"hi".padLeft(5) + "|"`).
 		Params("width", NonNull(IntType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -316,6 +336,7 @@ func registerStdlib() {
 	// String.center method: center(width: Int!) -> String!
 	Method(StringType, "center").
 		Doc("centers the string within the specified width by padding with spaces on both sides").
+		Example(`"hi".center(6) + "|"`).
 		Params("width", NonNull(IntType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -340,6 +361,7 @@ func registerStdlib() {
 	// List.contains method: contains(element: a) -> Boolean!
 	Method(ListTypeModule, "contains").
 		Doc("checks if the list contains the specified element").
+		Example(`[1, 2, 3].contains(2)`).
 		Params("element", TypeVar('a')).
 		Returns(NonNull(BooleanType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -357,6 +379,7 @@ func registerStdlib() {
 	// List.uniq method: uniq -> [a]!
 	Method(ListTypeModule, "uniq").
 		Doc("returns a new list with duplicate elements removed, preserving first occurrence order").
+		Example(`[1, 1, 2, 3, 3].uniq`).
 		Returns(NonNull(ListOf(TypeVar('a')))).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			list := self.(ListValue)
@@ -384,6 +407,7 @@ func registerStdlib() {
 	// List.reject method: reject(fn: \(a) -> Boolean!) -> [a]!
 	Method(ListTypeModule, "reject").
 		Doc("returns a new list excluding elements for which the predicate returns true").
+		Example(`[1, 2, 3, 4].reject { x => x > 2 }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -426,6 +450,7 @@ func registerStdlib() {
 	// List.each method: each(fn: \(a, Int!) -> b) -> [a]!
 	Method(ListTypeModule, "each").
 		Doc("iterates over each element in the list, calling the block for each element").
+		Example(`[1, 2, 3].each { x => print(x) }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -458,6 +483,7 @@ func registerStdlib() {
 	// List.any method: any(fn: \(a) -> Boolean!) -> Boolean!
 	Method(ListTypeModule, "any").
 		Doc("returns true if at least one element satisfies the predicate").
+		Example(`[1, 2, 3].any { x => x > 2 }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -496,6 +522,7 @@ func registerStdlib() {
 	// List.all method: all(fn: \(a) -> Boolean!) -> Boolean!
 	Method(ListTypeModule, "all").
 		Doc("returns true if all elements satisfy the predicate").
+		Example(`[1, 2, 3].all { x => x > 0 }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -534,6 +561,7 @@ func registerStdlib() {
 	// List.map method: map(fn: \(a) -> b) -> [b]!
 	Method(ListTypeModule, "map").
 		Doc("returns a new list with each element transformed by the given function").
+		Example(`[1, 2, 3].map { x => x * 2 }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -579,6 +607,7 @@ func registerStdlib() {
 	// List.filter method: filter(fn: \(a) -> Boolean!) -> [a]!
 	Method(ListTypeModule, "filter").
 		Doc("returns a new list containing only elements for which the predicate returns true").
+		Example(`[1, 2, 3, 4].filter { x => x > 2 }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -621,6 +650,7 @@ func registerStdlib() {
 	// List.length method: length -> Int!
 	Method(ListTypeModule, "length").
 		Doc("returns the number of elements in the list").
+		Example(`[1, 2, 3].length`).
 		Returns(NonNull(IntType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			list := self.(ListValue)
@@ -630,6 +660,7 @@ func registerStdlib() {
 	// List.isEmpty method: isEmpty -> Boolean!
 	Method(ListTypeModule, "isEmpty").
 		Doc("returns true if the list contains no elements").
+		Example(`[1, 2, 3].isEmpty`).
 		Returns(NonNull(BooleanType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			list := self.(ListValue)
@@ -639,6 +670,7 @@ func registerStdlib() {
 	// List.reduce method: reduce(fn: \(acc: b, item: a) -> b, initial: b) -> b
 	Method(ListTypeModule, "reduce").
 		Doc("reduces the list to a single value using an accumulator function").
+		Example(`[1, 2, 3, 4].reduce(0) { acc, x => acc + x }`).
 		Params("initial", TypeVar('b')).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
@@ -674,6 +706,7 @@ func registerStdlib() {
 	// List.dropLast method: dropLast(count: Int = 1) -> [a]!
 	Method(ListTypeModule, "dropLast").
 		Doc("returns a new list with the last count elements removed (default 1)").
+		Example(`[1, 2, 3, 4].dropLast(2)`).
 		Params("count", IntType, IntValue{Val: 1}).
 		Returns(NonNull(ListOf(TypeVar('a')))).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -689,6 +722,7 @@ func registerStdlib() {
 	// List.dropFirst method: dropFirst(count: Int = 1) -> [a]!
 	Method(ListTypeModule, "dropFirst").
 		Doc("returns a new list with the first count elements removed (default 1)").
+		Example(`[1, 2, 3, 4].dropFirst(2)`).
 		Params("count", IntType, IntValue{Val: 1}).
 		Returns(NonNull(ListOf(TypeVar('a')))).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -704,6 +738,7 @@ func registerStdlib() {
 	// List.takeFirst method: takeFirst(count: Int = 1) -> [a]!
 	Method(ListTypeModule, "takeFirst").
 		Doc("returns a new list containing only the first count elements (default 1)").
+		Example(`[1, 2, 3, 4].takeFirst(2)`).
 		Params("count", IntType, IntValue{Val: 1}).
 		Returns(NonNull(ListOf(TypeVar('a')))).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -719,6 +754,7 @@ func registerStdlib() {
 	// List.takeLast method: takeLast(count: Int = 1) -> [a]!
 	Method(ListTypeModule, "takeLast").
 		Doc("returns a new list containing only the last count elements (default 1)").
+		Example(`[1, 2, 3, 4].takeLast(2)`).
 		Params("count", IntType, IntValue{Val: 1}).
 		Returns(NonNull(ListOf(TypeVar('a')))).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -734,6 +770,7 @@ func registerStdlib() {
 	// List.takeWhile method: takeWhile(fn: \(a) -> Boolean!) -> [a]!
 	Method(ListTypeModule, "takeWhile").
 		Doc("returns a new list containing leading elements for which the predicate returns true, stopping at the first false").
+		Example(`[1, 2, 3, 1].takeWhile { x => x < 3 }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -777,6 +814,7 @@ func registerStdlib() {
 	// List.dropWhile method: dropWhile(fn: \(a) -> Boolean!) -> [a]!
 	Method(ListTypeModule, "dropWhile").
 		Doc("returns a new list with leading elements removed for which the predicate returns true, stopping at the first false").
+		Example(`[1, 2, 3, 1].dropWhile { x => x < 3 }`).
 		Block(hm.NewFnType(
 			NewRecordType("", Keyed[*hm.Scheme]{
 				Key:   "item",
@@ -824,6 +862,7 @@ func registerStdlib() {
 	// List.join method: join(separator: String!) -> String!
 	Method(ListTypeModule, "join").
 		Doc("joins the list elements into a string, converting each element to string and separating them with the given delimiter").
+		Example(`["a", "b", "c"].join("-")`).
 		Params("separator", NonNull(StringType)).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {

--- a/pkg/dang/stdlib_examples_test.go
+++ b/pkg/dang/stdlib_examples_test.go
@@ -1,0 +1,94 @@
+package dang
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/vito/dang/pkg/hm"
+	"github.com/vito/dang/pkg/ioctx"
+)
+
+// allBuiltins returns every registered builtin: free functions, methods on
+// every receiver type, and static methods on every module.
+func allBuiltins() []BuiltinDef {
+	var defs []BuiltinDef
+	ForEachFunction(func(d BuiltinDef) { defs = append(defs, d) })
+	for _, recv := range MethodReceivers() {
+		ForEachMethod(recv, func(d BuiltinDef) { defs = append(defs, d) })
+	}
+	for _, mod := range StaticModules() {
+		ForEachStaticMethod(mod, func(d BuiltinDef) { defs = append(defs, d) })
+	}
+	return defs
+}
+
+// builtinLabel is the qualified name used to identify a builtin in test output,
+// e.g. "List.map", "Random.int", or a bare "print".
+func builtinLabel(d BuiltinDef) string {
+	switch {
+	case d.IsStatic && d.HostModule != nil:
+		return d.HostModule.Named + "." + d.Name
+	case d.IsMethod && d.ReceiverType != nil:
+		return d.ReceiverType.Named + "." + d.Name
+	default:
+		return d.Name
+	}
+}
+
+// TestStdlibExamplesEvaluate runs every builtin's .Example(...) through the same
+// parse → infer → eval path as the docs REPL, so a pre-seeded example can never
+// drift out of sync with the implementation it documents.
+func TestStdlibExamplesEvaluate(t *testing.T) {
+	for _, d := range allBuiltins() {
+		if d.Example == "" {
+			continue
+		}
+		t.Run(builtinLabel(d), func(t *testing.T) {
+			if err := evalExample(d.Example); err != nil {
+				t.Fatalf("example %q failed: %v", d.Example, err)
+			}
+		})
+	}
+}
+
+// TestStdlibBuiltinsHaveExamples enforces that every builtin documents a
+// runnable example, so the stdlib reference renders a REPL for each entry.
+func TestStdlibBuiltinsHaveExamples(t *testing.T) {
+	for _, d := range allBuiltins() {
+		if d.Example == "" {
+			t.Errorf("builtin %q has no .Example(...)", builtinLabel(d))
+		}
+	}
+}
+
+// evalExample parses, type-checks, and evaluates a snippet against fresh core
+// scopes (no GraphQL imports), mirroring the browser REPL's evalForms. It
+// returns the first error from any stage, or nil if every form evaluates.
+func evalExample(src string) error {
+	parsed, err := ParseWithRecovery("example", []byte(src))
+	if err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	file, ok := parsed.(*FileBlock)
+	if !ok {
+		return fmt.Errorf("unexpected parse result %T", parsed)
+	}
+
+	typeScope, valueScope := BuildScopesFromImports("", nil)
+	fresh := hm.NewSimpleFresher()
+	if _, err := InferFormsWithPhases(context.Background(), file.Forms, typeScope, fresh); err != nil {
+		return fmt.Errorf("type: %w", err)
+	}
+
+	var out bytes.Buffer
+	ctx := ioctx.StdoutToContext(context.Background(), &out)
+	ctx = ioctx.StderrToContext(ctx, &out)
+	for _, node := range file.Forms {
+		if _, err := EvalNode(ctx, valueScope, node); err != nil {
+			return fmt.Errorf("eval: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/dang/stdlib_random.go
+++ b/pkg/dang/stdlib_random.go
@@ -27,6 +27,7 @@ func registerRandom() {
 	// Random.int(min: Int!, max: Int!) -> Int!
 	StaticMethod(RandomModule, "int").
 		Doc("generates a random integer between min (inclusive) and max (exclusive)").
+		Example(`Random.int(1, 7)`).
 		Params("min", NonNull(IntType), "max", NonNull(IntType)).
 		Returns(NonNull(IntType)).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
@@ -41,6 +42,7 @@ func registerRandom() {
 	// Random.float() -> Float!
 	StaticMethod(RandomModule, "float").
 		Doc("generates a random float between 0.0 (inclusive) and 1.0 (exclusive)").
+		Example(`Random.float`).
 		Returns(NonNull(FloatType)).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
 			return ToValue(mrand.Float64())
@@ -49,6 +51,7 @@ func registerRandom() {
 	// Random.string() -> String!
 	StaticMethod(RandomModule, "string").
 		Doc("generates a cryptographically random base32 string with at least 128 bits of entropy").
+		Example(`Random.string`).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
 			return ToValue(rand.Text())
@@ -61,6 +64,7 @@ func registerUUID() {
 	// UUID.v4() -> String!
 	StaticMethod(UUIDModule, "v4").
 		Doc("generates a random UUID v4 string").
+		Example(`UUID.v4`).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
 			return ToValue(uuid.New().String())
@@ -69,6 +73,7 @@ func registerUUID() {
 	// UUID.v7() -> String!
 	StaticMethod(UUIDModule, "v7").
 		Doc("generates a time-ordered UUID v7 string").
+		Example(`UUID.v7`).
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, args Args) (Value, error) {
 			id, err := uuid.NewV7()

--- a/pkg/dang/stdlib_regexp.go
+++ b/pkg/dang/stdlib_regexp.go
@@ -100,6 +100,7 @@ func registerRegexp() {
 func registerRegexpStringMethods() {
 	Method(StringType, "containsMatch").
 		Doc("reports whether the string contains a match for the regexp").
+		Example("\"abc123\".containsMatch(`\\d+`)").
 		Params("pattern", NonNull(RegexpType)).
 		Returns(NonNull(BooleanType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -110,6 +111,7 @@ func registerRegexpStringMethods() {
 
 	Method(StringType, "match").
 		Doc("returns the first match for the pattern, or null").
+		Example("\"x42y\".match(`\\d+`)").
 		Params("pattern", NonNull(RegexpType)).
 		Returns(MatchType).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -124,6 +126,7 @@ func registerRegexpStringMethods() {
 
 	Method(StringType, "matchAll").
 		Doc("returns all non-overlapping matches for the pattern").
+		Example("\"a1 b22 c333\".matchAll(`\\d+`)").
 		Params("pattern", NonNull(RegexpType)).
 		Returns(NonNull(ListOf(NonNull(MatchType)))).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -139,6 +142,7 @@ func registerRegexpStringMethods() {
 
 	Method(StringType, "replaceMatches").
 		Doc("replaces matches of pattern with `with`; supports $0/$1/$name backref expansion").
+		Example("\"a1b2\".replaceMatches(`\\d`, \"#\")").
 		Params(
 			"pattern", NonNull(RegexpType),
 			"with", NonNull(StringType),
@@ -159,6 +163,7 @@ func registerRegexpStringMethods() {
 
 	Method(StringType, "rewriteMatches").
 		Doc("replaces matches of pattern using the block to compute each replacement").
+		Example("\"hello world\".rewriteMatches(`\\w+`) { m => m.string.toUpper }").
 		Params(
 			"pattern", NonNull(RegexpType),
 			"count", IntType, IntValue{Val: -1},
@@ -205,6 +210,7 @@ func registerRegexpStringMethods() {
 
 	Method(StringType, "splitMatches").
 		Doc("splits the string by matches of pattern").
+		Example("\"a1b22c\".splitMatches(`\\d+`)").
 		Params(
 			"pattern", NonNull(RegexpType),
 			"limit", IntType, IntValue{Val: 0},
@@ -225,6 +231,7 @@ func registerRegexpStringMethods() {
 func registerRegexpMatchMethods() {
 	Method(MatchType, "string").
 		Doc("the whole matched substring").
+		Example("\"x42y\".match(`\\d+`).string").
 		Returns(NonNull(StringType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			m := self.(MatchValue)
@@ -233,6 +240,7 @@ func registerRegexpMatchMethods() {
 
 	Method(MatchType, "start").
 		Doc("byte offset of the match start in the source string").
+		Example("\"x42y\".match(`\\d+`).start").
 		Returns(NonNull(IntType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			return IntValue{Val: self.(MatchValue).Indices[0]}, nil
@@ -240,6 +248,7 @@ func registerRegexpMatchMethods() {
 
 	Method(MatchType, "end").
 		Doc("byte offset just past the end of the match").
+		Example("\"x42y\".match(`\\d+`).end").
 		Returns(NonNull(IntType)).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			return IntValue{Val: self.(MatchValue).Indices[1]}, nil
@@ -247,6 +256,7 @@ func registerRegexpMatchMethods() {
 
 	Method(MatchType, "captures").
 		Doc("positional captures, with `captures[0]` corresponding to $1").
+		Example("\"42-99\".match(`(\\d+)-(\\d+)`).captures").
 		Returns(NonNull(ListOf(NonNull(StringType)))).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
 			m := self.(MatchValue)
@@ -268,6 +278,7 @@ func registerRegexpMatchMethods() {
 
 	Method(MatchType, "capture").
 		Doc("named capture; null if no such group or the group did not match").
+		Example("\"555-1212\".match(`(?P<area>\\d{3})-(\\d{4})`).capture(\"area\")").
 		Params("name", NonNull(StringType)).
 		Returns(StringType).
 		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {


### PR DESCRIPTION
## What

Docs feedback: *"it would be great if each stdlib function had a runnable example."*

This expands the Builtin DSL so each function/method can declare example usage, and uses that metadata to render a pre-seeded, runnable REPL for every entry on the stdlib reference page.

## How

- **DSL** — `BuiltinDef` gains an `Example` field and an `.Example(code)` builder on the function, method, and static-method builders.
- **Content** — every one of the ~56 builtins now declares a one-line example a reader would actually type (`"a,b,c".split(",")`, `[1, 2, 3].map { x => x * 2 }`, `Random.int(1, 7)`, …), written in the core language so it runs in the browser REPL.
- **Reference** — each generated card renders its example beneath the signature/description, chroma-highlighted at build time. It's a *lazy* REPL: a static snippet until the reader presses **Run**, at which point `playground.js` upgrades it in place into a live REPL seeded with the code and evaluates it once (state then carries across entries, like the CLI). Deferring keeps a page full of examples cheap — no textareas or wasm until something is actually run, and it degrades to a plain code block without JavaScript.
- **Tests** — `pkg/dang/stdlib_examples_test.go` fails if any builtin lacks an example, and parses + type-checks + evaluates every example through the same path as the docs REPL, so a snippet can never drift from the implementation.

The page stays scannable (signature + description + one tiny example), matching the section's `> Meta` intent, rather than stacking ~56 always-on editors.

## Notes

`go test ./pkg/dang/` passes. The two `tests/` failures in this worktree (`TestNeovimHighlights`, `TestZedHighlightQueryCompatibility`) are pre-existing — they read untracked `editors/` files absent here — and are unrelated to this change.
