### PR TITLE
docs: brace non-trivial if expressions

### DIFF
--- a/docs/lit/language/control-flow.md
+++ b/docs/lit/language/control-flow.md
@@ -95,7 +95,11 @@ union instead (see [#flow-typing]). `pet` here is a `Cat! | Dog!`, which
 type Cat { name: String!, lives: Int! = 9 }
 type Dog { name: String! }
 
-let pet = if (grade(95) == "A") Cat(name: "Whiskers") else Dog(name: "Rex")
+let pet = if (grade(95) == "A") {
+  Cat(name: "Whiskers")
+} else {
+  Dog(name: "Rex")
+}
 ```
 
 ## `case`

--- a/docs/lit/language/errors.md
+++ b/docs/lit/language/errors.md
@@ -48,7 +48,11 @@ the caller's `catch`:
 
 ```dang
 halve(n: Int!): Int! {
-  if (n % 2 == 0) n / 2 else raise `${n} is odd`
+  if (n % 2 == 0) {
+    n / 2
+  } else {
+    raise `${n} is odd`
+  }
 }
 
 [halve(10), try { halve(7) } catch { err => 0 }]
@@ -146,9 +150,13 @@ type ValidationError implements Error {
 }
 
 lookup(id: Int!): String! {
-  if (id <= 0) raise ValidationError(message: "id must be positive", field: "id")
-  else if (id > 100) raise NotFoundError(message: `no user ${id}`, resource: "User")
-  else `user-${id}`
+  if (id <= 0) {
+    raise ValidationError(message: "id must be positive", field: "id")
+  } else if (id > 100) {
+    raise NotFoundError(message: `no user ${id}`, resource: "User")
+  } else {
+    `user-${id}`
+  }
 }
 
 lookup(7)


### PR DESCRIPTION
The recent literate docs rewrite dropped the braces around `if` branches almost everywhere, including multi-line `else if` chains and branches that `raise` or construct values. That went a little too far — without braces those forms were hard to follow.

This restores **multiline-indent braces** wherever a branch does real work, while keeping the braceless form only for trivial single-line conditionals whose branches are bare literals (e.g. `if (ready) "on" else "off"`). The brace style matches `dang fmt`'s canonical output (`} else {`, body indented).

Converted to braces:

- `language/errors.md` — `halve` (the `else raise` example)
- `language/errors.md` — `lookup` (the multi-line `if`/`else if`/`else` chain of raises)
- `language/control-flow.md` — `let pet = …` (two constructor calls)

The changes are purely cosmetic — each snippet was re-checked to parse and evaluate to the same value, so the baked-in results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
