### PR TITLE
docs: rewrite /control-flow in literate style

### DIFF
--- a/.agents/skills/dang-language/reference/control-flow.md
+++ b/.agents/skills/dang-language/reference/control-flow.md
@@ -57,10 +57,10 @@ let answer = loop { break 42 }   # block-taking builtin; runs until break
 - An expression: yields the `break` value (`null` for a bare `break`). The result is **non-null** when every `break` carries a non-null value: `loop { break 42 }` is usable directly as `Int!`.
 
 ## `break` / `continue`
-- Valid only inside a loop or block-taking call; otherwise compile error (`break outside of loop or block-taking call` / `continue outside of loop or block arg invocation`).
-- `break` exits; `break value` makes the loop/block-call yield `value`; bare `break` yields `null`.
+- Valid only inside a block passed to a call (`.each`, `loop`, user-defined block-taking fns — a `loop` body is just an ordinary block argument); otherwise compile error (`break outside of block-taking call` / `continue outside of block-taking call`).
+- `break` exits; `break value` makes the block-taking call yield `value`; bare `break` yields `null`.
 - `continue` skips to the next iteration; in `.map`, `continue value` inserts `value` into the result (bare → `null`); in `.each`/`loop` it just advances.
-- Target the nearest enclosing loop/block-call only; an ordinary nested function does NOT inherit the target.
+- Target the nearest enclosing block-taking call only; an ordinary nested function does NOT inherit the target.
 
 ## `return`
 - Exits the enclosing function/method/constructor early; outside one → `return outside of function`.

--- a/.agents/skills/dang-language/reference/objects.md
+++ b/.agents/skills/dang-language/reference/objects.md
@@ -95,7 +95,7 @@ list.each { item, index => ... }
 ### Control-flow handoff
 - `return` inside a block unwinds the enclosing **function**, not just the block.
 - `break value` / `continue value` work inside `.each`, `.map`, `loop`, and user-defined block-arg calls. `break value` becomes the loop/call result; bare `break` yields `null`. `continue value` flows into `.map`'s result (bare → `null`, e.g. `[null]`); in `.each`/`loop` it just advances.
-- `break`/`continue` target the **innermost** loop/block-call. An ordinary nested function declared inside a block does NOT inherit the break/continue target → `... outside of loop or block-taking call`.
+- `break`/`continue` target the **innermost** block-taking call. An ordinary nested function declared inside a block does NOT inherit the break/continue target → `... outside of block-taking call`.
 - Escaped blocks (stored via `&block`, called after the receiving call returned) error at runtime: `break from expired block call` / `return from expired function`.
 
 ## Objects (`type`)

--- a/cmd/dang-playground/main.go
+++ b/cmd/dang-playground/main.go
@@ -39,6 +39,14 @@
 //     (docs/go/literate.go), which share one session per page; re-running a
 //     page's chain client-side must show exactly what the build baked in.
 //
+//   - dangLiterateFailEval(sessionID, source) is dangLiterateEval against
+//     throwaway forks of the session's scopes, for the expected-failure
+//     literate blocks (```dang-failure fences): the entry sees everything the
+//     session has accumulated but contributes nothing back, mirroring
+//     literateFailEval (docs/go/literate.go). The result is reported as-is —
+//     the page decides how to present a block that was expected to fail but
+//     succeeded.
+//
 //   - dangReplReset(sessionID) discards a session's accumulated state, so the
 //     next dangReplEval starts from fresh standard-library scopes.
 //
@@ -50,6 +58,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -71,6 +80,7 @@ func main() {
 	js.Global().Set("dangEval", js.FuncOf(dangEval))
 	js.Global().Set("dangReplEval", js.FuncOf(dangReplEval))
 	js.Global().Set("dangLiterateEval", js.FuncOf(dangLiterateEval))
+	js.Global().Set("dangLiterateFailEval", js.FuncOf(dangLiterateFailEval))
 	js.Global().Set("dangReplReset", js.FuncOf(dangReplReset))
 	// dangReady lets the page know the module has finished initializing.
 	js.Global().Set("dangReady", js.ValueOf(true))
@@ -319,6 +329,58 @@ func dangLiterateEval(_ js.Value, args []js.Value) any {
 		value = ""
 	}
 	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
+}
+
+// dangLiterateFailEval evaluates one expected-failure literate block:
+// dangLiterateFailEval(sessionID, source). The block runs against throwaway
+// forks of the session's scopes — a cloned type scope and a sealed child
+// value scope — so whatever it declares or half-evaluates never reaches the
+// shared session: failing is the point, and a failing block's partial state
+// is unknowable. This mirrors the build-time evaluator (literateFailEval in
+// docs/go/literate.go — the two must stay in lockstep). Unlike the build,
+// which rejects a succeeding snippet outright, this reports the result
+// as-is; the page presents an unexpected success however it sees fit.
+func dangLiterateFailEval(_ js.Value, args []js.Value) any {
+	if len(args) < 2 || args[0].Type() != js.TypeNumber || args[1].Type() != js.TypeString {
+		return result("", "", "dangLiterateFailEval expects (sessionID, source)", "parse")
+	}
+	sess := session(args[0].Int())
+	source := args[1].String()
+
+	typeScope, ok := sess.typeScope.Clone().(dang.TypeScope)
+	if !ok {
+		return result("", "", "session type scope is not a TypeScope", "type")
+	}
+	valueScope := sess.valueScope.Derive(true)
+
+	fresh := hm.NewSimpleFresher()
+
+	var out bytes.Buffer
+	ctx := ioctx.StdoutToContext(context.Background(), &out)
+	ctx = ioctx.StderrToContext(ctx, &out)
+
+	value, lastIsDecl, err, stage := evalForms(ctx, source, typeScope, valueScope, fresh)
+	if err != nil {
+		return result("", strings.TrimRight(out.String(), "\n"), failureMessage(err), stage)
+	}
+	if lastIsDecl {
+		value = ""
+	}
+	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
+}
+
+// failureMessage extracts the bare message from an expected failure.
+// SourceError.Error() renders for a terminal — ANSI colors plus a quoted
+// source span — but the failing block's editor already shows the source, and
+// escape codes have no business in the page. The same unwrap lives in
+// docs/go/literate.go's failureMessage; the two must stay in lockstep so a
+// replay shows exactly the line the build baked.
+func failureMessage(err error) string {
+	var srcErr *dang.SourceError
+	if errors.As(err, &srcErr) {
+		return srcErr.Inner.Error()
+	}
+	return err.Error()
 }
 
 // dangReplReset(sessionID) discards a session so the next dangReplEval starts

--- a/docs/go/literate.go
+++ b/docs/go/literate.go
@@ -3,6 +3,7 @@ package dangdocs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -120,6 +121,33 @@ func (p Plugin) DangLiterate(code booklit.Content) (booklit.Content, error) {
 	return p.literateBlock(code, `\dang-literate block`)
 }
 
+// DangLiterateFailure renders a literate block that is REQUIRED to fail.
+// The snippet is evaluated like a literate block but against throwaway forks
+// of the page's session — a cloned type scope and a sealed child value scope
+// — so whatever it declares or half-evaluates before failing never reaches
+// later blocks. The error it raises is baked into the page in place of a
+// value; a snippet that succeeds fails the docs build, so expected-failure
+// examples are as rot-proof as the passing ones.
+//
+//	\dang-literate-failure{{{
+//	if (1) "yes" else "no"
+//	}}}
+//
+// In a \literate-fences scope, ```dang-failure fences render through this
+// same path (see CodeBlock).
+func (p Plugin) DangLiterateFailure(code booklit.Content) (booklit.Content, error) {
+	return p.literateFailureBlock(code, `\dang-literate-failure block`)
+}
+
+// stageLabels mirrors playground.js's STAGE_LABEL: the baked error line must
+// read exactly like the one renderReplOutput shows after a client-side
+// replay, label and all.
+var stageLabels = map[string]string{
+	"parse": "Parse error",
+	"type":  "Type error",
+	"eval":  "Runtime error",
+}
+
 // literateBlock evaluates and renders one literate snippet; label names the
 // originating syntax in build errors.
 func (p Plugin) literateBlock(code booklit.Content, label string) (booklit.Content, error) {
@@ -145,6 +173,89 @@ func (p Plugin) literateBlock(code booklit.Content, label string) (booklit.Conte
 		Partials: partials,
 		Block:    true,
 	}, nil
+}
+
+// literateFailureBlock evaluates and renders one expected-failure snippet;
+// label names the originating syntax in build errors. The rendered block
+// carries the error under the "Error" partial — its presence is what marks
+// the block as an expected failure, both for the template and for
+// playground.js's chain replay.
+func (p Plugin) literateFailureBlock(code booklit.Content, label string) (booklit.Content, error) {
+	source := strings.TrimRight(code.String(), "\n")
+	sess := literateSessionFor(p.section)
+
+	stdout, stage, failure := literateFailEval(source, sess)
+	if failure == nil {
+		return nil, fmt.Errorf("%s in %s: expected the snippet to fail, but it succeeded — use a plain ```dang fence", label, p.section.FilePath())
+	}
+
+	partials := booklit.Partials{
+		"Error": booklit.String(stageLabels[stage] + ": " + failureMessage(failure)),
+	}
+	if stdout != "" {
+		partials["Stdout"] = booklit.String(stdout)
+	}
+
+	return booklit.Styled{
+		Style:    "dang-literate",
+		Content:  p.highlightDang(source),
+		Partials: partials,
+		Block:    true,
+	}, nil
+}
+
+// failureMessage extracts the bare message from a snippet's failure.
+// SourceError.Error() renders for a terminal — ANSI colors plus a quoted
+// source span — but the snippet already sits right above the baked error,
+// and escape codes have no business in HTML. The same unwrap lives in
+// dangLiterateFailEval (cmd/dang-playground) so a client-side replay shows
+// the identical line.
+func failureMessage(err error) string {
+	var srcErr *dang.SourceError
+	if errors.As(err, &srcErr) {
+		return srcErr.Inner.Error()
+	}
+	return err.Error()
+}
+
+// literateFailEval runs source the way literateEval does, but against
+// throwaway forks of the session's scopes: a cloned type scope (declarations
+// land in the discarded child layer) and a sealed child value scope (even
+// reassignments of outer bindings stay local). Failing is the point, and a
+// failing block's partial state is unknowable, so it contributes nothing to
+// the page's chain — the same isolation dangLiterateFailEval
+// (cmd/dang-playground) applies when the page is replayed client-side. It
+// returns the captured output plus the failing stage ("parse" | "type" |
+// "eval") and error; a nil error means the snippet unexpectedly succeeded.
+func literateFailEval(source string, sess *literateSession) (string, string, error) {
+	parsed, err := dang.ParseWithRecovery("literate", []byte(source))
+	if err != nil {
+		return "", "parse", err
+	}
+	file, ok := parsed.(*dang.FileBlock)
+	if !ok {
+		return "", "parse", fmt.Errorf("unexpected parse result")
+	}
+	forms := file.Forms
+
+	typeScope := sess.typeScope.Clone()
+	valueScope := sess.valueScope.Derive(true)
+
+	fresh := hm.NewSimpleFresher()
+	if _, err := dang.InferFormsWithPhases(context.Background(), forms, typeScope, fresh); err != nil {
+		return "", "type", err
+	}
+
+	var out bytes.Buffer
+	ctx := ioctx.StdoutToContext(context.Background(), &out)
+	ctx = ioctx.StderrToContext(ctx, &out)
+
+	for _, node := range forms {
+		if _, err := dang.EvalNode(ctx, valueScope, node); err != nil {
+			return strings.TrimRight(out.String(), "\n"), "eval", err
+		}
+	}
+	return strings.TrimRight(out.String(), "\n"), "", nil
 }
 
 // literateEval parses, type-checks, and evaluates source against the

--- a/docs/go/literate_test.go
+++ b/docs/go/literate_test.go
@@ -2,6 +2,7 @@ package dangdocs
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -76,6 +77,83 @@ func TestCodeBlockLiterateRouting(t *testing.T) {
 	outside := render(plain, "dang", "undefinedNameNeverEvaluated")
 	if outside.Style != booklit.StyleCodeBlock {
 		t.Errorf("dang fence outside scope: style %q, want %q", outside.Style, booklit.StyleCodeBlock)
+	}
+}
+
+// A ```dang-failure fence is required to fail: it bakes the error it raises
+// (labelled like the playground's stage labels), runs against forks of the
+// session so nothing it declares leaks into later fences, and a snippet that
+// succeeds is a build error. Outside a literate scope it stays a plain
+// highlighted block.
+func TestCodeBlockFailureRouting(t *testing.T) {
+	root := &booklit.Section{Path: "failure-routing-test.md"}
+	lit := &booklit.Section{Parent: root}
+	plain := &booklit.Section{Parent: root}
+
+	Plugin{section: lit}.LiterateFences()
+
+	render := func(language, source string) (booklit.Styled, error) {
+		t.Helper()
+		content, err := Plugin{section: lit}.CodeBlock(language, booklit.Preformatted{booklit.String(source)})
+		if err != nil {
+			return booklit.Styled{}, err
+		}
+		styled, ok := content.(booklit.Styled)
+		if !ok {
+			t.Fatalf("CodeBlock(%q, %q) returned %T, want booklit.Styled", language, source, content)
+		}
+		return styled, nil
+	}
+
+	if _, err := render("dang", "let x = 6 * 7"); err != nil {
+		t.Fatalf("seeding session: %v", err)
+	}
+
+	// The failure block sees the session's state (x) and bakes its error.
+	failed, err := render("dang-failure", "x.toUpper")
+	if err != nil {
+		t.Fatalf("dang-failure fence: %v", err)
+	}
+	errPartial := failed.Partials["Error"]
+	if errPartial == nil {
+		t.Fatal("dang-failure fence baked no Error partial")
+	}
+	if got := errPartial.String(); !strings.HasPrefix(got, "Type error: ") {
+		t.Errorf("baked error %q, want a %q prefix matching playground.js's STAGE_LABEL", got, "Type error: ")
+	}
+	if failed.Partials["Value"] != nil {
+		t.Errorf("dang-failure fence baked a Value: %v", failed.Partials["Value"])
+	}
+
+	// Declarations made before the failure stay in the discarded fork.
+	if _, err := render("dang-failure", "let leaked = 1\nleaked.toUpper"); err != nil {
+		t.Fatalf("dang-failure fence with declaration: %v", err)
+	}
+	if _, err := render("dang", "leaked"); err == nil {
+		t.Error("a dang-failure fence's declaration leaked into the session")
+	}
+
+	// The session itself is unharmed: later fences still chain.
+	after, err := render("dang", "x + 1")
+	if err != nil {
+		t.Fatalf("fence after failures: %v", err)
+	}
+	if got := after.Partials["Value"]; got == nil || got.String() != "43" {
+		t.Errorf("fence after failures: Value = %v, want 43", got)
+	}
+
+	// A succeeding snippet in a dang-failure fence fails the build.
+	if _, err := render("dang-failure", "1 + 1"); err == nil {
+		t.Error("dang-failure fence with a succeeding snippet did not error")
+	}
+
+	// Outside a literate scope, dang-failure is just a highlighted block.
+	content, err := Plugin{section: plain}.CodeBlock("dang-failure", booklit.Preformatted{booklit.String("definitely not dang ((")})
+	if err != nil {
+		t.Fatalf("dang-failure outside literate scope: %v", err)
+	}
+	if styled, ok := content.(booklit.Styled); !ok || styled.Style != booklit.StyleCodeBlock {
+		t.Errorf("dang-failure outside literate scope: got %v, want %q", content, booklit.StyleCodeBlock)
 	}
 }
 

--- a/docs/go/render.go
+++ b/docs/go/render.go
@@ -19,15 +19,23 @@ import (
 //
 // Inside a \literate-fences scope (see literate.go) a ```dang fence instead
 // becomes a literate block — evaluated at build time in the page's shared
-// session, output baked in. ```dang-static opts a single fence back out: it
-// highlights (and auto-links) as Dang but is never evaluated, for fragments
-// or intentionally invalid code that would fail the literate build.
+// session, output baked in. ```dang-failure marks a fence that is REQUIRED
+// to fail: it runs against forks of the same session and bakes the error it
+// raises (see DangLiterateFailure). ```dang-static opts a single fence back
+// out: it highlights (and auto-links) as Dang but is never evaluated, for
+// fragments that can't run at all. Outside a literate scope both extra tags
+// just highlight as Dang.
 func (p Plugin) CodeBlock(language string, code booklit.Content, styleName ...string) (booklit.Content, error) {
 	switch language {
 	case "dang":
 		if literateFencesEnabled(p.section) {
 			return p.literateBlock(code, "```dang fence")
 		}
+	case "dang-failure":
+		if literateFencesEnabled(p.section) {
+			return p.literateFailureBlock(code, "```dang-failure fence")
+		}
+		language = "dang"
 	case "dang-static":
 		language = "dang"
 	}

--- a/docs/html/dang-literate.tmpl
+++ b/docs/html/dang-literate.tmpl
@@ -1,9 +1,10 @@
-<div class="dang-literate" data-dang-literate>
+<div class="dang-literate" data-dang-literate{{if .Partial "Error"}} data-dang-literate-failure{{end}}>
 <pre class="dang-literate-fallback">{{.Content | render}}</pre>
-{{- if or (.Partial "Stdout") (.Partial "Value")}}
-<div class="dang-literate-out">
+{{- if or (.Partial "Stdout") (.Partial "Value") (.Partial "Error")}}
+<div class="dang-literate-out{{if .Partial "Error"}} is-error{{end}}">
 {{- with .Partial "Stdout"}}<div class="dang-playground-stdout">{{. | render}}</div>{{end}}
-{{- with .Partial "Value"}}<div class="dang-playground-result">=&gt; {{. | render}}</div>{{end -}}
+{{- with .Partial "Value"}}<div class="dang-playground-result">=&gt; {{. | render}}</div>{{end}}
+{{- with .Partial "Error"}}<div class="dang-playground-error">{{. | render}}</div>{{end -}}
 </div>
 {{- end}}
 </div>

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -111,6 +111,7 @@
           eval: window.dangEval,
           replEval: window.dangReplEval,
           literateEval: window.dangLiterateEval,
+          literateFailEval: window.dangLiterateFailEval,
           replReset: window.dangReplReset,
         });
       };
@@ -857,7 +858,26 @@
               b.out.classList.add("is-stale");
               return;
             }
-            var res = dang.literateEval(sessionId, b.editor.value.replace(/\s+$/, ""));
+            var source = b.editor.value.replace(/\s+$/, "");
+            if (b.expectFailure) {
+              // Expected-failure blocks (```dang-failure) evaluate against
+              // throwaway forks of the session, so they never poison the
+              // chain: the error is their output, and even an (unexpected)
+              // success contributes no state.
+              var fres = dang.literateFailEval(sessionId, source);
+              if (fres.ok) {
+                renderReplOutput(b.out, {
+                  ok: false, stage: "", value: "", output: fres.output,
+                  error: "expected this block to fail, but it succeeded" +
+                    (fres.value !== "" ? " with => " + fres.value : ""),
+                });
+              } else {
+                renderReplOutput(b.out, fres);
+              }
+              b.out.classList.remove("is-stale");
+              return;
+            }
+            var res = dang.literateEval(sessionId, source);
             renderReplOutput(b.out, res);
             b.out.classList.remove("is-stale");
             if (!res.ok) failed = true;
@@ -929,7 +949,12 @@
       controls.appendChild(runBtn);
       container.appendChild(controls);
 
-      var entry = { editor: editor, out: out, runBtn: runBtn };
+      var entry = {
+        editor: editor,
+        out: out,
+        runBtn: runBtn,
+        expectFailure: container.hasAttribute("data-dang-literate-failure"),
+      };
       runBtn.addEventListener("click", function () { runChain(entry); });
 
       function rehighlight() {

--- a/docs/lit/language/blocks.md
+++ b/docs/lit/language/blocks.md
@@ -211,7 +211,7 @@ wrinkles:
 
 - an **ordinary nested function** declared inside a block does NOT inherit
   the block's break/continue target — `break`/`continue` there errors
-  `... outside of loop or block-taking call`
+  `... outside of block-taking call`
 - escaped blocks (stored via `&block`, then called after the receiving
   call/function has already returned) error at runtime:
   `break from expired block call` / `return from expired function`

--- a/docs/lit/language/control-flow.md
+++ b/docs/lit/language/control-flow.md
@@ -258,16 +258,18 @@ loop { break 42 } + 1
 
 ## `break` and `continue`
 
-`break` and `continue` are valid only inside a loop or a block-taking call —
-anywhere else they're compile errors (`continue` reports the same way):
+`break` and `continue` are valid only inside a block being passed to a call
+— `.each`, `loop`, a user-defined block-taking function; there is no other
+category, since a `loop` body is just an ordinary block argument. Anywhere
+else they're compile errors (`continue` reports the same way):
 
 ```dang-failure
 break
 ```
 
-`break` exits the nearest enclosing loop or block-taking call, and `break
-value` makes it yield `value` (a bare `break` yields `null`). `.each`
-normally returns its receiver, but a `break` overrides that:
+`break` exits the nearest enclosing block-taking call, and `break value`
+makes it yield `value` (a bare `break` yields `null`). `.each` normally
+returns its receiver, but a `break` overrides that:
 
 ```dang
 [5, 10, 15, 20].each { x => if (x > 12) { break x } }
@@ -290,7 +292,7 @@ let sum = 0
 sum
 ```
 
-Both target the *nearest* enclosing loop or block-call only, and an ordinary
+Both target the *nearest* enclosing block-taking call only, and an ordinary
 function declared inside a block does not inherit that target — a `break`
 there is the same compile error as outside. (More block-specific wrinkles in
 [#blocks].)

--- a/docs/lit/language/control-flow.md
+++ b/docs/lit/language/control-flow.md
@@ -13,7 +13,8 @@ argument — you can do with a conditional or a loop.
 > The examples on this page are live: they share one Dang environment, so
 > later snippets use earlier definitions. Each result is computed and baked
 > in by the docs build — edit a snippet and hit Run ▶ to replay the page in
-> your browser.
+> your browser. Blocks that show an error are *supposed* to fail: the build
+> verifies the failure the same way it verifies the results.
 
 ## Everything is an expression
 
@@ -49,8 +50,12 @@ grouping several expressions into one (see [#blocks]):
 if (ready) { let msg = "on", msg.toUpper } else { "off" }
 ```
 
-The condition must be a `Boolean!` — there is no truthiness. A non-`Boolean`
-condition is a compile error: `condition must be Boolean, got Int!`.
+The condition must be a `Boolean!` — there is no truthiness, and a
+non-`Boolean` condition is a compile error:
+
+```dang-failure
+if (1) "yes" else "no"
+```
 
 `else if` chains aren't special syntax either: the `else` branch is simply
 another `if` expression:
@@ -87,9 +92,8 @@ union instead (see [#flow-typing]). `pet` here is a `Cat! | Dog!`, which
 `case` type patterns will take back apart shortly:
 
 ```dang
-interface Named { name: String! }
-type Cat implements Named { name: String!, lives: Int! = 9 }
-type Dog implements Named { name: String! }
+type Cat { name: String!, lives: Int! = 9 }
+type Dog { name: String! }
 
 let pet = if (grade(95) == "A") Cat(name: "Whiskers") else Dog(name: "Rex")
 ```
@@ -108,10 +112,18 @@ case (1 + 1) {
 }
 ```
 
-Clause bodies must merge to one common type (otherwise: `Case.Infer: clause
-N type mismatch`). And there is **no compile-time exhaustiveness check**:
-when nothing matches and there's no `else`, the `case` raises a runtime
-error, catchable like any other (see [#errors]):
+Clause bodies must merge to one common type:
+
+```dang-failure
+case (1) {
+  1 => "one"
+  2 => 2
+}
+```
+
+And there is **no compile-time exhaustiveness check**: when nothing matches
+and there's no `else`, the `case` raises a runtime error, catchable like any
+other (see [#errors]):
 
 ```dang
 try { case (7) { 1 => "one" } } catch { err => err.message }
@@ -161,23 +173,36 @@ case (pet) {
 }
 ```
 
-The operand must be a union or an interface: on a plain object type the
-pattern is a compile error (`type pattern requires a union or interface
-operand`), as is naming a type that isn't in the union (`type X is not a
-member of union Y`). See [#interfaces-unions].
+The operand must be a union or an interface (see [#interfaces-unions]) — a
+plain object type is already fully known, so there is nothing to narrow:
 
-An interface is itself a valid pattern — a typed catch-all matching any
-implementer, so specific types go first:
+```dang-failure
+case (Cat(name: "Solo")) { c: Cat => c.name }
+```
+
+And the named type must be one of the operand's actual possibilities:
+
+```dang-failure
+case (pet) { s: String => s }
+```
+
+An interface-typed operand works the same way, with patterns checked against
+its implementers — and an interface is itself a valid pattern, a typed
+catch-all matching any implementer, so specific types go first:
 
 ```dang
-label(n: Named!): String! {
-  case (n) {
-    c: Cat => `the cat with ${c.lives} lives`
-    other: Named => `some other ${other.name}`
+interface Sound { noise: String! }
+type Bell implements Sound { noise: String! = "ding" }
+type Horn implements Sound { noise: String! = "honk" }
+
+play(s: Sound!): String! {
+  case (s) {
+    b: Bell => `a bell goes ${b.noise}`
+    other: Sound => `something goes ${other.noise}`
   }
 }
 
-[label(Cat(name: "Maru")), label(Dog(name: "Rex"))]
+[play(Bell), play(Horn)]
 ```
 
 `catch` clauses use these same type patterns, over `Error` implementers —
@@ -233,9 +258,12 @@ loop { break 42 } + 1
 
 ## `break` and `continue`
 
-`break` and `continue` are valid only inside a loop or a block-taking call;
-anywhere else they're compile errors (`break outside of loop or block-taking
-call`, `continue outside of loop or block arg invocation`).
+`break` and `continue` are valid only inside a loop or a block-taking call —
+anywhere else they're compile errors (`continue` reports the same way):
+
+```dang-failure
+break
+```
 
 `break` exits the nearest enclosing loop or block-taking call, and `break
 value` makes it yield `value` (a bare `break` yields `null`). `.each`
@@ -272,9 +300,14 @@ there is the same compile error as outside. (More block-specific wrinkles in
 `return` exits the enclosing function, method, or constructor early — there
 is no `return` for the normal result, since the last expression already is
 the result (see [#functions]). Its value must satisfy the declared return
-type, and outside a function it's a compile error (`return outside of
-function`). It unwinds through any blocks and loops in between, so returning
-from inside `.each` exits the whole function:
+type, and there must be a function to exit:
+
+```dang-failure
+return "early"
+```
+
+It unwinds through any blocks and loops in between, so returning from inside
+`.each` exits the whole function:
 
 ```dang
 firstEven(nums: [Int!]!): Int {

--- a/docs/lit/language/control-flow.md
+++ b/docs/lit/language/control-flow.md
@@ -1,94 +1,314 @@
 \use-plugin{dang}
+\literate-fences
 
 # Control flow {#control-flow}
 
 > Meta: keep `if`, `case`, and `loop` close together — they're all expression-form. The "no statements vs. expressions" point is worth stating once at the top.
 
+Dang has no control-flow *statements*. `if`, `case`, `loop`, and `try` are
+expressions: each yields the last expression of whichever branch ran, so
+anything you can do with a value — bind it, return it, pass it as an
+argument — you can do with a conditional or a loop.
+
+> The examples on this page are live: they share one Dang environment, so
+> later snippets use earlier definitions. Each result is computed and baked
+> in by the docs build — edit a snippet and hit Run ▶ to replay the page in
+> your browser.
+
 ## Everything is an expression
 
-- `if`, `case`, `loop`, `try` all return values
-- the value is the last expression in the chosen branch
-- so they're assignable, returnable, usable as args (see [#blocks])
+All four forms, sitting in expression position as list elements:
+
+```dang
+[
+  if (true) 1 else 2,
+  case { else => 3 },
+  loop { break 4 },
+  try { raise "!" } catch { err => 5 },
+]
+```
+
+The rest of this page covers `if`, `case`, and `loop`, plus the jumps —
+`break`, `continue`, `return` — that cut across them. `try`/`catch`/`raise`
+have their own page: [#errors].
 
 ## `if` / `else`
 
+Each branch of an `if` is a plain expression:
+
 ```dang
-status: String! = if (active) "on" else "off"
+let ready = true
+
+if (ready) "on" else "off"
 ```
 
-- branches are plain expressions; braces aren't part of the `if` syntax — `if (x) { a } else { b }` is just `if`/`else` applied to two blocks (see [#blocks]), useful when a branch needs multiple expressions
-- condition must be `Boolean!` — no truthiness; a non-`Boolean` condition is a compile error (`condition must be Boolean, got Int!`)
-- `else if` chains aren't special syntax either: the `else` branch is just another `if` expression — `if (a) {..} else if (b) {..} else {..}`
-- no-else form returns `null` when the condition is false — result type is nullable (e.g. `if (false) { "value" }` is `null`); `else if` chains with no final `else` are likewise nullable
-- branches must merge to a common type; if they diverge they widen to a union (see [#flow-typing])
-- flow-sensitive narrowings from the condition apply per-branch (then=truthy, else=falsy) — see [#flow-typing]
-- a no-else `if` whose then-branch `return`s does NOT make an enclosing fn non-null (the branch may be skipped → result stays nullable)
+Braces aren't part of the `if` syntax — a braced branch is just a block
+grouping several expressions into one (see [#blocks]):
+
+```dang
+if (ready) { let msg = "on", msg.toUpper } else { "off" }
+```
+
+The condition must be a `Boolean!` — there is no truthiness. A non-`Boolean`
+condition is a compile error: `condition must be Boolean, got Int!`.
+
+`else if` chains aren't special syntax either: the `else` branch is simply
+another `if` expression:
+
+```dang
+grade(score: Int!): String! {
+  if (score >= 90) "A" else if (score >= 80) "B" else "C"
+}
+
+grade(85)
+```
+
+With no `else`, the expression is `null` whenever the condition is false, so
+its type is nullable — and an `else if` chain with no final `else` is
+likewise nullable. (Not even a `return` from the then-branch can undo that;
+see `return` below.)
+
+```dang
+if (false) "value"
+```
+
+Narrowings from the condition apply per branch (then = truthy, else = falsy;
+see [#flow-typing]). Testing `nickname` against `null` is what makes
+`.toUpper` — a `String!` method — safe in the `else` branch:
+
+```dang
+let nickname = "zoe" :: String
+
+if (nickname == null) "anonymous" else nickname.toUpper
+```
+
+Branches must merge to a common type; branches that *diverge* widen to a
+union instead (see [#flow-typing]). `pet` here is a `Cat! | Dog!`, which
+`case` type patterns will take back apart shortly:
+
+```dang
+interface Named { name: String! }
+type Cat implements Named { name: String!, lives: Int! = 9 }
+type Dog implements Named { name: String! }
+
+let pet = if (grade(95) == "A") Cat(name: "Whiskers") else Dog(name: "Rex")
+```
 
 ## `case`
 
+`case` compares an operand against clauses, top to bottom — the first match
+wins, so a duplicate clause (or anything after an early `else`) is simply
+never reached:
+
 ```dang
-case (value) {
+case (1 + 1) {
+  2 => "first match wins"
+  2 => "a duplicate is never reached"
+  else => "no match above"
+}
+```
+
+Clause bodies must merge to one common type (otherwise: `Case.Infer: clause
+N type mismatch`). And there is **no compile-time exhaustiveness check**:
+when nothing matches and there's no `else`, the `case` raises a runtime
+error, catchable like any other (see [#errors]):
+
+```dang
+try { case (7) { 1 => "one" } } catch { err => err.message }
+```
+
+### Value patterns
+
+A value pattern is a literal scalar — an int, float, string, boolean, enum
+value, or `null`:
+
+```dang
+let digit = 2
+
+case (digit) {
   1 => "one"
   2 => "two"
   else => "?"
 }
 ```
 
-- clauses tried top-to-bottom; first match wins (incl. a stray duplicate or an `else` placed before later clauses)
-- clause bodies must merge to a common type (`Case.Infer: clause N type mismatch` otherwise)
-- no compile-time exhaustiveness check: if nothing matches and there's no `else`, it's a runtime error `no case clause matched the value: <v>`
-
-### Value patterns
-
-- literal scalars: ints `1`, floats `3.14`, strings `"foo"`, booleans `true`/`false`, `null`, enum values
-- literal strings/values auto-coerce to the operand's scalar/enum type (e.g. operand `URL!`/an enum, clause `"https://..."`/`"ACTIVE"`) — same coercion as field/arg/return boundaries (see [#enums-scalars])
-- coercion only applies to syntactic literals; a non-literal value whose type differs from the operand is a mismatch (`clause N value type mismatch`)
-
-### Type patterns
+`null` is just another pattern:
 
 ```dang
-case (animal) {
-  c: Cat => c.purr
-  d: Dog => d.bark
+case (null :: Int) {
+  1 => "one"
+  null => "nothing"
 }
 ```
 
-- form is `binding: Type => expr`; the binding is the operand narrowed to `Type` inside that clause
-- operand must be a union or interface (see [#interfaces-unions]); on a plain object it's an error (`type pattern requires a union or interface operand`)
-- the named type must be a member of the union / an implementer of the interface, else `type X is not a member of union Y`
-- an interface itself works as a pattern — matches any implementer (a typed catch-all); place specific types before it
-- also used in `catch` over `Error` subtypes (see [#errors])
+Literal patterns coerce to the operand's scalar or enum type — an operand of
+a custom scalar like `URL!` matches a `"https://…"` clause, an enum operand
+matches `"ACTIVE"` — the same coercion as at argument and return boundaries
+(see [#enums-scalars]). Only *syntactic* literals coerce; a non-literal
+value of a different type is a compile error (`clause N value type
+mismatch`).
+
+### Type patterns
+
+A type pattern has the form `binding: Type => expr`; the binding is the
+operand narrowed to that type inside the clause. Here it takes apart the
+`Cat! | Dog!` union `pet` picked up under `if`/`else` above:
+
+```dang
+case (pet) {
+  c: Cat => `a cat with ${c.lives} lives`
+  d: Dog => `a dog named ${d.name}`
+}
+```
+
+The operand must be a union or an interface: on a plain object type the
+pattern is a compile error (`type pattern requires a union or interface
+operand`), as is naming a type that isn't in the union (`type X is not a
+member of union Y`). See [#interfaces-unions].
+
+An interface is itself a valid pattern — a typed catch-all matching any
+implementer, so specific types go first:
+
+```dang
+label(n: Named!): String! {
+  case (n) {
+    c: Cat => `the cat with ${c.lives} lives`
+    other: Named => `some other ${other.name}`
+  }
+}
+
+[label(Cat(name: "Maru")), label(Dog(name: "Rex"))]
+```
+
+`catch` clauses use these same type patterns, over `Error` implementers —
+see [#errors].
 
 ### Optional operand
 
-- `case { x > 0 => "+", x < 0 => "-", else => "0" }` — omitting the operand desugars to `case (true)`; clauses are `Boolean!` conditions
+Omitting the operand desugars to `case (true)`: each clause is then a
+`Boolean!` condition, making `case` Dang's cond-style conditional chain:
+
+```dang
+let temp = 35
+
+case {
+  temp < 0 => "freezing"
+  temp > 30 => "hot"
+  else => "mild"
+}
+```
 
 ## `loop`
 
+`loop { ... }` is Dang's only loop — and it's a stdlib builtin (see
+[#stdlib]), not a keyword: it calls its block over and over, forever, until
+a `break`, `return`, or `raise` exits it.
+
 ```dang
-let answer = loop { break 42 }   # block-taking builtin; runs until break
+loop { break 42 }
 ```
 
-- `loop { ... }` is Dang's only loop — a stdlib builtin (see [#stdlib]), not a keyword: it calls its block repeatedly forever
-- there is no `for` or `while`; iterate collections with `xs.each { x => ... }` (see [#collections]), and write conditional loops with a mid-body guard: `loop { if (!cond) { break } ... }`
-- exit via `break` / `return` / `raise`; `continue` advances to the next iteration
-- an expression: yields the `break` value (`null` for a bare `break`); the result is non-null when every `break` carries a non-null value, so `loop { break 42 }` is usable directly as `Int!`
+There is no `for` or `while`. Collections are iterated with `.each` and
+friends (see [#collections] and [#blocks]), and a conditional loop is a
+`loop` with a guard at the top:
+
+```dang
+let n = 1
+loop {
+  if (n >= 100) { break }
+  n = n * 2
+}
+
+n
+```
+
+A `loop` is an expression: it yields whatever value its `break` carries.
+When every `break` carries a non-null value the loop's type is non-null too —
+this one is an `Int!`, usable directly in arithmetic — while a bare `break`
+yields `null` and makes it nullable:
+
+```dang
+loop { break 42 } + 1
+```
 
 ## `break` and `continue`
 
-- valid only inside a loop or a block-taking call; otherwise compile error (`break outside of loop or block-taking call` / `continue outside of loop or block arg invocation`)
-- `break` exits; `break value` makes the loop / block-call yield `value`; bare `break` yields `null`
-- `continue` skips to the next iteration; in `.map`, `continue value` inserts `value` into the result (bare `continue` inserts `null`); in `.each` / `loop` it just advances
-- target the nearest enclosing loop or block-call only; an ordinary nested function does NOT inherit the enclosing block's break/continue target (compile error if it tries)
+`break` and `continue` are valid only inside a loop or a block-taking call;
+anywhere else they're compile errors (`break outside of loop or block-taking
+call`, `continue outside of loop or block arg invocation`).
+
+`break` exits the nearest enclosing loop or block-taking call, and `break
+value` makes it yield `value` (a bare `break` yields `null`). `.each`
+normally returns its receiver, but a `break` overrides that:
+
+```dang
+[5, 10, 15, 20].each { x => if (x > 12) { break x } }
+```
+
+`continue` ends the current iteration. In `.map`, `continue value` supplies
+that element's result — so this bare `continue` inserts `null`:
+
+```dang
+[1, 2, 3].map { x => if (x == 2) { continue }, x }
+```
+
+In `.each` and `loop` there is no per-element result, so `continue` just
+advances:
+
+```dang
+let sum = 0
+[1, 2, 3, 4].each { x => if (x % 2 == 1) { continue }, sum += x }
+
+sum
+```
+
+Both target the *nearest* enclosing loop or block-call only, and an ordinary
+function declared inside a block does not inherit that target — a `break`
+there is the same compile error as outside. (More block-specific wrinkles in
+[#blocks].)
 
 ## `return`
 
-- exits the enclosing function / method / constructor early; outside one is a compile error (`return outside of function`)
-- value type must satisfy the function's declared return type
-- unwinds through enclosing blocks and loops (e.g. `return` from inside `.each` exits the whole fn; see [#blocks])
-- a `return` in a skippable branch (e.g. a no-else `if`) does not make the fn non-null
-- `return` is NOT an error and is NOT catchable by `try`/`catch` (see [#errors])
+`return` exits the enclosing function, method, or constructor early — there
+is no `return` for the normal result, since the last expression already is
+the result (see [#functions]). Its value must satisfy the declared return
+type, and outside a function it's a compile error (`return outside of
+function`). It unwinds through any blocks and loops in between, so returning
+from inside `.each` exits the whole function:
+
+```dang
+firstEven(nums: [Int!]!): Int {
+  nums.each { n => if (n % 2 == 0) { return n } }
+  null
+}
+
+firstEven([3, 7, 8, 9])
+```
+
+A `return` in a *skippable* branch — a no-else `if`, say — does not make the
+function non-null. `shout`'s only exit with a value is a `String!`, but the
+branch may be skipped, so its return type stays nullable:
+
+```dang
+shout(word: String): String {
+  if (word != null) { return word.toUpper }
+}
+
+[shout("hey"), shout(null)]
+```
+
+And `return` is not an error: `try`/`catch` cannot intercept it. (`sneaky`
+is a zero-arg function, so referencing it calls it — see [#functions].)
+
+```dang
+sneaky: String! {
+  try { return "returned" } catch { err => `caught: ${err.message}` }
+}
+
+sneaky
+```
 
 ## `try` / `catch` / `raise`
 
-- see [#errors]
+Errors are expressions with the same shape — a `try`/`catch` yields a value,
+and `raise` fits in any branch — but they earn their own page: [#errors].

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -2566,7 +2566,7 @@ func (c *Conditional) Walk(fn func(Node) bool) {
 	}
 }
 
-// Break represents a break statement in a loop or block-taking call.
+// Break represents a break statement in a block-taking call.
 type Break struct {
 	InferredTypeHolder
 	Value      Node
@@ -2599,7 +2599,7 @@ func (b *Break) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.Typ
 	return WithInferErrorHandling(b, func() (hm.Type, error) {
 		target := currentInferBreakTarget(ctx)
 		if target == nil {
-			return nil, NewInferError(fmt.Errorf("break outside of loop or block-taking call"), b)
+			return nil, NewInferError(fmt.Errorf("break outside of block-taking call"), b)
 		}
 		b.Target = target
 		b.TargetKind = target.Kind
@@ -2649,7 +2649,7 @@ func (b *Break) Walk(fn func(Node) bool) {
 	}
 }
 
-// Continue represents a continue statement in a loop or block invocation.
+// Continue represents a continue statement in a block-taking call.
 type Continue struct {
 	InferredTypeHolder
 	Value      Node
@@ -2682,7 +2682,7 @@ func (c *Continue) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (hm.
 	return WithInferErrorHandling(c, func() (hm.Type, error) {
 		target := currentInferContinueTarget(ctx)
 		if target == nil {
-			return nil, NewInferError(fmt.Errorf("continue outside of loop or block arg invocation"), c)
+			return nil, NewInferError(fmt.Errorf("continue outside of block-taking call"), c)
 		}
 		c.Target = target
 		c.TargetKind = target.Kind
@@ -2747,7 +2747,7 @@ func (e *BreakException) Error() string {
 			return "break from expired block call"
 		}
 	}
-	return "break outside of loop or block-taking call"
+	return "break outside of block-taking call"
 }
 
 // ContinueException is used to signal a continue statement.
@@ -2765,7 +2765,7 @@ func (e *ContinueException) Error() string {
 			return "continue from expired block invocation"
 		}
 	}
-	return "continue outside of loop or block arg invocation"
+	return "continue outside of block-taking call"
 }
 
 func breakValueType(br *Break) hm.Type {

--- a/tests/errors/break_outside_control_flow.dang
+++ b/tests/errors/break_outside_control_flow.dang
@@ -1,2 +1,2 @@
-# break is only valid inside a loop or block-taking call
+# break is only valid inside a block-taking call
 break

--- a/tests/errors/continue_outside_control_flow.dang
+++ b/tests/errors/continue_outside_control_flow.dang
@@ -1,2 +1,2 @@
-# continue is only valid inside a loop or block argument
+# continue is only valid inside a block-taking call
 continue

--- a/tests/testdata/break_in_ordinary_function_in_block.golden
+++ b/tests/testdata/break_in_ordinary_function_in_block.golden
@@ -1,4 +1,4 @@
-[1m[31mError:[0m break outside of loop or block-taking call
+[1m[31mError:[0m break outside of block-taking call
   [2m[34m--> errors/break_in_ordinary_function_in_block.dang:4:5[0m
  [2m    |[0m
  [2m  2 | let result = [1].map { x =>[0m

--- a/tests/testdata/break_outside_control_flow.golden
+++ b/tests/testdata/break_outside_control_flow.golden
@@ -1,7 +1,7 @@
-[1m[31mError:[0m break outside of loop or block-taking call
+[1m[31mError:[0m break outside of block-taking call
   [2m[34m--> errors/break_outside_control_flow.dang:2:1[0m
  [2m    |[0m
- [2m  1 | # break is only valid inside a loop or block-taking call[0m
+ [2m  1 | # break is only valid inside a block-taking call[0m
  [2m[34m[1m  2 | [0mbreak
 [2m       [31m^^^^^[0m
  [2m  3 | [0m

--- a/tests/testdata/continue_in_ordinary_function_in_block.golden
+++ b/tests/testdata/continue_in_ordinary_function_in_block.golden
@@ -1,4 +1,4 @@
-[1m[31mError:[0m continue outside of loop or block arg invocation
+[1m[31mError:[0m continue outside of block-taking call
   [2m[34m--> errors/continue_in_ordinary_function_in_block.dang:4:5[0m
  [2m    |[0m
  [2m  2 | let result = [1].map { x =>[0m

--- a/tests/testdata/continue_outside_control_flow.golden
+++ b/tests/testdata/continue_outside_control_flow.golden
@@ -1,7 +1,7 @@
-[1m[31mError:[0m continue outside of loop or block arg invocation
+[1m[31mError:[0m continue outside of block-taking call
   [2m[34m--> errors/continue_outside_control_flow.dang:2:1[0m
  [2m    |[0m
- [2m  1 | # continue is only valid inside a loop or block argument[0m
+ [2m  1 | # continue is only valid inside a block-taking call[0m
  [2m[34m[1m  2 | [0mcontinue
 [2m       [31m^^^^^^^^[0m
  [2m  3 | [0m


### PR DESCRIPTION
Following the trend from #116's `/blocks` rewrite: every claim on the `/control-flow` page is now a sentence followed by a live ```` ```dang ```` fence demonstrating exactly that claim — blocks sharing one environment, evaluated top to bottom by the docs build, with each result baked into the page.

The sections thread into each other the way `/blocks` does: `grade()` from the else-if chain picks the `pet` whose divergent `if` branches widen to a `Cat! | Dog!` union, which the `case` type-pattern section later takes back apart.

**New plugin capability: ```` ```dang-failure ```` fences.** A failure fence is a literate block that is *required* to fail: it evaluates in the page's shared session (against throwaway forks — cloned type scope, sealed child value scope — so its partial state never leaks into later blocks) and bakes the error it raises, e.g. `Type error: condition must be Boolean, got Int!`. A snippet that succeeds fails the build, so error examples are as rot-proof as passing ones. The wasm module gains `dangLiterateFailEval` with the same isolation, keeping client-side Run replays in lockstep with the baked output. Six error claims on the page use it: the non-Boolean condition, the `case` clause type mismatch, the type pattern on a plain object operand, the non-member union pattern, `break` outside a loop, and `return` outside a function.

The one *runtime* error fact — no exhaustiveness check — runs live inside a `try`/`catch` instead, so the page bakes the real `no case clause matched the value: 7` message while also demonstrating that the error is catchable.

Writing the non-member failure fence surfaced a subtlety: when both pet types implemented a shared interface, the divergent `if` merged to the interface rather than widening to a union (the baked message flipped to `does not implement interface Named`). So the union story keeps plain `Cat`/`Dog`, and the interface-pattern story gets its own demo (`Sound`/`Bell`/`Horn`) whose operand is genuinely interface-typed — with the bonus that `play(Bell)` shows zero-arg constructor auto-call.

Every fact from the old bullet outline is preserved and demonstrated: the nullable no-else `if`, per-branch narrowing, first-match-wins (shown with a duplicate clause), `null` as a value pattern, literal scalar/enum coercion, the optional operand, `loop` as a stdlib builtin with the guard-at-top idiom, `break`/`continue` yield rules across `.map`/`.each`/`loop`, `return` unwinding through blocks, the skippable-branch nullability rule, and `return` being uncatchable — the last demonstrated by a `try` that fails to intercept it.

The title anchor (`{#control-flow}`), Meta note, and heading structure are unchanged; no other page links into sub-anchors. Verified by a full docs build rendering the expected values and errors, plus new plugin tests covering the failure-fence routing, session isolation, and the build error on an unexpectedly-succeeding snippet.

**Follow-up: `break`/`continue` messages no longer mention loops.** With `loop` being just a stdlib builtin, a loop body is an ordinary block argument — the control-frame machinery never had a loop case, only the message strings did. `break outside of loop or block-taking call` and `continue outside of loop or block arg invocation` (which also disagreed with each other) both become `… outside of block-taking call`. Goldens regenerated; docs prose, the page's failure fence, and the in-repo skill reference updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
