### PR TITLE
docs: literate-programming blocks, applied to /blocks

### DIFF
--- a/cmd/dang-playground/main.go
+++ b/cmd/dang-playground/main.go
@@ -33,6 +33,12 @@
 //     session rather than replaying history. The browser REPL runs the core
 //     language only (no GraphQL imports), so it stays synchronous.
 //
+//   - dangLiterateEval(sessionID, source) is dangReplEval with the literate
+//     blocks' display rule: an entry whose last form is a declaration yields
+//     no value, only its output. It backs the \dang-literate blocks
+//     (docs/go/literate.go), which share one session per page; re-running a
+//     page's chain client-side must show exactly what the build baked in.
+//
 //   - dangReplReset(sessionID) discards a session's accumulated state, so the
 //     next dangReplEval starts from fresh standard-library scopes.
 //
@@ -64,6 +70,7 @@ const githubEndpoint = "https://api.github.com/graphql"
 func main() {
 	js.Global().Set("dangEval", js.FuncOf(dangEval))
 	js.Global().Set("dangReplEval", js.FuncOf(dangReplEval))
+	js.Global().Set("dangLiterateEval", js.FuncOf(dangLiterateEval))
 	js.Global().Set("dangReplReset", js.FuncOf(dangReplReset))
 	// dangReady lets the page know the module has finished initializing.
 	js.Global().Set("dangReady", js.ValueOf(true))
@@ -213,45 +220,50 @@ func session(id int) *replSession {
 
 // evalForms parses, type-checks, and evaluates source against the given scopes,
 // writing any stdout/stderr through ctx. It returns the stringified value of
-// the last form, or a non-nil error and the failing stage ("parse" | "type" |
-// "eval"). The scopes are mutated in place, so passing the same scopes to
-// successive calls accumulates session state.
-func evalForms(ctx context.Context, source string, typeScope dang.TypeScope, valueScope dang.ValueScope, fresh hm.Fresher) (string, error, string) {
+// the last form and whether that form is a declaration, or a non-nil error and
+// the failing stage ("parse" | "type" | "eval"). The scopes are mutated in
+// place, so passing the same scopes to successive calls accumulates session
+// state.
+func evalForms(ctx context.Context, source string, typeScope dang.TypeScope, valueScope dang.ValueScope, fresh hm.Fresher) (string, bool, error, string) {
 	parsed, err := dang.ParseWithRecovery("playground", []byte(source))
 	if err != nil {
-		return "", err, "parse"
+		return "", false, err, "parse"
 	}
 	file, ok := parsed.(*dang.FileBlock)
 	if !ok {
-		return "", fmt.Errorf("unexpected parse result"), "parse"
+		return "", false, fmt.Errorf("unexpected parse result"), "parse"
 	}
 	forms := file.Forms
 
 	if _, err := dang.InferFormsWithPhases(ctx, forms, typeScope, fresh); err != nil {
-		return "", err, "type"
+		return "", false, err, "type"
 	}
 
+	var lastNode dang.Node
 	var last dang.Value
 	for _, node := range forms {
 		val, err := dang.EvalNode(ctx, valueScope, node)
 		if err != nil {
-			return "", err, "eval"
+			return "", false, err, "eval"
 		}
+		lastNode = node
 		last = val
 	}
 
 	value := ""
+	lastIsDecl := false
 	if last != nil {
 		value = fmt.Sprint(last.String())
+		lastIsDecl = len(lastNode.DeclaredSymbols()) > 0
 	}
-	return value, nil, ""
+	return value, lastIsDecl, nil, ""
 }
 
 // dangReplEval evaluates one REPL entry: dangReplEval(sessionID, source).
 //
 // The entry is type-checked and evaluated against the session's persistent
 // scopes, which are mutated in place so definitions accumulate (`let greeting =
-// "world"` then `` `hello, ${greeting}!` `` works) without re-parsing or
+// "world"` then “ `hello, ${greeting}!` “ works) without re-parsing or
 // re-running any earlier entry. Only this entry's output and result are
 // returned. The browser REPL is core-language only (no GraphQL imports), so
 // unlike dangEval it never touches the network and stays synchronous.
@@ -274,9 +286,37 @@ func dangReplEval(_ js.Value, args []js.Value) any {
 	ctx := ioctx.StdoutToContext(context.Background(), &out)
 	ctx = ioctx.StderrToContext(ctx, &out)
 
-	value, err, stage := evalForms(ctx, source, sess.typeScope, sess.valueScope, fresh)
+	value, _, err, stage := evalForms(ctx, source, sess.typeScope, sess.valueScope, fresh)
 	if err != nil {
 		return result("", strings.TrimRight(out.String(), "\n"), err.Error(), stage)
+	}
+	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
+}
+
+// dangLiterateEval evaluates one literate block: dangLiterateEval(sessionID,
+// source). Identical to dangReplEval except for the display rule shared with
+// the build-time evaluator (literateEval in docs/go/literate.go — the two
+// must stay in lockstep): a block whose last form is a declaration yields no
+// value, so a setup block shows only what it prints.
+func dangLiterateEval(_ js.Value, args []js.Value) any {
+	if len(args) < 2 || args[0].Type() != js.TypeNumber || args[1].Type() != js.TypeString {
+		return result("", "", "dangLiterateEval expects (sessionID, source)", "parse")
+	}
+	sess := session(args[0].Int())
+	source := args[1].String()
+
+	fresh := hm.NewSimpleFresher()
+
+	var out bytes.Buffer
+	ctx := ioctx.StdoutToContext(context.Background(), &out)
+	ctx = ioctx.StderrToContext(ctx, &out)
+
+	value, lastIsDecl, err, stage := evalForms(ctx, source, sess.typeScope, sess.valueScope, fresh)
+	if err != nil {
+		return result("", strings.TrimRight(out.String(), "\n"), err.Error(), stage)
+	}
+	if lastIsDecl {
+		value = ""
 	}
 	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
 }

--- a/docs/go/literate.go
+++ b/docs/go/literate.go
@@ -1,0 +1,129 @@
+package dangdocs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/vito/booklit"
+	"github.com/vito/dang/v2/pkg/dang"
+	"github.com/vito/dang/v2/pkg/hm"
+	"github.com/vito/dang/v2/pkg/ioctx"
+)
+
+// literateSession is one page's shared Dang environment: a scope pair that
+// every \dang-literate block in the same source file evaluates into, in
+// document order. It mirrors the wasm REPL's replSession
+// (cmd/dang-playground), which backs the same blocks client-side.
+type literateSession struct {
+	typeScope  dang.TypeScope
+	valueScope dang.ValueScope
+}
+
+var (
+	literateMu       sync.Mutex
+	literateSessions = map[string]*literateSession{}
+)
+
+// literateSessionFor returns the shared session for the given source file,
+// creating it from fresh standard-library scopes on first use.
+func literateSessionFor(path string) *literateSession {
+	literateMu.Lock()
+	defer literateMu.Unlock()
+	s := literateSessions[path]
+	if s == nil {
+		typeScope, valueScope := dang.BuildScopesFromImports("", nil)
+		s = &literateSession{typeScope: typeScope, valueScope: valueScope}
+		literateSessions[path] = s
+	}
+	return s
+}
+
+// DangLiterate renders a literate-programming code block. The snippet is
+// evaluated at build time against a Dang environment shared by every
+// \dang-literate block in the same source file — earlier blocks' definitions
+// are in scope, like cells of a notebook — and its output (stdout plus the
+// value of the last form) is baked into the static page. A block that fails
+// to parse, type-check, or evaluate fails the docs build, so literate
+// examples can't rot.
+//
+//	\dang-literate{{{
+//	list.each { item, index => print(`${index}: ${item}`) }
+//	}}}
+//
+// docs/js/playground.js progressively enhances these blocks into editable
+// widgets with the same chain semantics: Run replays every literate block on
+// the page, top to bottom, in one wasm REPL session. Without JavaScript the
+// baked output still shows.
+func (p Plugin) DangLiterate(code booklit.Content) (booklit.Content, error) {
+	source := strings.TrimRight(code.String(), "\n")
+	sess := literateSessionFor(p.section.FilePath())
+
+	stdout, value, err := literateEval(source, sess)
+	if err != nil {
+		return nil, fmt.Errorf("\\dang-literate block in %s: %w", p.section.FilePath(), err)
+	}
+
+	partials := booklit.Partials{}
+	if stdout != "" {
+		partials["Stdout"] = booklit.String(stdout)
+	}
+	if value != "" {
+		partials["Value"] = booklit.String(value)
+	}
+
+	return booklit.Styled{
+		Style:    "dang-literate",
+		Content:  p.highlightDang(source),
+		Partials: partials,
+		Block:    true,
+	}, nil
+}
+
+// literateEval parses, type-checks, and evaluates source against the
+// session's scopes, mutating them in place so definitions accumulate across
+// blocks. It returns captured stdout/stderr and the stringified value of the
+// last form. A block whose last form is a declaration yields no value — a
+// setup block bakes only what it prints, not the noise of the bound value.
+// The same display rule lives in dangLiterateEval (cmd/dang-playground); the
+// two must stay in lockstep so enhancing a page client-side doesn't change
+// what the reader already saw.
+func literateEval(source string, sess *literateSession) (string, string, error) {
+	parsed, err := dang.ParseWithRecovery("literate", []byte(source))
+	if err != nil {
+		return "", "", err
+	}
+	file, ok := parsed.(*dang.FileBlock)
+	if !ok {
+		return "", "", fmt.Errorf("unexpected parse result")
+	}
+	forms := file.Forms
+
+	fresh := hm.NewSimpleFresher()
+	if _, err := dang.InferFormsWithPhases(context.Background(), forms, sess.typeScope, fresh); err != nil {
+		return "", "", err
+	}
+
+	var out bytes.Buffer
+	ctx := ioctx.StdoutToContext(context.Background(), &out)
+	ctx = ioctx.StderrToContext(ctx, &out)
+
+	var last dang.Node
+	var lastVal dang.Value
+	for _, node := range forms {
+		val, err := dang.EvalNode(ctx, sess.valueScope, node)
+		if err != nil {
+			return "", "", err
+		}
+		last = node
+		lastVal = val
+	}
+
+	value := ""
+	if lastVal != nil && (last == nil || len(last.DeclaredSymbols()) == 0) {
+		value = lastVal.String()
+	}
+	return strings.TrimRight(out.String(), "\n"), value, nil
+}

--- a/docs/html/dang-literate.tmpl
+++ b/docs/html/dang-literate.tmpl
@@ -3,7 +3,7 @@
 {{- if or (.Partial "Stdout") (.Partial "Value")}}
 <div class="dang-literate-out">
 {{- with .Partial "Stdout"}}<div class="dang-playground-stdout">{{. | render}}</div>{{end}}
-{{- with .Partial "Value"}}<div class="dang-playground-result">=&gt; {{. | render}}</div>{{end}}
+{{- with .Partial "Value"}}<div class="dang-playground-result">=&gt; {{. | render}}</div>{{end -}}
 </div>
 {{- end}}
 </div>

--- a/docs/html/dang-literate.tmpl
+++ b/docs/html/dang-literate.tmpl
@@ -1,0 +1,9 @@
+<div class="dang-literate" data-dang-literate>
+<pre class="dang-literate-fallback">{{.Content | render}}</pre>
+{{- if or (.Partial "Stdout") (.Partial "Value")}}
+<div class="dang-literate-out">
+{{- with .Partial "Stdout"}}<div class="dang-playground-stdout">{{. | render}}</div>{{end}}
+{{- with .Partial "Value"}}<div class="dang-playground-result">=&gt; {{. | render}}</div>{{end}}
+</div>
+{{- end}}
+</div>

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -231,6 +231,37 @@ pre code{display:block}
   font-size:.8rem;line-height:1.65;padding:1rem 1.25rem;margin:0;white-space:pre;overflow-x:auto;
 }
 
+/* ── literate blocks ─────────────────────────────────────────────────── */
+/* \dang-literate snippets share one Dang environment per page; their output
+   is baked in at build time and replayed client-side on Run (playground.js).
+   Editor metrics and output classes are the playground's, so the static and
+   live states render identically. */
+.dang-literate{
+  position:relative;background:var(--code-bg);border:1px solid var(--code-border);
+  border-radius:6px;margin:.75rem 0;overflow:hidden;
+}
+.dang-literate-fallback{
+  background:var(--code-bg);color:var(--base05);font-family:'JetBrains Mono',monospace;
+  font-size:.8rem;line-height:1.65;padding:1rem 1.25rem;margin:0;white-space:pre;overflow-x:auto;
+}
+.dang-literate-out{
+  border-top:1px solid var(--code-border);padding:.6rem 1.25rem;
+  font-family:'JetBrains Mono',monospace;font-size:.78rem;line-height:1.6;
+  color:var(--fg);white-space:pre-wrap;word-break:break-word;
+}
+.dang-literate-out.is-empty{display:none}
+/* An edit above this output may have invalidated it; dim until the next Run. */
+.dang-literate-out.is-stale{opacity:.45}
+/* Run sits in the block's corner, revealed on hover/focus (always shown on
+   touch layouts, which have no hover). */
+.dang-literate-controls{
+  position:absolute;top:.4rem;right:.4rem;display:flex;gap:.3rem;z-index:2;
+  opacity:0;transition:opacity .12s;
+}
+.dang-literate:hover .dang-literate-controls,
+.dang-literate:focus-within .dang-literate-controls{opacity:1}
+@media (hover:none){.dang-literate-controls{opacity:1}}
+
 table{width:100%;border-collapse:collapse;font-size:.85rem;margin:.75rem 0}
 th{text-align:left;padding:.5rem .6rem;color:var(--fg2);font-weight:500;border-bottom:1px solid var(--code-border)}
 td{padding:.4rem .6rem;border-bottom:1px solid var(--td-border)}

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -223,6 +223,27 @@
     return out;
   }
 
+  // ── editor autosizing ─────────────────────────────────────────────────────
+  //
+  // Every editor textarea autosizes to its content by measuring scrollHeight.
+  // The measurement is only valid for the width (and font) it was taken at:
+  // wrapping changes when the viewport narrows and again when the monospace
+  // webfont arrives. Each widget registers its autosize here so one shared,
+  // frame-throttled pass can re-measure them all on those events.
+
+  var autosizers = [];
+  var autosizeQueued = false;
+  function autosizeAll() {
+    if (autosizeQueued) return;
+    autosizeQueued = true;
+    requestAnimationFrame(function () {
+      autosizeQueued = false;
+      for (var i = 0; i < autosizers.length; i++) autosizers[i]();
+    });
+  }
+  window.addEventListener("resize", autosizeAll);
+  if (document.fonts && document.fonts.ready) document.fonts.ready.then(autosizeAll);
+
   // ── output rendering ──────────────────────────────────────────────────────
 
   var STAGE_LABEL = { parse: "Parse error", type: "Type error", eval: "Runtime error", auth: "GitHub error" };
@@ -357,6 +378,7 @@
       editor.style.height = "auto";
       editor.style.height = editor.scrollHeight + "px";
     }
+    autosizers.push(autosize);
     if (seedHtml && !ts) {
       highlight.innerHTML = seedHtml;
     } else {
@@ -597,6 +619,7 @@
       input.style.height = "auto";
       input.style.height = input.scrollHeight + "px";
     }
+    autosizers.push(autosize);
     if (seedHtml && !ts) {
       highlight.innerHTML = seedHtml;
     } else {
@@ -916,6 +939,7 @@
         editor.style.height = "auto";
         editor.style.height = editor.scrollHeight + "px";
       }
+      autosizers.push(autosize);
       if (seedHtml && !ts) {
         highlight.innerHTML = seedHtml;
       } else {

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -333,6 +333,9 @@
     editor.setAttribute("autocomplete", "off");
     editor.setAttribute("autocapitalize", "off");
     editor.setAttribute("autocorrect", "off");
+    // rows=1, like the REPL input: the default two-row minimum would keep a
+    // single-line snippet two lines tall even after autosize.
+    editor.setAttribute("rows", "1");
     editor.value = source;
 
     editorWrap.appendChild(highlight);
@@ -884,6 +887,10 @@
       editor.setAttribute("autocomplete", "off");
       editor.setAttribute("autocapitalize", "off");
       editor.setAttribute("autocorrect", "off");
+      // rows=1: a textarea defaults to two rows, and autosize can't shrink
+      // below that (scrollHeight includes the rows-derived minimum), which
+      // would render every single-line block two lines tall.
+      editor.setAttribute("rows", "1");
       editor.value = source;
       editorWrap.appendChild(highlight);
       editorWrap.appendChild(editor);

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -110,6 +110,7 @@
         resolve({
           eval: window.dangEval,
           replEval: window.dangReplEval,
+          literateEval: window.dangLiterateEval,
           replReset: window.dangReplReset,
         });
       };
@@ -798,6 +799,153 @@
     });
   }
 
+  // ── literate blocks ───────────────────────────────────────────────────────
+  //
+  // \dang-literate blocks (docs/go/literate.go) arrive with their output
+  // already baked in at build time, so the page is complete without JS. The
+  // enhancement makes them editable: every literate block on the page shares
+  // one Dang environment, evaluated top to bottom — Run (or Ctrl/Cmd+Enter)
+  // resets that shared session and replays the whole chain with the editors'
+  // current contents, updating each block's output along the way. Editing a
+  // block dims its output and every output below it until the next replay,
+  // since anything downstream may depend on the edit.
+
+  function enhanceLiterateChain(containers) {
+    var sessionId = nextReplSession++;
+    var chain = []; // { editor, out, runBtn } in document order
+
+    var running = false;
+    function runChain(origin) {
+      if (running) return;
+      running = true;
+      chain.forEach(function (b) { b.runBtn.disabled = true; });
+      if (origin) origin.runBtn.textContent = "Running…";
+      loadDang()
+        .then(function (dang) {
+          dang.replReset(sessionId);
+          var failed = false;
+          chain.forEach(function (b) {
+            if (failed) {
+              // State below a failed block is unknowable; dim its last-known
+              // output rather than pretend it still holds.
+              b.out.classList.add("is-stale");
+              return;
+            }
+            var res = dang.literateEval(sessionId, b.editor.value.replace(/\s+$/, ""));
+            renderReplOutput(b.out, res);
+            b.out.classList.remove("is-stale");
+            if (!res.ok) failed = true;
+          });
+        })
+        .catch(function (err) {
+          var out = origin ? origin.out : chain[0].out;
+          renderReplOutput(out, {
+            ok: false, stage: "", value: "", output: "",
+            error: "Failed to load: " + (err && err.message ? err.message : err),
+          });
+        })
+        .then(function () {
+          running = false;
+          chain.forEach(function (b) {
+            b.runBtn.disabled = false;
+            b.runBtn.textContent = "Run ▶";
+          });
+        });
+    }
+
+    function build(container, index) {
+      var fallback = container.querySelector(".dang-literate-fallback");
+      if (!fallback) return;
+      var seed = fallback.cloneNode(true);
+      seed.querySelectorAll(".dang-fb").forEach(function (n) { n.remove(); });
+      var source = seed.textContent.replace(/\s+$/, "");
+      var seedCode = seed.querySelector("code");
+      var seedHtml = seedCode ? seedCode.innerHTML : null;
+
+      // Reuse the baked output element so the build-time results stay on
+      // screen until the first replay; create one for output-less blocks.
+      var out = container.querySelector(".dang-literate-out");
+      if (!out) {
+        out = document.createElement("div");
+        out.className = "dang-literate-out is-empty";
+        container.appendChild(out);
+      }
+
+      // Same overlay editor as the playground: transparent textarea over a
+      // highlighted layer with identical metrics.
+      var editorWrap = document.createElement("div");
+      editorWrap.className = "dang-playground-editor";
+      var highlight = document.createElement("pre");
+      highlight.className = "dang-playground-highlight";
+      highlight.setAttribute("aria-hidden", "true");
+      var editor = document.createElement("textarea");
+      editor.className = "dang-playground-input";
+      editor.spellcheck = false;
+      editor.setAttribute("autocomplete", "off");
+      editor.setAttribute("autocapitalize", "off");
+      editor.setAttribute("autocorrect", "off");
+      editor.value = source;
+      editorWrap.appendChild(highlight);
+      editorWrap.appendChild(editor);
+      container.replaceChild(editorWrap, fallback);
+
+      var controls = document.createElement("div");
+      controls.className = "dang-literate-controls";
+      var runBtn = document.createElement("button");
+      runBtn.className = "dang-playground-btn dang-playground-run";
+      runBtn.type = "button";
+      runBtn.textContent = "Run ▶";
+      runBtn.title = "Replay every block on this page in one shared environment";
+      controls.appendChild(runBtn);
+      container.appendChild(controls);
+
+      var entry = { editor: editor, out: out, runBtn: runBtn };
+      runBtn.addEventListener("click", function () { runChain(entry); });
+
+      function rehighlight() {
+        highlight.innerHTML = highlightHtml(editor.value);
+      }
+      function autosize() {
+        editor.style.height = "auto";
+        editor.style.height = editor.scrollHeight + "px";
+      }
+      if (seedHtml && !ts) {
+        highlight.innerHTML = seedHtml;
+      } else {
+        rehighlight();
+      }
+      autosize();
+      editor.addEventListener("input", function () {
+        rehighlight();
+        autosize();
+        // This output and everything downstream may no longer match the code.
+        for (var i = index; i < chain.length; i++) {
+          chain[i].out.classList.add("is-stale");
+        }
+      });
+      loadTreeSitter().then(function () { rehighlight(); });
+
+      editor.addEventListener("keydown", function (e) {
+        if (e.key === "Tab") {
+          e.preventDefault();
+          var s = editor.selectionStart, en = editor.selectionEnd;
+          editor.value = editor.value.slice(0, s) + "  " + editor.value.slice(en);
+          editor.selectionStart = editor.selectionEnd = s + 2;
+          rehighlight();
+          autosize();
+        }
+        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          runChain(entry);
+        }
+      });
+
+      chain.push(entry);
+    }
+
+    for (var i = 0; i < containers.length; i++) build(containers[i], chain.length);
+  }
+
   function init() {
     var blocks = document.querySelectorAll("[data-dang-playground]");
     for (var i = 0; i < blocks.length; i++) enhance(blocks[i]);
@@ -805,6 +953,8 @@
     for (var j = 0; j < repls.length; j++) enhanceRepl(repls[j]);
     var lazies = document.querySelectorAll("[data-dang-repl-lazy]");
     for (var k = 0; k < lazies.length; k++) enhanceLazyRepl(lazies[k]);
+    var lits = document.querySelectorAll("[data-dang-literate]");
+    if (lits.length) enhanceLiterateChain(lits);
   }
 
   // Capture any OAuth token handed back in the fragment before enhancing, so

--- a/docs/lit/language/blocks.md
+++ b/docs/lit/language/blocks.md
@@ -13,9 +13,14 @@
 
 ## Block arguments to functions
 
+> The examples with results attached are live: they share one Dang
+> environment, so later snippets use earlier definitions. The results are
+> baked in by the docs build — edit a snippet and hit Run ▶ to replay the
+> page in your browser.
+
 - a block parameter is declared with the `&` sigil (same operator as [#functions]'s `&fn` refs); its type is a function type:
 
-```dang
+\dang-literate{{{
 # zero-arg block returning Int! (parens omitted)
 twice(&body: Int!): Int! {
   body + body
@@ -25,35 +30,44 @@ twice(&body: Int!): Int! {
 myFun(&block(x: Int!): String!): String! {
   block(42)
 }
-```
+
+# regular args mix with the block param (it comes last)
+withArg(prefix: String!, &fmt(x: Int!): String!): String! {
+  prefix + fmt(42)
+}
+}}}
 
 - the block param's arg types may also be a type variable: `id(&yield: b): b { yield }`. A type variable is opaque — the body can only pass the value through, not operate on it, so `yield * 2` would be a type error (see [#nullability])
 - a function/constructor may have at most one block parameter
 - regular args and a block param can mix; the block param comes last
 - callers pass a trailing brace block:
 
-```dang
+\dang-literate{{{
+let list = [1, 2, 3]
+
 twice { 21 }                  # ⇒ 42, body takes no args
 twice { let n = 21, n }       # multi-statement (separate with newline or `,`)
 list.map { x => x * 2 }       # built-in
 withArg("Number: ") { x => toJSON(x) }   # args then block
-```
+}}}
 
 - block parameter list can take multiple args:
 
-```dang
-list.each { item, index => print("${index}: ${item}") }
-```
+\dang-literate{{{
+list.each { item, index => print(`${index}: ${item}`) }
+}}}
 
 ## Optional parameters
 
 - a block whose body ignores its parameters can omit the `param =>` entirely:
 
-```dang
+\dang-literate{{{
+let numbers = [1, 2, 3]
+
 [1, 2, 3].map { "whee" }        # param ignored ⇒ ["whee", "whee", "whee"]
 numbers.filter { true }         # param ignored ⇒ all
 numbers.filter { false }        # ⇒ []
-```
+}}}
 
 ## Implicit `_` parameter {#implicit-param}
 

--- a/docs/lit/language/blocks.md
+++ b/docs/lit/language/blocks.md
@@ -4,109 +4,216 @@
 
 > Meta: blocks are doing a lot of work in Dang — they're the iteration protocol, the `Ruby`-ish DSL hook, the lambda-equivalent, *and* the body of conditionals/loops. Worth a paragraph naming them explicitly as "the lambda of Dang."
 
+Blocks are the lambda of Dang. There is no separate closure literal or arrow
+function: a brace block is how code gets passed around, and the same form is
+the iteration protocol, the hook for Ruby-ish DSLs, and the body of every
+conditional and loop.
+
+> The examples on this page are live: they share one Dang environment, so
+> later snippets use earlier definitions. Each result is computed and baked
+> in by the docs build — edit a snippet and hit Run ▶ to replay the page in
+> your browser.
+
 ## What a block is
 
-- braces with optional parameter list: `{ x => x + 1 }`
-- zero or more parameters separated by commas before `=>` (e.g. `{ item, index => ... }`)
-- body is a form sequence separated by newlines or `,`; the last form is the result
-- a bare `{ ... }` with no `=>` is also a block expression and evaluates to its last form: `let single = { 42 }` ⇒ `42`
+A block is braces around a sequence of forms, separated by newlines or `,`;
+the last form is the block's result. A bare `{ ... }` with no parameters is
+itself an expression:
+
+\dang-literate{{{
+{ let width = 4, let height = 3, width * height }
+}}}
+
+Parameters, when a block takes them, are comma-separated names before a `=>`:
+
+\dang-literate{{{
+[1, 2, 3].map { x => x + 1 }
+}}}
 
 ## Block arguments to functions
 
-> The examples with results attached are live: they share one Dang
-> environment, so later snippets use earlier definitions. The results are
-> baked in by the docs build — edit a snippet and hit Run ▶ to replay the
-> page in your browser.
-
-- a block parameter is declared with the `&` sigil (same operator as [#functions]'s `&fn` refs); its type is a function type:
+A function declares a block parameter with the `&` sigil (the same operator
+as [#functions]'s `&fn` refs); its type is a function type. The caller passes
+the block as trailing braces after the call:
 
 \dang-literate{{{
-# zero-arg block returning Int! (parens omitted)
 twice(&body: Int!): Int! {
   body + body
 }
 
-# block taking args: &name(params): Ret
-myFun(&block(x: Int!): String!): String! {
+twice { 21 }
+}}}
+
+The block parameter can itself take arguments — declared `&name(params): Ret`
+— and the function body calls it like any function:
+
+\dang-literate{{{
+apply(&block(x: Int!): String!): String! {
   block(42)
 }
 
-# regular args mix with the block param (it comes last)
-withArg(prefix: String!, &fmt(x: Int!): String!): String! {
-  prefix + fmt(42)
+apply { x => `got ${x}` }
+}}}
+
+The block param's arg types may also be a type variable. A type variable is
+opaque — the body can only pass the value through, not operate on it, so
+`yield * 2` here would be a type error (see [#nullability]):
+
+\dang-literate{{{
+id(&yield: b): b { yield }
+
+id { "anything" }
+}}}
+
+Regular args and a block param can mix; the block param comes last, and a
+function or constructor may have at most one:
+
+\dang-literate{{{
+greet(name: String!, &style(s: String!): String!): String! {
+  style(`Hello, ${name}`)
 }
+
+greet("Dang") { s => s.toUpper }
 }}}
 
-- the block param's arg types may also be a type variable: `id(&yield: b): b { yield }`. A type variable is opaque — the body can only pass the value through, not operate on it, so `yield * 2` would be a type error (see [#nullability])
-- a function/constructor may have at most one block parameter
-- regular args and a block param can mix; the block param comes last
-- callers pass a trailing brace block:
+A block's parameter list can take multiple args when the call supplies them —
+`.each` passes the element and its index:
 
 \dang-literate{{{
-let list = [1, 2, 3]
+let fruits = ["apple", "banana", "cherry"]
 
-twice { 21 }                  # ⇒ 42, body takes no args
-twice { let n = 21, n }       # multi-statement (separate with newline or `,`)
-list.map { x => x * 2 }       # built-in
-withArg("Number: ") { x => toJSON(x) }   # args then block
+fruits.each { item, index => print(`${index}: ${item}`) }
 }}}
 
-- block parameter list can take multiple args:
-
-\dang-literate{{{
-list.each { item, index => print(`${index}: ${item}`) }
-}}}
+(`.each` returns the original list — that's the `=>` line above — so calls
+chain even when the block is pure side effect.)
 
 ## Optional parameters
 
-- a block whose body ignores its parameters can omit the `param =>` entirely:
+A block whose body ignores its parameters can omit the `param =>` entirely:
 
 \dang-literate{{{
-let numbers = [1, 2, 3]
+[1, 2, 3].map { "whee" }
+}}}
 
-[1, 2, 3].map { "whee" }        # param ignored ⇒ ["whee", "whee", "whee"]
-numbers.filter { true }         # param ignored ⇒ all
-numbers.filter { false }        # ⇒ []
+That works anywhere a block does — a constant predicate, say:
+
+\dang-literate{{{
+fruits.filter { true }     # param ignored ⇒ keeps everything
+fruits.filter { false }
 }}}
 
 ## Implicit `_` parameter {#implicit-param}
 
 > Meta: Kotlin's `it`, not Scala's positional `_`. The one rule people trip on: every `_` in a param-less block is the *same* one argument.
 
-- a block with **no explicit params** that references `_` gets a single implicit parameter named `_`
-- every `_` in that block refers to that same one argument — `{ _ * 2 }` and `{ _ + _ }` both bind exactly one value (NOT Scala-style positional `_1`, `_2`)
-- works everywhere blocks are used:
+A block with **no explicit params** that references `_` gets a single
+implicit parameter named `_`:
 
-```dang
-xs.map { _ * 2 }                # ⇒ each doubled
-xs.filter { _ > 0 }             # ⇒ positives
-foo.{ bar(_) }                  # dot-block; see [#dot-block]
-```
+\dang-literate{{{
+[1, 2, 3].map { _ * 2 }
+}}}
 
-- a block with **explicit params** does not capture `_` — `{ x => x * 2 }` has no implicit parameter
-- nesting: `_` binds to the **nearest enclosing param-less block**; a nested param-less block shadows the outer one
-- a bare `_` outside any block is an undefined-reference error
+Every `_` in that block refers to that same one argument — Kotlin's `it`, NOT
+Scala-style positional `_1`, `_2`. So `{ _ + _ }` doubles each element rather
+than pairing two arguments:
+
+\dang-literate{{{
+[1, 2, 3].map { _ + _ }
+}}}
+
+`_` binds to the **nearest enclosing param-less block**, and a nested
+param-less block shadows the outer one — here the outer `_` is each sublist,
+the inner `_` each number:
+
+\dang-literate{{{
+[[1, 2], [3]].map { _.map { _ * 10 } }
+}}}
+
+A block with **explicit params** does not capture `_` — `{ x => x * 2 }` has
+no implicit parameter — and a bare `_` outside any block is an
+undefined-reference error.
 
 ## Scoping
 
-- a block is a lexical scope; `let` declares a fresh local. `let` is *the* way
-  to declare a local — a bare `name = value` is a reassignment of an existing
-  field, not a new declaration (see [#fields])
-- inside a block, prefer `let` for locals; bare (public) declarations are for a
-  type's or module's exported surface, where "public" actually means something
-- a local `let` shadows an outer field of the same name; mutating the local leaves the outer untouched
-- reassignment without a shadowing `let` mutates the enclosing field — across nested blocks too
-- `+=` works on the outer field from inside a block
-- hoisting: a mutation made inside a `loop` block is visible to code after the loop in the same scope
+A block is a lexical scope, and `let` is *the* way to declare a local. A
+local `let` shadows an outer field of the same name; mutating the local
+leaves the outer untouched:
+
+\dang-literate{{{
+let name = "outer"
+let result = { let name = "inner", name }
+
+[result, name]
+}}}
+
+Without a shadowing `let`, a bare `name = value` is a *reassignment* of the
+existing field, not a new declaration (see [#fields]) — and that reach
+extends through nested blocks, with mutations still visible after the block
+returns. `+=` works on the outer field the same way:
+
+\dang-literate{{{
+let total = 0
+[1, 2, 3].each { x => total += x }
+
+total
+}}}
+
+The same hoisting applies to `loop` bodies:
+
+\dang-literate{{{
+let tries = 0
+loop {
+  tries += 1
+  if (tries == 3) { break }
+}
+
+tries
+}}}
+
+Inside a block, prefer `let` for locals; bare (public) declarations are for a
+type's or module's exported surface, where "public" actually means something.
 
 ## Control-flow handoff
 
 > Meta: the cute Ruby-esque part. `return` inside a `.map`/`.each` block unwinds the *enclosing function*, not just the block. The full `break`/`continue` spec lives in [#control-flow]; keep only the block-specific wrinkles here.
 
-- `return` inside a block unwinds through the enclosing **function**, not just the block
-- `break value` / `continue value` work inside `.each`, `.map`, `loop`, and user-defined block-arg calls — a block-taking call is a valid target, and the value/result rules are specified in [#control-flow]
-- an **ordinary nested function** declared inside a block does NOT inherit the block's break/continue target — `break`/`continue` there errors `... outside of loop or block-taking call`
-- escaped blocks (stored via `&block`, then called after the receiving call/function has already returned) error at runtime: `break from expired block call` / `return from expired function`
+`return` inside a block unwinds through the enclosing **function**, not just
+the block — which is what makes early exit from an iteration read naturally:
+
+\dang-literate{{{
+firstMatch(words: [String!]!, prefix: String!): String {
+  words.each { w => if (w.hasPrefix(prefix)) { return w } }
+  null
+}
+
+firstMatch(fruits, "b")
+}}}
+
+`break value` works inside `.each`, `.map`, `loop`, and user-defined
+block-arg calls — a block-taking call is a valid target, and `break` makes it
+yield the value:
+
+\dang-literate{{{
+[1, 2, 3, 4].each { x => if (x > 2) { break x } }
+}}}
+
+`continue value` supplies one iteration's result — in `.map` it inserts the
+value; in `.each` it just advances:
+
+\dang-literate{{{
+[1, 2, 3].map { x => if (x == 2) { continue 0 }, x }
+}}}
+
+The value/result rules are specified in [#control-flow]. Two block-specific
+wrinkles:
+
+- an **ordinary nested function** declared inside a block does NOT inherit
+  the block's break/continue target — `break`/`continue` there errors
+  `... outside of loop or block-taking call`
+- escaped blocks (stored via `&block`, then called after the receiving
+  call/function has already returned) error at runtime:
+  `break from expired block call` / `return from expired function`
 
 ## When to use a block vs. a function reference
 
@@ -117,26 +224,63 @@ foo.{ bar(_) }                  # dot-block; see [#dot-block]
 
 > Meta: this is Dang's piping primitive — there is no `|>` operator. Lead with the equivalence, then the interleaving, then the null behaviour as a consequence of "application, not navigation."
 
-- `receiver.{ block }` calls the block with the receiver as its single argument — Dang's piping mechanism
-- `foo.{ bar(_) }` ≡ `bar(foo)`, and `foo.{ x => bar(x) }` ≡ `bar(foo)` (the implicit `_` from [#implicit-param] is the idiomatic form)
-- it sits at `.`'s precedence — a sibling of `.{{ }}` selection and method calls — so it **interleaves with real method calls in a single chain**:
+`receiver.{ block }` calls the block with the receiver as its single argument
+— Dang's piping mechanism; there is no `|>` operator. `foo.{ bar(_) }` ≡
+`bar(foo)`, and `foo.{ x => bar(x) }` ≡ `bar(foo)` (the implicit `_` from
+[#implicit-param] is the idiomatic form):
 
-```dang
-c.{ mountCache(_, path, cache) }
- .withEnvVariable("X", "y")
- .{ prepare(_) }
-```
+\dang-literate{{{
+inc(x: Int!): Int! { x + 1 }
 
-- the block must take **0 or 1 parameters**; 2+ is an error: `dot-block takes a single value`
-- a 0-param block ignores the receiver and just returns its body
+41.{ inc(_) }
+}}}
+
+It sits at `.`'s precedence — a sibling of `.{{ }}` selection and method
+calls — so it **interleaves with real method calls in a single chain**:
+
+\dang-literate{{{
+emphasize(s: String!): String! { `**${s}**` }
+
+"hello world"
+  .toUpper
+  .{ emphasize(_) }
+  .replace(" ", ", ")
+}}}
+
+The block must take **0 or 1 parameters**; 2+ is an error: `dot-block takes a
+single value`. A 0-param block ignores the receiver and just returns its
+body:
+
+\dang-literate{{{
+5.{ "ignored the receiver" }
+}}}
 
 ### Null: dot-block is application, not navigation
 
 > Meta: the null behaviour follows from what dot-block *is*. Frame it that way rather than as a gotcha vs. selection.
 
-- because `foo.{ bar(_) }` ≡ `bar(foo)`, a null receiver is simply *passed in*: the block runs with `_` bound to null, exactly as `bar(null)` would. Dot-block applies a block — it does not navigate into the receiver, so it has nothing to short-circuit
-- this is what lets a block *handle* null: `x.{ _ ?? 0 }`, `x.{ if (_ == null) { … } else { … } }`
-- contrast `.{{ }}` selection ([#interop]), which *is* navigation and therefore **short-circuits**: `user.{{name}}` is `null` when `user` is null, and its result type is nullable. Same `.`-brace surface, but selection reads fields while dot-block calls a block
+Because `foo.{ bar(_) }` ≡ `bar(foo)`, a null receiver is simply *passed in*:
+the block runs with `_` bound to null, exactly as `bar(null)` would.
+Dot-block applies a block — it does not navigate into the receiver, so it has
+nothing to short-circuit. This is what lets a block *handle* null:
+
+\dang-literate{{{
+let missing = null :: String
+
+missing.{ _ ?? "fallback" }
+}}}
+
+Contrast `.{{ }}` selection ([#interop]), which *is* navigation and therefore
+**short-circuits**: the selection below never reads `name`, and its result
+type is nullable. Same `.`-brace surface, but selection reads fields while
+dot-block calls a block:
+
+\dang-literate{{{
+type User { name: String! }
+let nobody = null :: User
+
+nobody.{{name}}
+}}}
 
 ## Common methods that take blocks
 


### PR DESCRIPTION
## Docs feedback

> This should be runnable. And also the string should use backticks. In fact, let's do something fun: literate programming. Add a plugin for that - alternating paragraphs and code sharing a Dang environment that runs and prints the result of each code block.

— feedback on `/blocks`, on the `list.each { item, index => print("${index}: ${item}") }` example.

The reader was more right than they knew (edit by "reader": oh, I knew): that example was *broken*, not just unidiomatic — `${...}` only interpolates inside backtick templates, so it printed the literal text `${index}: ${item}`.

## The literate plugin

`\dang-literate{{{ ... }}}` is a code fence that actually runs:

- **Build time** (`docs/go/literate.go`): all literate blocks in one source file share a single Dang environment, evaluated in document order — later snippets use earlier definitions, like notebook cells. Each block's output (stdout + the value of its last form, suppressed when the last form is a declaration) is baked into the static HTML, so the page is complete without JS and **a broken example fails the docs build**. This bug couldn't have shipped through a literate block.
- **Client side** (`playground.js`): the blocks upgrade into the playground's overlay editor. Run (or Ctrl/Cmd+Enter) resets a shared wasm REPL session and replays the page top to bottom via a new `dangLiterateEval` export, updating every output; editing a block dims its output and everything downstream until the next replay.

## /blocks rewritten in full literate style

The whole page is now alternating prose and evaluations: every claim is followed by a small literate block demonstrating exactly that claim — 23 blocks sharing one environment (`fruits` defined under "Block arguments" is the list `firstMatch` searches four sections later). Highlights:

- the flagged `.each` example uses backticks and shows its real printed output
- `{ _ + _ }` ⇒ `[2, 4, 6]` demonstrates "every `_` is the same one argument" better than prose ever did; nested `_` shadowing maps over a list of lists
- `break x` from `.each` and `continue 0` in `.map` show their yielded values
- the Dagger-flavored dot-block chain became a runnable string-method chain (`.toUpper` → `.{ emphasize(_) }` → `.replace`)
- the null sections evaluate a null receiver through `.{ }` (⇒ `fallback`) and `.{{ }}` (⇒ `null`) side by side

Two error cases stay prose since a failing literate block fails the build by design: the nested-function break target, and expired escaped blocks (which also can't be written runnably — there's no surface syntax for a function-type annotation, so a function can't return a stored block ref).

Section anchors (`{#blocks}`, `{#implicit-param}`, `{#dot-block}`) and Meta notes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
