### PR TITLE
feat: add mapEntries to collect map values as a list

### DIFF
--- a/docs/lit/data/collections.md
+++ b/docs/lit/data/collections.md
@@ -98,6 +98,7 @@ are always `String!`; only the value type is parameterized.
 ### Transform and iterate
 
 - `m.map { key, value => f(key, value) }` — transforms values, preserves keys → `Map[b]!`
+- `m.mapEntries { key, value => f(key, value) }` — collects each entry into a single list element → `[b]!`
 - `m.each { key, value => ... }` — iterates in insertion order, returns the original map (for chaining)
 
 > Note: maps are equal when they hold the same entries, regardless of insertion

--- a/pkg/dang/stdlib.go
+++ b/pkg/dang/stdlib.go
@@ -1136,6 +1136,44 @@ func registerStdlib() {
 			}
 			return MapValue{Keys: append([]string{}, m.Keys...), Entries: entries, ValType: resultValType}, nil
 		})
+
+	// Map.mapEntries method: mapEntries(fn: \(String!, a) -> b) -> [b]!
+	Method(MapTypeModule, "mapEntries").
+		Doc("returns a list with each entry transformed into a single element by the block").
+		Example(`["a": 1, "b": 2].mapEntries { key, value => `+"`${key}=${value}`"+` }`).
+		Block(hm.NewFnType(
+			NewRecordType("", Keyed[*hm.Scheme]{
+				Key:   "key",
+				Value: hm.NewScheme(nil, NonNull(StringType)),
+			}, Keyed[*hm.Scheme]{
+				Key:   "value",
+				Value: hm.NewScheme(nil, TypeVar('a')),
+			}),
+			TypeVar('b'),
+		)).
+		Returns(NonNull(ListOf(TypeVar('b')))).
+		Impl(func(ctx context.Context, self Value, args Args) (Value, error) {
+			m := self.(MapValue)
+			if args.Block == nil {
+				return nil, fmt.Errorf("mapEntries requires a block argument")
+			}
+			fn := *args.Block
+			fnType, ok := fn.Type().(*hm.FunctionType)
+			if !ok {
+				return nil, fmt.Errorf("mapEntries expects a function type, got %T", fn.Type())
+			}
+			resultElemType := fnType.ReturnType()
+
+			result := make([]Value, 0, len(m.Keys))
+			for _, k := range m.Keys {
+				res, err := callFunc(ctx, fn, StringValue{Val: k}, m.Entries[k])
+				if err != nil {
+					return nil, fmt.Errorf("mapEntries block: %w", err)
+				}
+				result = append(result, res)
+			}
+			return ListValue{Elements: result, ElemType: resultElemType}, nil
+		})
 }
 
 // callFunc calls a function with the given values as arguments.

--- a/tests/test_maps.dang
+++ b/tests/test_maps.dang
@@ -73,6 +73,14 @@ assert { doubled == ["a": 2, "b": 4, "c": 6] }
 let labeled = counts.map { key, value => `${key}=${value}` }
 assert { labeled["a"] == "a=1" }
 
+# mapEntries collects each entry into a single list element
+let pairs = counts.mapEntries { key, value => `${key}=${value}` }
+assert { pairs == ["a=1", "b=2", "c=3"] }
+
+# mapEntries can produce any element type
+let sums = ["a": 1, "b": 2].mapEntries { key, value => value + 10 }
+assert { sums == [11, 12] }
+
 # each iterates in insertion order and returns the original map
 let seen: List[String!] = []
 counts.each { key, value => seen = seen + [key] }


### PR DESCRIPTION
It allows mapping both keys and values to a list.

Example:

```
["log-level": "debug"].mapEntries{ key, value => `--${key}=${value}`}
```