### PR TITLE
lang: file-scope imports in single-file modules

### DIFF
--- a/pkg/dang/env_test.go
+++ b/pkg/dang/env_test.go
@@ -292,7 +292,15 @@ type Directory {
 }
 `)
 
-	daggerVal, found := requireEvalGet(t, env, "Dagger")
+	// Imports are file-scoped, so the Dagger namespace is not a binding on the
+	// returned module scope; reach it through a local type's captured closure,
+	// which still sees the file's imports.
+	testVal, found := requireEvalGet(t, env, "TestShadowing")
+	require.True(t, found)
+	testCtor, ok := testVal.(*ConstructorFunction)
+	require.True(t, ok)
+
+	daggerVal, found := requireEvalGet(t, testCtor.Closure, "Dagger")
 	require.True(t, found)
 	daggerMod, ok := daggerVal.(*Object)
 	require.True(t, ok)
@@ -321,11 +329,6 @@ type Directory {
 	directoryCtor, ok := directoryVal.(*ConstructorFunction)
 	require.True(t, ok)
 	require.NotSame(t, importedDirectory, directoryCtor.ObjectType)
-
-	testVal, found := requireEvalGet(t, env, "TestShadowing")
-	require.True(t, found)
-	testCtor, ok := testVal.(*ConstructorFunction)
-	require.True(t, ok)
 
 	localScheme, found := testCtor.ObjectType.LocalSchemeOf("makeLocal")
 	require.True(t, found)
@@ -463,6 +466,64 @@ fromB: String! = container.value
 	_, err := RunDir(ctx, dir, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "container")
+}
+
+// importingTypeModule writes a module whose Widget type, declared in a file that
+// imports Dagger, references the imported namespace. multiFile controls whether
+// the module is single- or multi-file.
+func importingTypeModule(t *testing.T, ctx context.Context, multiFile bool) ValueScope {
+	t.Helper()
+	dir := t.TempDir()
+	if multiFile {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.dang"), []byte(`
+pub mainThing: String! = "hi"
+`), 0o600))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "widget.dang"), []byte(`
+import Dagger
+
+type Widget {
+  pub make: Dagger.Container! { Dagger.container }
+}
+`), 0o600))
+	env, err := RunDir(ctx, dir, false)
+	require.NoError(t, err)
+	return env
+}
+
+// TestRunDirImportsFileLocalReachableViaClosure is the regression test for
+// dagger#13440: imports are file-scoped (absent from the returned module scope),
+// but each type's constructor captures its file's composite scope as Closure, so
+// imported symbols remain resolvable there. Dagger relies on this to evaluate
+// directive arguments like @cache(policy: FunctionCachePolicy.Never). Single- and
+// multi-file modules must behave identically.
+func TestRunDirImportsFileLocalReachableViaClosure(t *testing.T) {
+	for _, multiFile := range []bool{false, true} {
+		name := "single-file"
+		if multiFile {
+			name = "multi-file"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := ContextWithImportConfigs(context.Background(), ImportConfig{
+				Name:   "Dagger",
+				Schema: schemaWithCoreShadowTypes(),
+			})
+			env := importingTypeModule(t, ctx, multiFile)
+
+			// Imports are file-scoped: the Dagger namespace must not leak into
+			// the returned module scope.
+			_, found := requireEvalGet(t, env, "Dagger")
+			require.False(t, found, "imported Dagger namespace must not leak into the module scope")
+
+			// But the owning type's constructor Closure still resolves it.
+			widgetVal, found := requireEvalGet(t, env, "Widget")
+			require.True(t, found)
+			widgetCtor, ok := widgetVal.(*ConstructorFunction)
+			require.True(t, ok)
+			_, found = requireEvalGet(t, widgetCtor.Closure, "Dagger")
+			require.True(t, found, "constructor Closure should still see the file's imports")
+		})
+	}
 }
 
 func TestRunDirMultipleFilesCanImportSameSchema(t *testing.T) {

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -2295,15 +2295,13 @@ func RunDir(ctx context.Context, dirPath string, isDebug bool) (ValueScope, erro
 // scoping. Phases run in lockstep across files so cross-file references resolve
 // regardless of file order.
 //
-// A single-file directory has no sibling to leak imports to, so its forms are
-// evaluated directly against valueScope — the imports end up reachable from the
-// returned env, which is what callers like RunDir's single-file tests rely on.
+// Imports are file-scoped regardless of file count: even a single-file directory
+// installs its imports into a per-file env rather than the returned valueScope,
+// so `import` consistently means "this file imports X" and imported symbols never
+// leak into the module scope. Each declaration still captures its file's composite
+// scope (e.g. via ConstructorFunction.Closure), so directive arguments and method
+// bodies that reference imported symbols continue to resolve.
 func evaluateDirectoryFiles(ctx context.Context, blocks []*FileBlock, valueScope ValueScope) error {
-	if len(blocks) == 1 {
-		_, err := EvaluateFormsWithPhases(ctx, blocks[0].Forms, valueScope)
-		return err
-	}
-
 	type fileEvalScope struct {
 		classified ClassifiedForms
 		scope      ValueScope


### PR DESCRIPTION
## What

Make `import` consistently file-scoped in `RunDir`, regardless of how many `.dang` files a directory contains.

## Why

`evaluateDirectoryFiles` special-cased single-file directories: it evaluated their forms directly against the returned module scope, so a file's `import`s leaked into that scope. Multi-file directories instead install each file's imports into a per-file env, keeping imported symbols file-local. The two paths disagreed on whether `import` is file- or module-scoped, which is surprising and was the root cause behind [dagger#13440](https://github.com/dagger/dagger/issues/13440): a `@cache(policy: FunctionCachePolicy.Never)` directive argument resolved fine when the type was the only file (imports leaked in) but failed in a multi-file module (imports stayed file-local and the module scope Dagger evaluates directive args against couldn't see the enum).

## How

Drop the single-file special case so every directory goes through the per-file path. Imported symbols never appear in the returned module scope now, in single- and multi-file modules alike. Each declaration still captures its file's composite scope (e.g. via `ConstructorFunction.Closure`), so directive arguments and method bodies that reference imported symbols continue to resolve — verified by the new `TestRunDirImportsFileLocalReachableViaClosure`, which asserts identical behavior for single- and multi-file modules.

One existing test (`TestRunDirDeclarationsShadowImportedTypes`) reached the `Dagger` namespace through the leaked module-scope binding; it now reaches it through a local type's closure, matching the new semantics.

This is the consistency half of dagger#13440. The Dagger-side fix that actually unblocks the bug (evaluating directive args against the owning type's closure) is independent and does not require a release of this change.
