### PR TITLE
docs: scope literate mode onto ```dang fences

### DIFF
--- a/docs/go/literate.go
+++ b/docs/go/literate.go
@@ -25,6 +25,11 @@ type literateSession struct {
 var (
 	literateMu       sync.Mutex
 	literateSessions = map[string]*literateSession{}
+
+	// literateFenceSections holds the sections in which \literate-fences has
+	// been invoked. Fences check their own section and every ancestor, so the
+	// call covers the rest of its section including sub-sections.
+	literateFenceSections = map[*booklit.Section]bool{}
 )
 
 // literateSessionFor returns the shared session for the given source file,
@@ -41,9 +46,39 @@ func literateSessionFor(path string) *literateSession {
 	return s
 }
 
+// LiterateFences turns the ```dang fences that follow it into literate
+// blocks, each rendered exactly as if it were a \dang-literate invocation.
+// The switch is lexically scoped: it covers the rest of the section it's
+// called in, sub-sections included (each markdown heading is its own booklit
+// section, linked by Parent), and only fences evaluated after the call —
+// booklit evaluates in document order. Call it right after the page title for
+// a fully literate page, or under one heading to scope it to that section;
+// ```dang fences elsewhere stay plain highlighted Markdown. A ```dang-static
+// fence opts a single snippet back out (see CodeBlock).
+//
+//	\literate-fences
+func (p Plugin) LiterateFences() {
+	literateMu.Lock()
+	defer literateMu.Unlock()
+	literateFenceSections[p.section] = true
+}
+
+// literateFencesEnabled reports whether \literate-fences was called in sec or
+// any of its ancestors before this point in document order.
+func literateFencesEnabled(sec *booklit.Section) bool {
+	literateMu.Lock()
+	defer literateMu.Unlock()
+	for s := sec; s != nil; s = s.Parent {
+		if literateFenceSections[s] {
+			return true
+		}
+	}
+	return false
+}
+
 // DangLiterate renders a literate-programming code block. The snippet is
 // evaluated at build time against a Dang environment shared by every
-// \dang-literate block in the same source file — earlier blocks' definitions
+// literate block in the same source file — earlier blocks' definitions
 // are in scope, like cells of a notebook — and its output (stdout plus the
 // value of the last form) is baked into the static page. A block that fails
 // to parse, type-check, or evaluate fails the docs build, so literate
@@ -53,17 +88,26 @@ func literateSessionFor(path string) *literateSession {
 //	list.each { item, index => print(`${index}: ${item}`) }
 //	}}}
 //
+// In a \literate-fences scope, plain ```dang fences render through this same
+// path (see CodeBlock), so pages can stay pure Markdown.
+//
 // docs/js/playground.js progressively enhances these blocks into editable
 // widgets with the same chain semantics: Run replays every literate block on
 // the page, top to bottom, in one wasm REPL session. Without JavaScript the
 // baked output still shows.
 func (p Plugin) DangLiterate(code booklit.Content) (booklit.Content, error) {
+	return p.literateBlock(code, `\dang-literate block`)
+}
+
+// literateBlock evaluates and renders one literate snippet; label names the
+// originating syntax in build errors.
+func (p Plugin) literateBlock(code booklit.Content, label string) (booklit.Content, error) {
 	source := strings.TrimRight(code.String(), "\n")
 	sess := literateSessionFor(p.section.FilePath())
 
 	stdout, value, err := literateEval(source, sess)
 	if err != nil {
-		return nil, fmt.Errorf("\\dang-literate block in %s: %w", p.section.FilePath(), err)
+		return nil, fmt.Errorf("%s in %s: %w", label, p.section.FilePath(), err)
 	}
 
 	partials := booklit.Partials{}

--- a/docs/go/literate.go
+++ b/docs/go/literate.go
@@ -25,12 +25,14 @@ type literateSession struct {
 var (
 	literateMu       sync.Mutex
 	literateSessions = map[string]*literateSession{}
-
-	// literateFenceSections holds the sections in which \literate-fences has
-	// been invoked. Fences check their own section and every ancestor, so the
-	// call covers the rest of its section including sub-sections.
-	literateFenceSections = map[*booklit.Section]bool{}
 )
+
+// literateFencesPartial is the section partial under which \literate-fences
+// records itself. Partials are booklit's "arbitrary named content" slot, the
+// closest plugin-side analogue to how \split-sections sets a flag on its
+// section; templates only read partials by explicit name, so the marker
+// never renders.
+const literateFencesPartial = "LiterateFences"
 
 // literateSessionFor returns the shared session for the given source file,
 // creating it from fresh standard-library scopes on first use.
@@ -58,18 +60,15 @@ func literateSessionFor(path string) *literateSession {
 //
 //	\literate-fences
 func (p Plugin) LiterateFences() {
-	literateMu.Lock()
-	defer literateMu.Unlock()
-	literateFenceSections[p.section] = true
+	p.section.SetPartial(literateFencesPartial, booklit.Empty)
 }
 
 // literateFencesEnabled reports whether \literate-fences was called in sec or
-// any of its ancestors before this point in document order.
+// any of its ancestors before this point in document order. The ancestor walk
+// mirrors booklit's SplitSectionsPrevented.
 func literateFencesEnabled(sec *booklit.Section) bool {
-	literateMu.Lock()
-	defer literateMu.Unlock()
 	for s := sec; s != nil; s = s.Parent {
-		if literateFenceSections[s] {
+		if s.Partial(literateFencesPartial) != nil {
 			return true
 		}
 	}

--- a/docs/go/literate_test.go
+++ b/docs/go/literate_test.go
@@ -1,0 +1,78 @@
+package dangdocs
+
+import (
+	"testing"
+
+	"github.com/vito/booklit"
+)
+
+// \literate-fences covers the section it's called in and its sub-sections —
+// not the parent or siblings.
+func TestLiterateFencesScope(t *testing.T) {
+	root := &booklit.Section{Path: "scope-test.md"}
+	marked := &booklit.Section{Parent: root}
+	sibling := &booklit.Section{Parent: root}
+	sub := &booklit.Section{Parent: marked}
+
+	Plugin{section: marked}.LiterateFences()
+
+	cases := []struct {
+		name string
+		sec  *booklit.Section
+		want bool
+	}{
+		{"root", root, false},
+		{"marked section", marked, true},
+		{"sub-section of marked", sub, true},
+		{"sibling", sibling, false},
+	}
+	for _, c := range cases {
+		if got := literateFencesEnabled(c.sec); got != c.want {
+			t.Errorf("%s: literateFencesEnabled = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// In a \literate-fences scope a ```dang fence evaluates as a literate block,
+// chaining state with earlier fences in the same file; ```dang-static stays a
+// plain highlighted block, as does ```dang outside the scope.
+func TestCodeBlockLiterateRouting(t *testing.T) {
+	root := &booklit.Section{Path: "routing-test.md"}
+	lit := &booklit.Section{Parent: root}
+	plain := &booklit.Section{Parent: root}
+
+	Plugin{section: lit}.LiterateFences()
+
+	render := func(sec *booklit.Section, language, source string) booklit.Styled {
+		t.Helper()
+		content, err := Plugin{section: sec}.CodeBlock(language, booklit.Preformatted{booklit.String(source)})
+		if err != nil {
+			t.Fatalf("CodeBlock(%q, %q): %v", language, source, err)
+		}
+		styled, ok := content.(booklit.Styled)
+		if !ok {
+			t.Fatalf("CodeBlock(%q, %q) returned %T, want booklit.Styled", language, source, content)
+		}
+		return styled
+	}
+
+	first := render(lit, "dang", "let x = 6 * 7")
+	if first.Style != "dang-literate" {
+		t.Errorf("dang fence in literate scope: style %q, want dang-literate", first.Style)
+	}
+
+	second := render(lit, "dang", "x + 1")
+	if got := second.Partials["Value"]; got == nil || got.String() != "43" {
+		t.Errorf("second fence should see first fence's `x`: Value = %v, want 43", got)
+	}
+
+	static := render(lit, "dang-static", "definitely not dang ((")
+	if static.Style != booklit.StyleCodeBlock {
+		t.Errorf("dang-static fence: style %q, want %q", static.Style, booklit.StyleCodeBlock)
+	}
+
+	outside := render(plain, "dang", "undefinedNameNeverEvaluated")
+	if outside.Style != booklit.StyleCodeBlock {
+		t.Errorf("dang fence outside scope: style %q, want %q", outside.Style, booklit.StyleCodeBlock)
+	}
+}

--- a/docs/go/render.go
+++ b/docs/go/render.go
@@ -16,7 +16,22 @@ import (
 // Booklit resolves plugin methods first-match across the section's plugin
 // stack and baselit always sits first, so NewPlugin prepends this plugin to
 // make this override reachable.
+//
+// Inside a \literate-fences scope (see literate.go) a ```dang fence instead
+// becomes a literate block — evaluated at build time in the page's shared
+// session, output baked in. ```dang-static opts a single fence back out: it
+// highlights (and auto-links) as Dang but is never evaluated, for fragments
+// or intentionally invalid code that would fail the literate build.
 func (p Plugin) CodeBlock(language string, code booklit.Content, styleName ...string) (booklit.Content, error) {
+	switch language {
+	case "dang":
+		if literateFencesEnabled(p.section) {
+			return p.literateBlock(code, "```dang fence")
+		}
+	case "dang-static":
+		language = "dang"
+	}
+
 	source := code.String()
 
 	var links []linkSpan

--- a/docs/lit/language/blocks.md
+++ b/docs/lit/language/blocks.md
@@ -1,4 +1,5 @@
 \use-plugin{dang}
+\literate-fences
 
 # Blocks {#blocks}
 
@@ -20,15 +21,15 @@ A block is braces around a sequence of forms, separated by newlines or `,`;
 the last form is the block's result. A bare `{ ... }` with no parameters is
 itself an expression:
 
-\dang-literate{{{
+```dang
 { let width = 4, let height = 3, width * height }
-}}}
+```
 
 Parameters, when a block takes them, are comma-separated names before a `=>`:
 
-\dang-literate{{{
+```dang
 [1, 2, 3].map { x => x + 1 }
-}}}
+```
 
 ## Block arguments to functions
 
@@ -36,54 +37,54 @@ A function declares a block parameter with the `&` sigil (the same operator
 as [#functions]'s `&fn` refs); its type is a function type. The caller passes
 the block as trailing braces after the call:
 
-\dang-literate{{{
+```dang
 twice(&body: Int!): Int! {
   body + body
 }
 
 twice { 21 }
-}}}
+```
 
 The block parameter can itself take arguments — declared `&name(params): Ret`
 — and the function body calls it like any function:
 
-\dang-literate{{{
+```dang
 apply(&block(x: Int!): String!): String! {
   block(42)
 }
 
 apply { x => `got ${x}` }
-}}}
+```
 
 The block param's arg types may also be a type variable. A type variable is
 opaque — the body can only pass the value through, not operate on it, so
 `yield * 2` here would be a type error (see [#nullability]):
 
-\dang-literate{{{
+```dang
 id(&yield: b): b { yield }
 
 id { "anything" }
-}}}
+```
 
 Regular args and a block param can mix; the block param comes last, and a
 function or constructor may have at most one:
 
-\dang-literate{{{
+```dang
 greet(name: String!, &style(s: String!): String!): String! {
   style(`Hello, ${name}`)
 }
 
 greet("Dang") { s => s.toUpper }
-}}}
+```
 
 A block's parameter list can take multiple args when the call supplies them —
 `.each` passes the element and its index:
 
-\dang-literate{{{
+```dang
 let fruits = ["apple", "banana", "cherry"]
 
 fruits.each { item, index => print(`${index}: ${item}`) }
-}}}
+```
 
 (`.each` returns the original list — that's the `=>` line above — so calls
 chain even when the block is pure side effect.)
@@ -92,16 +93,16 @@ chain even when the block is pure side effect.)
 
 A block whose body ignores its parameters can omit the `param =>` entirely:
 
-\dang-literate{{{
+```dang
 [1, 2, 3].map { "whee" }
-}}}
+```
 
 That works anywhere a block does — a constant predicate, say:
 
-\dang-literate{{{
+```dang
 fruits.filter { true }     # param ignored ⇒ keeps everything
 fruits.filter { false }
-}}}
+```
 
 ## Implicit `_` parameter {#implicit-param}
 
@@ -110,25 +111,25 @@ fruits.filter { false }
 A block with **no explicit params** that references `_` gets a single
 implicit parameter named `_`:
 
-\dang-literate{{{
+```dang
 [1, 2, 3].map { _ * 2 }
-}}}
+```
 
 Every `_` in that block refers to that same one argument — Kotlin's `it`, NOT
 Scala-style positional `_1`, `_2`. So `{ _ + _ }` doubles each element rather
 than pairing two arguments:
 
-\dang-literate{{{
+```dang
 [1, 2, 3].map { _ + _ }
-}}}
+```
 
 `_` binds to the **nearest enclosing param-less block**, and a nested
 param-less block shadows the outer one — here the outer `_` is each sublist,
 the inner `_` each number:
 
-\dang-literate{{{
+```dang
 [[1, 2], [3]].map { _.map { _ * 10 } }
-}}}
+```
 
 A block with **explicit params** does not capture `_` — `{ x => x * 2 }` has
 no implicit parameter — and a bare `_` outside any block is an
@@ -140,28 +141,28 @@ A block is a lexical scope, and `let` is *the* way to declare a local. A
 local `let` shadows an outer field of the same name; mutating the local
 leaves the outer untouched:
 
-\dang-literate{{{
+```dang
 let name = "outer"
 let result = { let name = "inner", name }
 
 [result, name]
-}}}
+```
 
 Without a shadowing `let`, a bare `name = value` is a *reassignment* of the
 existing field, not a new declaration (see [#fields]) — and that reach
 extends through nested blocks, with mutations still visible after the block
 returns. `+=` works on the outer field the same way:
 
-\dang-literate{{{
+```dang
 let total = 0
 [1, 2, 3].each { x => total += x }
 
 total
-}}}
+```
 
 The same hoisting applies to `loop` bodies:
 
-\dang-literate{{{
+```dang
 let tries = 0
 loop {
   tries += 1
@@ -169,7 +170,7 @@ loop {
 }
 
 tries
-}}}
+```
 
 Inside a block, prefer `let` for locals; bare (public) declarations are for a
 type's or module's exported surface, where "public" actually means something.
@@ -181,29 +182,29 @@ type's or module's exported surface, where "public" actually means something.
 `return` inside a block unwinds through the enclosing **function**, not just
 the block — which is what makes early exit from an iteration read naturally:
 
-\dang-literate{{{
+```dang
 firstMatch(words: [String!]!, prefix: String!): String {
   words.each { w => if (w.hasPrefix(prefix)) { return w } }
   null
 }
 
 firstMatch(fruits, "b")
-}}}
+```
 
 `break value` works inside `.each`, `.map`, `loop`, and user-defined
 block-arg calls — a block-taking call is a valid target, and `break` makes it
 yield the value:
 
-\dang-literate{{{
+```dang
 [1, 2, 3, 4].each { x => if (x > 2) { break x } }
-}}}
+```
 
 `continue value` supplies one iteration's result — in `.map` it inserts the
 value; in `.each` it just advances:
 
-\dang-literate{{{
+```dang
 [1, 2, 3].map { x => if (x == 2) { continue 0 }, x }
-}}}
+```
 
 The value/result rules are specified in [#control-flow]. Two block-specific
 wrinkles:
@@ -229,31 +230,31 @@ wrinkles:
 `bar(foo)`, and `foo.{ x => bar(x) }` ≡ `bar(foo)` (the implicit `_` from
 [#implicit-param] is the idiomatic form):
 
-\dang-literate{{{
+```dang
 inc(x: Int!): Int! { x + 1 }
 
 41.{ inc(_) }
-}}}
+```
 
 It sits at `.`'s precedence — a sibling of `.{{ }}` selection and method
 calls — so it **interleaves with real method calls in a single chain**:
 
-\dang-literate{{{
+```dang
 emphasize(s: String!): String! { `**${s}**` }
 
 "hello world"
   .toUpper
   .{ emphasize(_) }
   .replace(" ", ", ")
-}}}
+```
 
 The block must take **0 or 1 parameters**; 2+ is an error: `dot-block takes a
 single value`. A 0-param block ignores the receiver and just returns its
 body:
 
-\dang-literate{{{
+```dang
 5.{ "ignored the receiver" }
-}}}
+```
 
 ### Null: dot-block is application, not navigation
 
@@ -264,23 +265,23 @@ the block runs with `_` bound to null, exactly as `bar(null)` would.
 Dot-block applies a block — it does not navigate into the receiver, so it has
 nothing to short-circuit. This is what lets a block *handle* null:
 
-\dang-literate{{{
+```dang
 let missing = null :: String
 
 missing.{ _ ?? "fallback" }
-}}}
+```
 
 Contrast `.{{ }}` selection ([#interop]), which *is* navigation and therefore
 **short-circuits**: the selection below never reads `name`, and its result
 type is nullable. Same `.`-brace surface, but selection reads fields while
 dot-block calls a block:
 
-\dang-literate{{{
+```dang
 type User { name: String! }
 let nobody = null :: User
 
 nobody.{{name}}
-}}}
+```
 
 ## Common methods that take blocks
 


### PR DESCRIPTION
Literate pages currently have to spell every snippet as a `\dang-literate{{{...}}}` invocation, giving up Markdown's native fenced code blocks. This adds a `\literate-fences` function that scopes literate mode onto plain ` ```dang ` fences.

The mechanism falls out of booklit's structure: every markdown heading becomes its own booklit section linked by `Parent`, and every fence routes through the plugin's `CodeBlock` method. `\literate-fences` marks the section it's called in; a ` ```dang ` fence whose section — or any ancestor — is marked renders through the exact same literate path as `\dang-literate` (evaluated at build time in the page's shared session, output baked in, Run ▶ enhancement unchanged). So a call right after the page title makes the whole page literate in pure Markdown, while a call under one `##` heading covers just that section and its subsections. Only fences after the call are affected, since booklit evaluates in document order.

` ```dang-static ` opts a single fence back out within a literate scope: highlighted and stdlib-auto-linked, but never evaluated — for fragments or intentionally invalid code that would otherwise fail the build.

The second commit converts `/blocks`: one `\literate-fences` line replaces all 23 `\dang-literate{{{...}}}` invocations with ordinary fences. The rendered HTML is byte-identical to the previous build (verified by diffing full site builds of main vs. this branch). Unit tests cover the scoping rules: marked section and subsections are literate, siblings and parents are not, later fences see earlier fences' definitions, and `dang-static`/out-of-scope fences stay plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
