### PR TITLE
docs: stow literate sessions on the file's section

### DIFF
--- a/docs/go/literate.go
+++ b/docs/go/literate.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/vito/booklit"
 	"github.com/vito/dang/v2/pkg/dang"
@@ -22,11 +21,6 @@ type literateSession struct {
 	valueScope dang.ValueScope
 }
 
-var (
-	literateMu       sync.Mutex
-	literateSessions = map[string]*literateSession{}
-)
-
 // literateFencesPartial is the section partial under which \literate-fences
 // records itself. Partials are booklit's "arbitrary named content" slot, the
 // closest plugin-side analogue to how \split-sections sets a flag on its
@@ -34,17 +28,45 @@ var (
 // never renders.
 const literateFencesPartial = "LiterateFences"
 
-// literateSessionFor returns the shared session for the given source file,
-// creating it from fresh standard-library scopes on first use.
-func literateSessionFor(path string) *literateSession {
-	literateMu.Lock()
-	defer literateMu.Unlock()
-	s := literateSessions[path]
-	if s == nil {
-		typeScope, valueScope := dang.BuildScopesFromImports("", nil)
-		s = &literateSession{typeScope: typeScope, valueScope: valueScope}
-		literateSessions[path] = s
+// literateSessionPartial is the section partial under which the source
+// file's literate session is stowed, on the section that carries the file.
+// Stowing it on the section rather than in a package-level map ties the
+// session's lifetime to one load of the book: booklit's dev server
+// (`build.sh -s`) re-loads the whole book on every page request,
+// concurrently across requests, and Dang scopes are not safe for concurrent
+// use (one request's Infer writes the scope maps another request's Eval is
+// reading). Sections are rebuilt per load and a load evaluates on one
+// goroutine, so sessions never cross goroutines and every rebuild replays
+// the page's chain fresh.
+const literateSessionPartial = "LiterateSession"
+
+// literateSessionContent carries a session as a Content so it can live in a
+// partial; like the \literate-fences marker it never renders.
+type literateSessionContent struct {
+	booklit.Content
+	session *literateSession
+}
+
+// literateSessionFor returns the session shared by every literate block in
+// the given section's source file, creating it from fresh standard-library
+// scopes on first use.
+func literateSessionFor(section *booklit.Section) *literateSession {
+	// The session lives on the section that carries the source file: inline
+	// \section blocks have no Path of their own, so walk up to the file's
+	// section (mirroring FilePath) — the chain spans every heading in the
+	// file.
+	file := section
+	for file.Path == "" && file.Parent != nil {
+		file = file.Parent
 	}
+
+	if c, ok := file.Partial(literateSessionPartial).(literateSessionContent); ok {
+		return c.session
+	}
+
+	typeScope, valueScope := dang.BuildScopesFromImports("", nil)
+	s := &literateSession{typeScope: typeScope, valueScope: valueScope}
+	file.SetPartial(literateSessionPartial, literateSessionContent{booklit.Empty, s})
 	return s
 }
 
@@ -102,7 +124,7 @@ func (p Plugin) DangLiterate(code booklit.Content) (booklit.Content, error) {
 // originating syntax in build errors.
 func (p Plugin) literateBlock(code booklit.Content, label string) (booklit.Content, error) {
 	source := strings.TrimRight(code.String(), "\n")
-	sess := literateSessionFor(p.section.FilePath())
+	sess := literateSessionFor(p.section)
 
 	stdout, value, err := literateEval(source, sess)
 	if err != nil {

--- a/docs/go/literate_test.go
+++ b/docs/go/literate_test.go
@@ -1,6 +1,8 @@
 package dangdocs
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/vito/booklit"
@@ -74,5 +76,53 @@ func TestCodeBlockLiterateRouting(t *testing.T) {
 	outside := render(plain, "dang", "undefinedNameNeverEvaluated")
 	if outside.Style != booklit.StyleCodeBlock {
 		t.Errorf("dang fence outside scope: style %q, want %q", outside.Style, booklit.StyleCodeBlock)
+	}
+}
+
+// Booklit's dev server re-loads the whole book on every page request,
+// concurrently across requests, and Dang scopes are not safe for concurrent
+// use — so each load must get its own sessions. Each goroutine here simulates
+// one load evaluating the same source file; `go test -race` fails if loads
+// share scopes. The loads declare distinct names: concurrent loads of a real
+// book sit at different blocks of the page, and identical sources fail fast
+// in Infer without the scope writes that make the detector fire.
+func TestLiterateSessionsScopedPerLoad(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			root := &booklit.Section{Path: "blocks.md"}
+			sess := literateSessionFor(root)
+			if _, _, err := literateEval(fmt.Sprintf("let nums%d = [1, 2, 3]", i), sess); err != nil {
+				t.Error(err)
+				return
+			}
+
+			// An inline \section shares the file path but is its own Section;
+			// the notebook chain spans it, so it must get the same session.
+			sub := &booklit.Section{Parent: root}
+			if subSess := literateSessionFor(sub); subSess != sess {
+				t.Error("inline subsection got a different session than its file")
+				return
+			}
+
+			// Earlier blocks' definitions are in scope for later blocks.
+			if _, _, err := literateEval(fmt.Sprintf("nums%d.map { x => x + 1 }", i), sess); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// Re-loading the same file in a new load must start the chain fresh rather
+// than reusing (and accumulating into) the previous load's scopes.
+func TestLiterateSessionsFreshPerLoad(t *testing.T) {
+	first := literateSessionFor(&booklit.Section{Path: "blocks.md"})
+	second := literateSessionFor(&booklit.Section{Path: "blocks.md"})
+	if first == second {
+		t.Error("new load reused the previous load's session")
 	}
 }


### PR DESCRIPTION
Fixes the `fatal error: concurrent map read and map write` panic when running the docs in server mode (`./docs/build.sh -s 3000`).

## Root cause

Booklit's dev server re-loads the whole book on every page request, and `Server.ServeHTTP` only serializes rendering — `Processor.LoadFile` runs concurrently across requests. The literate plugin cached sessions by source file in a package-level map, so two overlapping loads got the *same* Dang scope pair, and Dang scopes are not safe for concurrent use: one request's `InferFormsWithPhases` writes the scope's `valueOrigins`/`vars` maps while another request's `Symbol.Eval` reads them via `CheckValueConflict` (`pkg/dang/env.go:767` in the reported trace). Path-keying also meant every dev-server rebuild kept evaluating into the previous load's accumulated scopes instead of replaying the page's chain fresh.

## Fix

Stow the session in a partial on the section that carries the source file — the same slot `\literate-fences` records itself in. Sections are rebuilt per load and a load evaluates on one goroutine, so the session's lifetime and visibility follow the load's by construction: no shared scopes between concurrent requests, a fresh chain every rebuild, nothing accumulating across them, and no global state to clean up. Inline `\section` blocks walk up to the file's section (mirroring `FilePath`), so the chain still spans every heading in the file.

## Verification

- New regression test runs 8 simulated concurrent loads under `go test -race`; an A/B check confirmed the harness trips the detector (8 `DATA RACE` reports) when sessions are shared the way the old path-keyed map shared them. The loads must declare distinct names — identical sources fail fast in Infer without the scope writes that make the detector fire.
- Built the docs server with `-race` and hammered `/blocks.html` with 12-way concurrent requests: all 200s, no race reports, no panics. The unfixed server under the same load is what produces the reported fatal error.
- Main's `\literate-fences` tests (`TestLiterateFencesScope`, `TestCodeBlockLiterateRouting`) pass unchanged, including the cross-fence chaining assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
