### PR TITLE
stdlib: restore removed conversion fns as @deprecated

### DIFF
--- a/docs/go/stdlib.go
+++ b/docs/go/stdlib.go
@@ -175,6 +175,12 @@ func (p Plugin) stdlibModule(defs []dang.BuiltinDef, prefix, key, qualifier stri
 			cardPartials["Example"] = p.exampleRepl(d.Example)
 		}
 
+		// A deprecated builtin gets a right-aligned "@deprecated" badge in its
+		// card header, linking to the replacement's own card when one is known.
+		if d.Deprecated != "" {
+			cardPartials["Deprecated"] = p.deprecatedBadge(d.Replacement)
+		}
+
 		cards = append(cards, booklit.Styled{
 			Style:    "stdlib-entry",
 			Block:    true,
@@ -215,6 +221,39 @@ func (p Plugin) stdlibModule(defs []dang.BuiltinDef, prefix, key, qualifier stri
 
 func stdlibTag(key, name string) string {
 	return "stdlib-" + key + "-" + name
+}
+
+// deprecatedBadge renders the "@deprecated" marker shown on a deprecated
+// builtin's card header. When replacement names a superseding callable, it is
+// appended as a link to that entry's own card (resolved by tag, so it works
+// across the page's module sections).
+func (p Plugin) deprecatedBadge(replacement string) booklit.Content {
+	badge := booklit.Sequence{booklit.String("@deprecated")}
+	if replacement != "" {
+		badge = append(badge,
+			booklit.String(" → "),
+			&booklit.Reference{
+				Section: p.section,
+				TagName: replacementTag(replacement),
+				Content: booklit.Styled{
+					Style:   booklit.StyleVerbatim,
+					Content: booklit.String(replacement),
+				},
+			},
+		)
+	}
+	return badge
+}
+
+// replacementTag maps a replacement callable name to the anchor tag of its
+// stdlib card. A qualified name like "JSON.encode" or "String.toBase64" splits
+// into the section key and member ("JSON"/"encode"); a bare name is a top-level
+// function, whose cards use the "fn" key.
+func replacementTag(replacement string) string {
+	if i := strings.LastIndex(replacement, "."); i >= 0 {
+		return stdlibTag(replacement[:i], replacement[i+1:])
+	}
+	return stdlibTag("fn", replacement)
 }
 
 // exampleRepl renders a builtin's example as a pre-seeded, runnable REPL. The

--- a/docs/go/stdlib.go
+++ b/docs/go/stdlib.go
@@ -231,7 +231,7 @@ func (p Plugin) deprecatedBadge(replacement string) booklit.Content {
 	badge := booklit.Sequence{booklit.String("@deprecated")}
 	if replacement != "" {
 		badge = append(badge,
-			booklit.String(" → "),
+			booklit.String(" => "),
 			&booklit.Reference{
 				Section: p.section,
 				TagName: replacementTag(replacement),

--- a/docs/go/stdlib_test.go
+++ b/docs/go/stdlib_test.go
@@ -1,0 +1,63 @@
+package dangdocs
+
+import (
+	"testing"
+
+	"github.com/vito/booklit"
+)
+
+func TestReplacementTag(t *testing.T) {
+	cases := map[string]string{
+		"JSON.encode":     "stdlib-JSON-encode",
+		"JSON.decode":     "stdlib-JSON-decode",
+		"YAML.decode":     "stdlib-YAML-decode",
+		"String.toBase64": "stdlib-String-toBase64",
+		"loop":            "stdlib-fn-loop", // bare name => top-level function card
+	}
+	for replacement, want := range cases {
+		if got := replacementTag(replacement); got != want {
+			t.Errorf("replacementTag(%q) = %q, want %q", replacement, got, want)
+		}
+	}
+}
+
+func TestDeprecatedBadgeLinksReplacement(t *testing.T) {
+	var p Plugin
+
+	// With a replacement, the badge appends a reference to the replacement's card.
+	badge := p.deprecatedBadge("JSON.encode")
+	seq, ok := badge.(booklit.Sequence)
+	if !ok {
+		t.Fatalf("expected a Sequence, got %T", badge)
+	}
+	var ref *booklit.Reference
+	for _, c := range seq {
+		if r, isRef := c.(*booklit.Reference); isRef {
+			ref = r
+		}
+	}
+	if ref == nil {
+		t.Fatalf("badge has no reference to the replacement: %#v", seq)
+	}
+	if ref.TagName != "stdlib-JSON-encode" {
+		t.Errorf("reference tag = %q, want %q", ref.TagName, "stdlib-JSON-encode")
+	}
+	if ref.Content.String() != "JSON.encode" {
+		t.Errorf("reference display = %q, want %q", ref.Content.String(), "JSON.encode")
+	}
+
+	// Without a replacement, it is just the plain marker — no link.
+	bare := p.deprecatedBadge("")
+	bareSeq, ok := bare.(booklit.Sequence)
+	if !ok {
+		t.Fatalf("expected a Sequence, got %T", bare)
+	}
+	for _, c := range bareSeq {
+		if _, isRef := c.(*booklit.Reference); isRef {
+			t.Errorf("badge with no replacement should not contain a reference: %#v", bareSeq)
+		}
+	}
+	if bareSeq.String() != "@deprecated" {
+		t.Errorf("bare badge = %q, want %q", bareSeq.String(), "@deprecated")
+	}
+}

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -296,6 +296,11 @@ td{padding:.4rem .6rem;border-bottom:1px solid var(--td-border)}
 .stdlib-sig-prefix{padding:.5rem 0 .5rem .8rem;font-size:.82rem;white-space:pre;font-family:'JetBrains Mono',monospace;opacity:.65}
 .stdlib-sig-prefix+code{padding-left:0}
 .stdlib-sig:hover{border-left-color:var(--accent2)}
+/* Right-aligned "@deprecated" badge in a card header. The signature <code> takes
+   flex:1, so the badge sits flush against the right edge of the bar. */
+.stdlib-deprecated{flex:none;align-self:stretch;display:flex;align-items:center;gap:.3rem;padding:.5rem .7rem;font-size:.72rem;font-family:'JetBrains Mono',monospace;white-space:nowrap;color:var(--orange);background:var(--bg2);border-left:1px solid var(--code-border)}
+.stdlib-deprecated a{color:var(--accent2);text-decoration:none}
+.stdlib-deprecated a:hover{text-decoration:underline}
 .stdlib-entry>a[id]:target+.stdlib-sig{border-left-color:var(--accent2);box-shadow:0 0 0 2px var(--accent2)}
 .stdlib-desc{color:var(--fg);font-size:.9rem;margin:.4rem 0 0 .85rem}
 /* A runnable example: a syntax-highlighted snippet with a Run bar that upgrades

--- a/docs/html/page.tmpl
+++ b/docs/html/page.tmpl
@@ -298,7 +298,8 @@ td{padding:.4rem .6rem;border-bottom:1px solid var(--td-border)}
 .stdlib-sig:hover{border-left-color:var(--accent2)}
 /* Right-aligned "@deprecated" badge in a card header. The signature <code> takes
    flex:1, so the badge sits flush against the right edge of the bar. */
-.stdlib-deprecated{flex:none;align-self:stretch;display:flex;align-items:center;gap:.3rem;padding:.5rem .7rem;font-size:.72rem;font-family:'JetBrains Mono',monospace;white-space:nowrap;color:var(--orange);background:var(--bg2);border-left:1px solid var(--code-border)}
+.stdlib-deprecated{flex:none;align-self:stretch;display:flex;align-items:center;gap:.3rem;padding:0 0 0 .7rem;font-size:.72rem;font-family:'JetBrains Mono',monospace;white-space:nowrap;color:var(--orange);background:var(--bg2);border-left:1px solid var(--code-border)}
+.stdlib-deprecated code{padding-left:0.2rem}
 .stdlib-deprecated a{color:var(--accent2);text-decoration:none}
 .stdlib-deprecated a:hover{text-decoration:underline}
 .stdlib-entry>a[id]:target+.stdlib-sig{border-left-color:var(--accent2);box-shadow:0 0 0 2px var(--accent2)}

--- a/docs/html/stdlib-entry.tmpl
+++ b/docs/html/stdlib-entry.tmpl
@@ -1,6 +1,6 @@
 <div class="stdlib-entry">
   {{- .Partial "Target" | render -}}
-  <div class="stdlib-sig">{{with .Partial "Prefix"}}<span class="stdlib-sig-prefix syntax">{{. | render}}</span>{{end}}{{.Content | render}}</div>
+  <div class="stdlib-sig">{{with .Partial "Prefix"}}<span class="stdlib-sig-prefix syntax">{{. | render}}</span>{{end}}{{.Content | render}}{{with .Partial "Deprecated"}}<span class="stdlib-deprecated">{{. | render}}</span>{{end}}</div>
   {{with .Partial "Description"}}<p class="stdlib-desc">{{. | render}}</p>{{end}}
   {{with .Partial "Example"}}{{. | render}}{{end}}
 </div>

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -319,6 +319,11 @@ func (c *FunCall) Eval(ctx context.Context, scope ValueScope) (Value, error) {
 			return nil, NewSourceError(fmt.Errorf("cannot call null"), c.Fun.GetSourceLocation(), "")
 		}
 
+		// Warn at the call site if the callee is a deprecated builtin.
+		if fn, ok := funVal.(BuiltinFunction); ok && fn.Deprecated != "" {
+			WarnAtSource(ctx, c.Loc, fmt.Sprintf("%s is deprecated: %s", fn.Name, fn.Deprecated))
+		}
+
 		// Evaluate arguments and handle positional/named argument mapping
 		argValues, err := c.evaluateArguments(ctx, scope, funVal)
 		if err != nil {

--- a/pkg/dang/builtins.go
+++ b/pkg/dang/builtins.go
@@ -304,6 +304,13 @@ func (b *BuiltinBuilder) Returns(typ hm.Type) *BuiltinBuilder {
 	return b
 }
 
+// Deprecated marks the function as deprecated. The reason is shown (alongside
+// the call site) when the function is called.
+func (b *BuiltinBuilder) Deprecated(reason string) *BuiltinBuilder {
+	b.def.Deprecated = reason
+	return b
+}
+
 // Impl sets the implementation and registers the builtin
 func (b *BuiltinBuilder) Impl(fn func(context.Context, Args) (Value, error)) {
 	// Wrap to match the internal signature (functions ignore self)
@@ -360,6 +367,13 @@ func (b *MethodBuilder) Returns(typ hm.Type) *MethodBuilder {
 	return b
 }
 
+// Deprecated marks the method as deprecated. The reason is shown (alongside
+// the call site) when the method is called.
+func (b *MethodBuilder) Deprecated(reason string) *MethodBuilder {
+	b.def.Deprecated = reason
+	return b
+}
+
 // Impl sets the implementation and registers the method
 func (b *MethodBuilder) Impl(fn func(context.Context, Value, Args) (Value, error)) {
 	b.def.Impl = fn
@@ -407,6 +421,13 @@ func (b *StaticMethodBuilder) Returns(typ hm.Type) *StaticMethodBuilder {
 	return b
 }
 
+// Deprecated marks the static method as deprecated. The reason is shown
+// (alongside the call site) when the method is called.
+func (b *StaticMethodBuilder) Deprecated(reason string) *StaticMethodBuilder {
+	b.def.Deprecated = reason
+	return b
+}
+
 // Impl sets the implementation and registers the static method
 func (b *StaticMethodBuilder) Impl(fn func(context.Context, Args) (Value, error)) {
 	b.def.Impl = func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -431,6 +452,11 @@ type BuiltinDef struct {
 	// builtin. The docs reference renders it as a pre-seeded, runnable REPL,
 	// and a test evaluates every example to keep them honest.
 	Example string
+	// Deprecated, when non-empty, marks this builtin as the Go-side equivalent
+	// of a @deprecated directive. The string is the human-facing reason
+	// (typically naming the replacement). Calling a deprecated builtin prints a
+	// warning to stderr pointing at the call site; see FunCall.Eval.
+	Deprecated string
 }
 
 // ParamDef defines a parameter with optional default value.
@@ -623,6 +649,7 @@ func attachBuiltinMethods(obj *Object, scalarType TypeScope) {
 			Name:         def.Name,
 			FnType:       createFunctionTypeFromDef(def),
 			AllDefaulted: allParamsDefaulted(def),
+			Deprecated:   def.Deprecated,
 			CallFn: func(ctx context.Context, scope ValueScope, args map[string]Value) (Value, error) {
 				return def.Impl(ctx, nil, Args{Values: applyDefaults(args, def)})
 			},

--- a/pkg/dang/builtins.go
+++ b/pkg/dang/builtins.go
@@ -311,6 +311,14 @@ func (b *BuiltinBuilder) Deprecated(reason string) *BuiltinBuilder {
 	return b
 }
 
+// Replacement names the callee that supersedes this one (e.g. "JSON.encode"),
+// letting tools rewrite a call mechanically. Only meaningful alongside
+// Deprecated.
+func (b *BuiltinBuilder) Replacement(name string) *BuiltinBuilder {
+	b.def.Replacement = name
+	return b
+}
+
 // Impl sets the implementation and registers the builtin
 func (b *BuiltinBuilder) Impl(fn func(context.Context, Args) (Value, error)) {
 	// Wrap to match the internal signature (functions ignore self)
@@ -374,6 +382,13 @@ func (b *MethodBuilder) Deprecated(reason string) *MethodBuilder {
 	return b
 }
 
+// Replacement names the member that supersedes this method, letting tools
+// rewrite a call mechanically. Only meaningful alongside Deprecated.
+func (b *MethodBuilder) Replacement(name string) *MethodBuilder {
+	b.def.Replacement = name
+	return b
+}
+
 // Impl sets the implementation and registers the method
 func (b *MethodBuilder) Impl(fn func(context.Context, Value, Args) (Value, error)) {
 	b.def.Impl = fn
@@ -428,6 +443,13 @@ func (b *StaticMethodBuilder) Deprecated(reason string) *StaticMethodBuilder {
 	return b
 }
 
+// Replacement names the member that supersedes this static method, letting
+// tools rewrite a call mechanically. Only meaningful alongside Deprecated.
+func (b *StaticMethodBuilder) Replacement(name string) *StaticMethodBuilder {
+	b.def.Replacement = name
+	return b
+}
+
 // Impl sets the implementation and registers the static method
 func (b *StaticMethodBuilder) Impl(fn func(context.Context, Args) (Value, error)) {
 	b.def.Impl = func(ctx context.Context, self Value, args Args) (Value, error) {
@@ -457,6 +479,10 @@ type BuiltinDef struct {
 	// (typically naming the replacement). Calling a deprecated builtin prints a
 	// warning to stderr pointing at the call site; see FunCall.Eval.
 	Deprecated string
+	// Replacement, when non-empty, names the callee that supersedes this one
+	// (e.g. "JSON.encode"). Unlike the prose in Deprecated, it is structured so
+	// tools can rewrite a call mechanically — the LSP offers it as a quick fix.
+	Replacement string
 }
 
 // ParamDef defines a parameter with optional default value.

--- a/pkg/dang/builtins_test.go
+++ b/pkg/dang/builtins_test.go
@@ -9,23 +9,34 @@ import (
 
 func TestBuiltinRegistryClassifiesDefinitions(t *testing.T) {
 	functionNames := map[string]bool{}
+	functionDefs := map[string]BuiltinDef{}
 	ForEachFunction(func(def BuiltinDef) {
 		if def.IsMethod || def.IsStatic {
 			t.Fatalf("function iterator returned non-function builtin: %+v", def)
 		}
 		functionNames[def.Name] = true
+		functionDefs[def.Name] = def
 	})
 	for _, name := range []string{"print", "toString"} {
 		if !functionNames[name] {
 			t.Fatalf("function %q was not registered", name)
 		}
 	}
-	// encode/decode are static methods on the codec modules, not top-level
-	// functions: keep the precious top-level namespace clear of conversions.
+	// toJSON/fromJSON/fromYAML are restored as deprecated top-level aliases for
+	// their JSON/YAML namespace members so old scripts keep working; each must
+	// carry a deprecation reason so callers get a warning pointing at the new
+	// namespace.
 	for _, name := range []string{"toJSON", "fromJSON", "fromYAML"} {
-		if functionNames[name] {
-			t.Fatalf("%q should no longer be a top-level function", name)
+		if !functionNames[name] {
+			t.Fatalf("%q should be registered as a (deprecated) top-level function", name)
 		}
+		if functionDefs[name].Deprecated == "" {
+			t.Fatalf("%q should be marked deprecated", name)
+		}
+	}
+	// Non-deprecated builtins must not carry a deprecation reason.
+	if functionDefs["print"].Deprecated != "" {
+		t.Fatalf("print should not be marked deprecated")
 	}
 	for _, mod := range []*Type{JSONModule, YAMLModule, TOMLModule} {
 		methods := map[string]bool{}

--- a/pkg/dang/deprecated_test.go
+++ b/pkg/dang/deprecated_test.go
@@ -1,0 +1,32 @@
+package dang
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/vito/dang/v2/pkg/ioctx"
+)
+
+// TestWarnAtSourceDedupesPerCallSite checks that repeated warnings from the same
+// call site (e.g. a deprecated call inside a loop) collapse to one, while a
+// distinct call site warns again.
+func TestWarnAtSourceDedupesPerCallSite(t *testing.T) {
+	var stderr bytes.Buffer
+	ctx := ioctx.StderrToContext(context.Background(), &stderr)
+	ctx = WithEvalContext(ctx, NewEvalContext("main.dang", "a\nb\n"))
+
+	loc := &SourceLocation{Filename: "main.dang", Line: 1, Column: 1, Length: 1}
+	WarnAtSource(ctx, loc, "foo is deprecated: bar")
+	WarnAtSource(ctx, loc, "foo is deprecated: bar")
+	if got := strings.Count(stderr.String(), "Warning:"); got != 1 {
+		t.Errorf("expected 1 warning after dedupe, got %d: %q", got, stderr.String())
+	}
+
+	loc2 := &SourceLocation{Filename: "main.dang", Line: 2, Column: 1, Length: 1}
+	WarnAtSource(ctx, loc2, "foo is deprecated: bar")
+	if got := strings.Count(stderr.String(), "Warning:"); got != 2 {
+		t.Errorf("expected 2 warnings across two call sites, got %d: %q", got, stderr.String())
+	}
+}

--- a/pkg/dang/deprecated_test.go
+++ b/pkg/dang/deprecated_test.go
@@ -3,11 +3,45 @@ package dang
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/vito/dang/v2/pkg/ioctx"
 )
+
+// TestDeprecatedBuiltinWarnsAtCallSite checks that calling a builtin marked
+// .Deprecated(...) (here the restored toJSON) prints a warning to stderr that
+// names the deprecation reason and points at the call site.
+func TestDeprecatedBuiltinWarnsAtCallSite(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.dang")
+	src := "let s = toJSON([1, 2, 3])\n"
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr, stdout bytes.Buffer
+	ctx := ioctx.StderrToContext(context.Background(), &stderr)
+	ctx = ioctx.StdoutToContext(ctx, &stdout)
+
+	if err := RunFile(ctx, file, false); err != nil {
+		t.Fatalf("RunFile: %v", err)
+	}
+
+	out := stderr.String()
+	if !strings.Contains(out, "toJSON is deprecated") {
+		t.Errorf("expected deprecation warning naming toJSON, got: %q", out)
+	}
+	if !strings.Contains(out, "use JSON.encode instead") {
+		t.Errorf("expected replacement hint in warning, got: %q", out)
+	}
+	// The warning must report where toJSON was called from.
+	if !strings.Contains(out, "main.dang:1:") {
+		t.Errorf("expected call-site location (main.dang:1:...) in warning, got: %q", out)
+	}
+}
 
 // TestWarnAtSourceDedupesPerCallSite checks that repeated warnings from the same
 // call site (e.g. a deprecated call inside a loop) collapse to one, while a

--- a/pkg/dang/errors.go
+++ b/pkg/dang/errors.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/vito/dang/v2/pkg/hm"
+	"github.com/vito/dang/v2/pkg/ioctx"
 )
 
 // SourceLocation represents a location in source code
@@ -107,48 +108,65 @@ func (e *SourceError) FormatWithHighlighting() string {
 		}
 	}
 
-	lines := strings.Split(e.Source, "\n")
-	if e.Location.Line < 1 || e.Location.Line > len(lines) {
+	const red = "\033[31m"
+	out, ok := formatSourceAnnotation(e.Location, e.Source, "Error:", red, e.Inner.Error())
+	if !ok {
 		return e.Inner.Error()
+	}
+	return out
+}
+
+// formatSourceAnnotation renders a source location as a labeled, highlighted
+// snippet — the shared rendering behind both error and warning output. label is
+// the bold colored prefix (e.g. "Error:" / "Warning:") and accent is the ANSI
+// color used for that prefix and the "^^^" underline. It returns ok=false when
+// the location can't be highlighted (no location, or line out of range) so the
+// caller can fall back to a plain message.
+func formatSourceAnnotation(loc *SourceLocation, source, label, accent, message string) (string, bool) {
+	if loc == nil {
+		return "", false
+	}
+
+	lines := strings.Split(source, "\n")
+	if loc.Line < 1 || loc.Line > len(lines) {
+		return "", false
 	}
 
 	// Colors for terminal output
 	const (
-		red    = "\033[31m"
-		yellow = "\033[33m"
-		blue   = "\033[34m"
-		bold   = "\033[1m"
-		reset  = "\033[0m"
-		dim    = "\033[2m"
+		blue  = "\033[34m"
+		bold  = "\033[1m"
+		reset = "\033[0m"
+		dim   = "\033[2m"
 	)
 
 	var result strings.Builder
 
-	// Error header
-	fmt.Fprintf(&result, "%s%sError:%s %s\n", bold, red, reset, e.Inner)
-	fmt.Fprintf(&result, "  %s%s--> %s:%d:%d%s\n", dim, blue, e.Location.Filename, e.Location.Line, e.Location.Column, reset)
+	// Header
+	fmt.Fprintf(&result, "%s%s%s%s %s\n", bold, accent, label, reset, message)
+	fmt.Fprintf(&result, "  %s%s--> %s:%d:%d%s\n", dim, blue, loc.Filename, loc.Line, loc.Column, reset)
 
 	// Top separator pipe (aligned with line numbers)
 	fmt.Fprintf(&result, " %s%s |%s\n", dim, padLeft("", 3), reset)
 
 	// Show context lines
-	startLine := max(1, e.Location.Line-2)
-	endLine := min(len(lines), e.Location.Line+2)
+	startLine := max(1, loc.Line-2)
+	endLine := min(len(lines), loc.Line+2)
 
 	for i := startLine; i <= endLine; i++ {
 		lineStr := fmt.Sprintf("%d", i)
 		paddedLineStr := padLeft(lineStr, 3)
-		if i == e.Location.Line {
-			// Highlight the error line
+		if i == loc.Line {
+			// Highlight the annotated line
 			fmt.Fprintf(&result, " %s%s%s%s | %s%s\n",
 				dim, blue, bold, paddedLineStr, reset, lines[i-1])
 
-			// Add underline for the specific error location
+			// Add underline for the specific location
 			// Calculate padding: 1 space + 3 for line number + " | " (3 chars) + column position - 1
-			padding := strings.Repeat(" ", 1+3+3+e.Location.Column-1)
-			underline := strings.Repeat("^", max(1, e.Location.Length))
+			padding := strings.Repeat(" ", 1+3+3+loc.Column-1)
+			underline := strings.Repeat("^", max(1, loc.Length))
 			fmt.Fprintf(&result, "%s%s%s%s%s\n",
-				dim, padding, red, underline, reset)
+				dim, padding, accent, underline, reset)
 		} else {
 			// Context lines
 			fmt.Fprintf(&result, " %s%s | %s%s\n",
@@ -159,7 +177,7 @@ func (e *SourceError) FormatWithHighlighting() string {
 	// Bottom separator pipe (aligned with line numbers)
 	fmt.Fprintf(&result, " %s%s |%s\n", dim, padLeft("", 3), reset)
 
-	return result.String()
+	return result.String(), true
 }
 
 func padLeft(s string, width int) string {
@@ -173,6 +191,12 @@ func padLeft(s string, width int) string {
 type EvalContext struct {
 	Filename string
 	Source   string
+
+	// warnedDeprecations dedupes deprecation warnings by call site within a
+	// single evaluation run, so calling a deprecated builtin inside a loop warns
+	// once rather than on every iteration. Eval is single-threaded, so no lock is
+	// needed.
+	warnedDeprecations map[string]bool
 }
 
 // Context key for storing EvalContext in Go context
@@ -239,11 +263,55 @@ func WrapInferError(err error, node SourceLocatable) error {
 	return NewInferError(err, node)
 }
 
+// WarnAtSource prints a non-fatal warning to the context's stderr, annotated
+// with the given source location (file:line:col) and a highlighted snippet when
+// the source is available. Warnings are deduped per call site within an
+// evaluation run, so a deprecated call inside a loop warns once. With no stderr
+// wired into the context (the default), this is silent.
+func WarnAtSource(ctx context.Context, loc *SourceLocation, message string) {
+	w := ioctx.StderrFromContext(ctx)
+
+	var source string
+	if evalCtx := GetEvalContext(ctx); evalCtx != nil {
+		if loc != nil && evalCtx.warnedDeprecations != nil {
+			key := fmt.Sprintf("%s:%d:%d", loc.Filename, loc.Line, loc.Column)
+			if evalCtx.warnedDeprecations[key] {
+				return
+			}
+			evalCtx.warnedDeprecations[key] = true
+		}
+		source = evalCtx.Source
+	}
+
+	if source == "" && loc != nil && loc.Filename != "" {
+		if contents, err := os.ReadFile(loc.Filename); err == nil {
+			source = string(contents)
+		}
+	}
+
+	const yellow = "\033[33m"
+	if out, ok := formatSourceAnnotation(loc, source, "Warning:", yellow, message); ok {
+		_, _ = fmt.Fprint(w, out)
+		return
+	}
+
+	// Fall back to a plain one-line warning when we can't highlight a snippet.
+	switch {
+	case loc != nil && loc.Filename != "":
+		_, _ = fmt.Fprintf(w, "Warning: %s (%s:%d:%d)\n", message, loc.Filename, loc.Line, loc.Column)
+	case loc != nil:
+		_, _ = fmt.Fprintf(w, "Warning: %s (%d:%d)\n", message, loc.Line, loc.Column)
+	default:
+		_, _ = fmt.Fprintf(w, "Warning: %s\n", message)
+	}
+}
+
 // NewEvalContext creates a new evaluation context
 func NewEvalContext(filename, source string) *EvalContext {
 	return &EvalContext{
-		Filename: filename,
-		Source:   source,
+		Filename:           filename,
+		Source:             source,
+		warnedDeprecations: map[string]bool{},
 	}
 }
 

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -601,6 +601,7 @@ func addBuiltinFunctions(scope ValueScope) {
 			Name:         def.Name,
 			FnType:       fnType,
 			AllDefaulted: allParamsDefaulted(def),
+			Deprecated:   def.Deprecated,
 			CallFn: func(ctx context.Context, scope ValueScope, args map[string]Value) (Value, error) {
 				// Apply defaults for missing arguments
 				argsWithDefaults := applyDefaults(args, def)
@@ -627,6 +628,7 @@ func addBuiltinFunctions(scope ValueScope) {
 				Name:         def.Name,
 				FnType:       fnType,
 				AllDefaulted: allParamsDefaulted(def),
+				Deprecated:   def.Deprecated,
 				CallFn: func(ctx context.Context, scope ValueScope, args map[string]Value) (Value, error) {
 					selfVal, _ := scope.Self()
 					// Apply defaults for missing arguments
@@ -657,6 +659,7 @@ func addBuiltinFunctions(scope ValueScope) {
 				Name:         def.Name,
 				FnType:       fnType,
 				AllDefaulted: allParamsDefaulted(def),
+				Deprecated:   def.Deprecated,
 				CallFn: func(ctx context.Context, scope ValueScope, args map[string]Value) (Value, error) {
 					argsWithDefaults := applyDefaults(args, def)
 					return def.Impl(ctx, nil, Args{Values: argsWithDefaults})
@@ -1681,6 +1684,9 @@ type BuiltinFunction struct {
 	FnType       *hm.FunctionType
 	CallFn       func(ctx context.Context, scope ValueScope, args map[string]Value) (Value, error)
 	AllDefaulted bool // true when every parameter has a default value
+	// Deprecated, when non-empty, is the reason this builtin is deprecated.
+	// FunCall.Eval emits a warning naming the call site whenever it is called.
+	Deprecated string
 }
 
 func (b BuiltinFunction) Type() hm.Type {

--- a/pkg/dang/stdlib_codec.go
+++ b/pkg/dang/stdlib_codec.go
@@ -63,6 +63,41 @@ func registerCodecs() {
 			return DeferredValue{Raw: raw, Codec: jsonCodec}, nil
 		})
 
+	// toJSON / fromJSON / fromYAML are the deprecated top-level predecessors of
+	// the JSON.encode / JSON.decode / YAML.decode namespace members, kept so
+	// existing scripts keep working. They are marked @deprecated via the builtin
+	// DSL; calling one prints a warning pointing at the call site (see
+	// FunCall.Eval / WarnAtSource). Each delegates to the same implementation as
+	// its namespaced successor, so they honor codec field directives identically.
+	// (There was never a top-level toYAML/toTOML/fromTOML to restore.)
+	Builtin("toJSON").
+		Doc("serializes a value to a JSON string. Deprecated: use JSON.encode instead.").
+		Deprecated("use JSON.encode instead").
+		Example(`toJSON([1, 2, 3])`).
+		Params("value", TypeVar('a')).
+		Returns(NonNull(StringType)).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			val, _ := args.Get("value")
+			out, err := encodeJSON(val)
+			if err != nil {
+				return nil, fmt.Errorf("toJSON: %w", err)
+			}
+			return ToValue(out)
+		})
+	Builtin("fromJSON").
+		Doc("parses a JSON string into an opaque value that is materialized by an expected type. Deprecated: use JSON.decode instead.").
+		Deprecated("use JSON.decode instead").
+		Example(`fromJSON("[1, 2, 3]") :: [Int!]!`).
+		Params("data", NonNull(StringType)).
+		Returns(TypeVar('a')).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			raw, err := decodeJSON(args.GetString("data"))
+			if err != nil {
+				return nil, fmt.Errorf("fromJSON: %w", err)
+			}
+			return DeferredValue{Raw: raw, Codec: jsonCodec}, nil
+		})
+
 	YAMLModule.SetTypeDocString("functions for encoding and decoding YAML")
 	StaticMethod(YAMLModule, "encode").
 		Doc("serializes a value to a YAML string").
@@ -86,6 +121,19 @@ func registerCodecs() {
 			raw, err := decodeYAMLRaw(args.GetString("data"))
 			if err != nil {
 				return nil, fmt.Errorf("YAML.decode: %w", err)
+			}
+			return DeferredValue{Raw: raw, Codec: yamlCodec}, nil
+		})
+	Builtin("fromYAML").
+		Doc("parses a YAML string into an opaque value that is materialized by an expected type. Deprecated: use YAML.decode instead.").
+		Deprecated("use YAML.decode instead").
+		Example(`fromYAML("[a, b, c]") :: [String!]!`).
+		Params("data", NonNull(StringType)).
+		Returns(TypeVar('a')).
+		Impl(func(ctx context.Context, args Args) (Value, error) {
+			raw, err := decodeYAMLRaw(args.GetString("data"))
+			if err != nil {
+				return nil, fmt.Errorf("fromYAML: %w", err)
 			}
 			return DeferredValue{Raw: raw, Codec: yamlCodec}, nil
 		})

--- a/pkg/dang/stdlib_codec.go
+++ b/pkg/dang/stdlib_codec.go
@@ -73,6 +73,7 @@ func registerCodecs() {
 	Builtin("toJSON").
 		Doc("serializes a value to a JSON string. Deprecated: use JSON.encode instead.").
 		Deprecated("use JSON.encode instead").
+		Replacement("JSON.encode").
 		Example(`toJSON([1, 2, 3])`).
 		Params("value", TypeVar('a')).
 		Returns(NonNull(StringType)).
@@ -87,6 +88,7 @@ func registerCodecs() {
 	Builtin("fromJSON").
 		Doc("parses a JSON string into an opaque value that is materialized by an expected type. Deprecated: use JSON.decode instead.").
 		Deprecated("use JSON.decode instead").
+		Replacement("JSON.decode").
 		Example(`fromJSON("[1, 2, 3]") :: [Int!]!`).
 		Params("data", NonNull(StringType)).
 		Returns(TypeVar('a')).
@@ -127,6 +129,7 @@ func registerCodecs() {
 	Builtin("fromYAML").
 		Doc("parses a YAML string into an opaque value that is materialized by an expected type. Deprecated: use YAML.decode instead.").
 		Deprecated("use YAML.decode instead").
+		Replacement("YAML.decode").
 		Example(`fromYAML("[a, b, c]") :: [String!]!`).
 		Params("data", NonNull(StringType)).
 		Returns(TypeVar('a')).

--- a/pkg/lsp/ast_query.go
+++ b/pkg/lsp/ast_query.go
@@ -31,6 +31,20 @@ func positionWithinNode(node dang.Node, pos Position) bool {
 		(pos.Line < endLine || (pos.Line == endLine && pos.Character <= endCol))
 }
 
+// positionAfter reports whether p comes strictly after q in a document.
+func positionAfter(p, q Position) bool {
+	if p.Line != q.Line {
+		return p.Line > q.Line
+	}
+	return p.Character > q.Character
+}
+
+// rangesOverlap reports whether two ranges intersect. Touching endpoints count
+// as overlapping, so a zero-width cursor at either edge of a range matches.
+func rangesOverlap(a, b Range) bool {
+	return !positionAfter(a.Start, b.End) && !positionAfter(b.Start, a.End)
+}
+
 // findEnclosingEnvironments walks the AST and collects all environments that enclose the given position.
 // Returns environments from outermost to innermost.
 func findEnclosingEnvironments(root dang.Node, pos Position) []dang.TypeScope {

--- a/pkg/lsp/deprecations.go
+++ b/pkg/lsp/deprecations.go
@@ -1,0 +1,120 @@
+package lsp
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/vito/dang/v2/pkg/dang"
+)
+
+// deprecatedBuiltin captures what the LSP needs to flag a deprecated builtin
+// call: the human-facing reason and, when available, the structured replacement
+// callee used for the quick-fix rewrite.
+type deprecatedBuiltin struct {
+	reason      string
+	replacement string
+}
+
+var (
+	deprecatedBuiltinsOnce   sync.Once
+	deprecatedBuiltinsByName map[string]deprecatedBuiltin
+)
+
+// deprecatedBuiltins returns the top-level builtin functions marked deprecated,
+// keyed by name. The builtin registry is populated in dang's package init, so
+// it is safe to read once and cache.
+func deprecatedBuiltins() map[string]deprecatedBuiltin {
+	deprecatedBuiltinsOnce.Do(func() {
+		deprecatedBuiltinsByName = map[string]deprecatedBuiltin{}
+		dang.ForEachFunction(func(d dang.BuiltinDef) {
+			if d.Deprecated != "" {
+				deprecatedBuiltinsByName[d.Name] = deprecatedBuiltin{
+					reason:      d.Deprecated,
+					replacement: d.Replacement,
+				}
+			}
+		})
+	})
+	return deprecatedBuiltinsByName
+}
+
+// deprecatedCall is a call site whose callee names a deprecated builtin.
+type deprecatedCall struct {
+	name string
+	info deprecatedBuiltin
+	// sym is the callee identifier, used for both the diagnostic range and the
+	// quick-fix rewrite (only the callee token is replaced; arguments stay put).
+	sym *dang.Symbol
+}
+
+// findDeprecatedCalls walks the AST and returns every call whose callee names a
+// deprecated builtin. It matches by callee name: a local binding that shadows a
+// builtin of the same name would be a false positive, but shadowing the
+// deprecated conversion builtins is vanishingly rare, and the eval-time warning
+// is the source of truth.
+func findDeprecatedCalls(root dang.Node) []deprecatedCall {
+	if root == nil {
+		return nil
+	}
+	deprecated := deprecatedBuiltins()
+	var calls []deprecatedCall
+	root.Walk(func(n dang.Node) bool {
+		if n == nil {
+			return false
+		}
+		call, ok := n.(*dang.FunCall)
+		if !ok {
+			return true
+		}
+		sym, ok := call.Fun.(*dang.Symbol)
+		if !ok {
+			return true
+		}
+		if info, ok := deprecated[sym.Name]; ok {
+			calls = append(calls, deprecatedCall{name: sym.Name, info: info, sym: sym})
+		}
+		return true
+	})
+	return calls
+}
+
+// symbolRange returns the LSP range covering a callee identifier. Dang source
+// locations are 1-based; LSP positions are 0-based.
+func symbolRange(sym *dang.Symbol) (Range, bool) {
+	loc := sym.GetSourceLocation()
+	if loc == nil {
+		return Range{}, false
+	}
+	startLine := loc.Line - 1
+	startCol := loc.Column - 1
+	return Range{
+		Start: Position{Line: startLine, Character: startCol},
+		End:   Position{Line: startLine, Character: startCol + len(sym.Name)},
+	}, true
+}
+
+// deprecationMessage is the warning shown for a deprecated call; it matches the
+// eval-time warning wording so the two surfaces agree.
+func deprecationMessage(call deprecatedCall) string {
+	return fmt.Sprintf("%s is deprecated: %s", call.name, call.info.reason)
+}
+
+// deprecationDiagnostics produces a strike-through warning for each deprecated
+// builtin call in the AST.
+func deprecationDiagnostics(root dang.Node) []Diagnostic {
+	var diags []Diagnostic
+	for _, call := range findDeprecatedCalls(root) {
+		rng, ok := symbolRange(call.sym)
+		if !ok {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Range:    rng,
+			Severity: int(SeverityWarning),
+			Source:   stringPtr("dang"),
+			Message:  deprecationMessage(call),
+			Tags:     []DiagnosticTag{DiagnosticTagDeprecated},
+		})
+	}
+	return diags
+}

--- a/pkg/lsp/deprecations_test.go
+++ b/pkg/lsp/deprecations_test.go
@@ -1,0 +1,110 @@
+package lsp_test
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+	"github.com/vito/dang/v2/pkg/lsp"
+)
+
+func (LSPSuite) TestDeprecationDiagnosticFlagsDeprecatedBuiltin(ctx context.Context, t *testctx.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "main.dang")
+	writeDangFile(t, mainPath, "let s = toJSON([1, 2, 3])\n")
+
+	h := newLSPHarness(ctx, t, root)
+	uri := h.open(ctx, t, mainPath)
+	diagnostics := h.waitForDiagnostics(ctx, t, uri)
+
+	require.Len(t, diagnostics, 1)
+	d := diagnostics[0]
+	require.Equal(t, "toJSON is deprecated: use JSON.encode instead", d.Message)
+	require.Equal(t, int(lsp.SeverityWarning), d.Severity)
+	require.Contains(t, d.Tags, lsp.DiagnosticTagDeprecated)
+
+	// The range must cover the `toJSON` callee token: line 0, after "let s = ".
+	require.Equal(t, 0, d.Range.Start.Line)
+	require.Equal(t, len("let s = "), d.Range.Start.Character)
+	require.Equal(t, len("let s = ")+len("toJSON"), d.Range.End.Character)
+}
+
+func (LSPSuite) TestDeprecationDiagnosticCleanWhenUsingReplacement(ctx context.Context, t *testctx.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "main.dang")
+	writeDangFile(t, mainPath, "let s = JSON.encode([1, 2, 3])\n")
+
+	h := newLSPHarness(ctx, t, root)
+	uri := h.open(ctx, t, mainPath)
+	diagnostics := h.waitForDiagnostics(ctx, t, uri)
+
+	require.Empty(t, diagnostics, "the non-deprecated JSON.encode should not be flagged")
+}
+
+// codeActionResult mirrors the wire shape of a returned CodeAction with the
+// Changes map typed concretely, since lsp.WorkspaceEdit.Changes is `any`.
+type codeActionResult struct {
+	Title       string             `json:"title"`
+	Kind        string             `json:"kind"`
+	IsPreferred bool               `json:"isPreferred"`
+	Diagnostics []lsp.Diagnostic   `json:"diagnostics"`
+	Edit        codeActionEditWire `json:"edit"`
+}
+
+type codeActionEditWire struct {
+	Changes map[string][]lsp.TextEdit `json:"changes"`
+}
+
+func (LSPSuite) TestDeprecationCodeActionReplacesCallee(ctx context.Context, t *testctx.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "main.dang")
+	writeDangFile(t, mainPath, "let s = toJSON([1, 2, 3])\n")
+
+	h := newLSPHarness(ctx, t, root)
+	uri := h.open(ctx, t, mainPath)
+	_ = h.waitForDiagnostics(ctx, t, uri)
+
+	// Request actions for a cursor sitting inside the toJSON token.
+	cursor := lsp.Position{Line: 0, Character: len("let s = ") + 2}
+	var actions []codeActionResult
+	require.NoError(t, h.client.CallResult(ctx, "textDocument/codeAction", lsp.CodeActionParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
+		Range:        lsp.Range{Start: cursor, End: cursor},
+		Context:      lsp.CodeActionContext{Only: []lsp.CodeActionKind{lsp.QuickFix}},
+	}, &actions))
+
+	require.Len(t, actions, 1)
+	action := actions[0]
+	require.Equal(t, "Replace toJSON with JSON.encode", action.Title)
+	require.Equal(t, string(lsp.QuickFix), action.Kind)
+	require.True(t, action.IsPreferred)
+
+	edits := action.Edit.Changes[string(uri)]
+	require.Len(t, edits, 1)
+	require.Equal(t, "JSON.encode", edits[0].NewText)
+	// The edit replaces only the callee token, leaving the argument list intact.
+	require.Equal(t, len("let s = "), edits[0].Range.Start.Character)
+	require.Equal(t, len("let s = ")+len("toJSON"), edits[0].Range.End.Character)
+}
+
+func (LSPSuite) TestDeprecationCodeActionSkipsUnrelatedRange(ctx context.Context, t *testctx.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "main.dang")
+	// Two lines: the deprecated call is on line 0; ask for actions on line 1.
+	writeDangFile(t, mainPath, "let s = toJSON([1, 2, 3])\nlet t = 1\n")
+
+	h := newLSPHarness(ctx, t, root)
+	uri := h.open(ctx, t, mainPath)
+	_ = h.waitForDiagnostics(ctx, t, uri)
+
+	pos := lsp.Position{Line: 1, Character: 0}
+	var actions []codeActionResult
+	require.NoError(t, h.client.CallResult(ctx, "textDocument/codeAction", lsp.CodeActionParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
+		Range:        lsp.Range{Start: pos, End: pos},
+		Context:      lsp.CodeActionContext{},
+	}, &actions))
+
+	require.Empty(t, actions, "no deprecated call overlaps the requested range")
+}

--- a/pkg/lsp/handle_initialize.go
+++ b/pkg/lsp/handle_initialize.go
@@ -36,6 +36,7 @@ func (h *langHandler) handleInitialize(ctx context.Context, req *jrpc2.Request) 
 			},
 			DefinitionProvider:         true,
 			HoverProvider:              true,
+			CodeActionProvider:         true,
 			RenameProvider:             true,
 			WorkspaceSymbolProvider:    true,
 			DocumentFormattingProvider: true,

--- a/pkg/lsp/handle_text_document_code_action.go
+++ b/pkg/lsp/handle_text_document_code_action.go
@@ -1,0 +1,95 @@
+package lsp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/creachadair/jrpc2"
+)
+
+func (h *langHandler) handleTextDocumentCodeAction(ctx context.Context, req *jrpc2.Request) (any, error) {
+	if !req.HasParams() {
+		return nil, jrpc2.Errorf(jrpc2.InvalidParams, "missing parameters")
+	}
+
+	var params CodeActionParams
+	if err := req.UnmarshalParams(&params); err != nil {
+		return nil, err
+	}
+
+	// Always return a (possibly empty) array rather than null, so clients don't
+	// treat a no-op as an error.
+	actions := []CodeAction{}
+
+	// Honor an explicit `only` filter: if the client asked for kinds that don't
+	// include quick fixes, we have nothing to offer.
+	if !codeActionKindAllowed(params.Context.Only, QuickFix) {
+		return actions, nil
+	}
+
+	f := h.waitForFile(params.TextDocument.URI)
+	if f == nil || f.AST == nil {
+		return actions, nil
+	}
+
+	for _, call := range findDeprecatedCalls(f.AST) {
+		if call.info.replacement == "" {
+			// No structured replacement to rewrite to; the diagnostic still
+			// flags it, but there's no safe automatic fix.
+			continue
+		}
+		rng, ok := symbolRange(call.sym)
+		if !ok || !rangesOverlap(rng, params.Range) {
+			continue
+		}
+
+		diag := Diagnostic{
+			Range:    rng,
+			Severity: int(SeverityWarning),
+			Source:   stringPtr("dang"),
+			Message:  deprecationMessage(call),
+			Tags:     []DiagnosticTag{DiagnosticTagDeprecated},
+		}
+
+		// Replace only the callee identifier (e.g. toJSON -> JSON.encode); the
+		// argument list is untouched.
+		edit := TextEdit{Range: rng, NewText: call.info.replacement}
+		actions = append(actions, CodeAction{
+			Title:       fmt.Sprintf("Replace %s with %s", call.name, call.info.replacement),
+			Kind:        QuickFix,
+			Diagnostics: []Diagnostic{diag},
+			IsPreferred: true,
+			Edit: &WorkspaceEdit{
+				Changes: map[string][]TextEdit{
+					string(params.TextDocument.URI): {edit},
+				},
+			},
+		})
+	}
+
+	slog.InfoContext(ctx, "code action request",
+		"uri", params.TextDocument.URI, "range", params.Range, "actions", len(actions))
+
+	return actions, nil
+}
+
+// codeActionKindAllowed reports whether a code action of the given kind should
+// be offered for a request restricting kinds via context.only. An empty filter
+// allows everything; otherwise the kind is allowed when it equals, or is nested
+// under, one of the requested kinds.
+func codeActionKindAllowed(only []CodeActionKind, kind CodeActionKind) bool {
+	if len(only) == 0 {
+		return true
+	}
+	for _, k := range only {
+		if k == Empty || k == kind {
+			return true
+		}
+		// A requested ancestor kind (e.g. "quickfix") permits descendants.
+		if len(kind) > len(k) && kind[:len(k)] == k && kind[len(k)] == '.' {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -329,6 +329,10 @@ func (h *langHandler) analyzeDirectory(ctx context.Context, uri DocumentURI, fp 
 		analysis.TypeScope = typeScope
 	}
 
+	// Surface deprecated-builtin usages as strike-through warnings. This walks
+	// the parsed AST, so it works regardless of whether inference succeeded.
+	analysis.Diagnostics = append(analysis.Diagnostics, deprecationDiagnostics(currentBlock)...)
+
 	return analysis, nil
 }
 
@@ -894,6 +898,8 @@ func (h *langHandler) Assign(ctx context.Context, method string) jrpc2.Handler {
 		return h.handleTextDocumentDefinition
 	case "textDocument/hover":
 		return h.handleTextDocumentHover
+	case "textDocument/codeAction":
+		return h.handleTextDocumentCodeAction
 	case "textDocument/rename":
 		return h.handleTextDocumentRename
 	case "textDocument/formatting":

--- a/pkg/lsp/lsp.go
+++ b/pkg/lsp/lsp.go
@@ -177,6 +177,27 @@ type DiagnosticRelatedInformation struct {
 	Message  string   `json:"message"`
 }
 
+// DiagnosticSeverity is
+type DiagnosticSeverity int
+
+// SeverityError is
+const (
+	SeverityError       DiagnosticSeverity = 1
+	SeverityWarning     DiagnosticSeverity = 2
+	SeverityInformation DiagnosticSeverity = 3
+	SeverityHint        DiagnosticSeverity = 4
+)
+
+// DiagnosticTag is
+type DiagnosticTag int
+
+// DiagnosticTagUnnecessary fades the range; DiagnosticTagDeprecated strikes it
+// through. See the LSP spec's DiagnosticTag.
+const (
+	DiagnosticTagUnnecessary DiagnosticTag = 1
+	DiagnosticTagDeprecated  DiagnosticTag = 2
+)
+
 // Diagnostic is
 type Diagnostic struct {
 	Range              Range                          `json:"range"`
@@ -184,6 +205,7 @@ type Diagnostic struct {
 	Code               *string                        `json:"code,omitempty"`
 	Source             *string                        `json:"source,omitempty"`
 	Message            string                         `json:"message"`
+	Tags               []DiagnosticTag                `json:"tags,omitempty"`
 	RelatedInformation []DiagnosticRelatedInformation `json:"relatedInformation,omitempty"`
 }
 
@@ -289,10 +311,11 @@ type WorkspaceEdit struct {
 // CodeAction is
 type CodeAction struct {
 	Title       string         `json:"title"`
-	Diagnostics []Diagnostic   `json:"diagnostics"`
-	IsPreferred bool           `json:"isPreferred"` // TODO
-	Edit        *WorkspaceEdit `json:"edit"`
-	Command     *Command       `json:"command"`
+	Kind        CodeActionKind `json:"kind,omitempty"`
+	Diagnostics []Diagnostic   `json:"diagnostics,omitempty"`
+	IsPreferred bool           `json:"isPreferred,omitempty"`
+	Edit        *WorkspaceEdit `json:"edit,omitempty"`
+	Command     *Command       `json:"command,omitempty"`
 }
 
 // CompletionItem is

--- a/tests/test_to_json_deprecated.dang
+++ b/tests/test_to_json_deprecated.dang
@@ -1,0 +1,15 @@
+# toJSON / fromJSON / fromYAML are the deprecated predecessors of JSON.encode,
+# JSON.decode, and YAML.decode. They still work (printing a deprecation warning
+# that names the call site) and behave identically to their successors because
+# they share the same implementation.
+let obj = {{name: "test", value: 42}}
+assert { toJSON(obj) == JSON.encode(obj) }
+assert { toJSON([1, 2, 3]) == "[1,2,3]" }
+
+let parsed = fromJSON("[1, 2, 3]") :: [Int!]!
+assert { parsed == [1, 2, 3] }
+
+let yparsed = fromYAML("[a, b, c]") :: [String!]!
+assert { yparsed == ["a", "b", "c"] }
+
+print("deprecated conversion aliases work")


### PR DESCRIPTION
## What

Brings back the top-level `toJSON`, `fromJSON`, and `fromYAML` functions that were removed when JSON/YAML/TOML encode/decode moved into format namespaces (#105), this time as `@deprecated` aliases. Calling one still works but prints a warning pointing at the call site and naming the namespaced replacement — and the LSP now flags and fixes these usages in-editor.

## How

### `@deprecated` handling for builtins

A `.Deprecated(reason)` builder on the function/method/static-method DSLs records the reason on `BuiltinDef` and the resulting `BuiltinFunction`. When a `FunCall` resolves to a deprecated builtin, eval prints a warning to the context's stderr using the existing source-highlighting renderer (factored out as `formatSourceAnnotation`):

```
Warning: toJSON is deprecated: use JSON.encode instead
  --> main.dang:1:9
  1 | let a = toJSON([1, 2, 3])
              ^^^^^^^^^^^^^^^^^
```

Warnings are deduped per call site within a run (a set on `EvalContext`), so a deprecated call inside a loop warns once. Eval is single-threaded, so no lock is needed.

### Restored functions

`toJSON`/`fromJSON`/`fromYAML` are thin aliases that delegate to the same implementation as `JSON.encode`/`JSON.decode`/`YAML.decode`, so they honor codec field directives identically. There was never a top-level `toYAML`/`toTOML`/`fromTOML`, so none is restored.

### LSP integration

- A `.Replacement(name)` builder adds a *structured* successor (e.g. `JSON.encode`) alongside the prose reason, so tools can rewrite mechanically instead of parsing the message.
- The LSP walks the inferred AST for calls whose callee names a deprecated builtin and publishes a **warning diagnostic** over the callee token, tagged `Deprecated` so editors render it struck-through.
- A new `textDocument/codeAction` handler (capability now advertised) offers a **quick fix** that replaces just the callee — `toJSON(x)` → `JSON.encode(x)` — leaving the argument list untouched.

Matching is by callee name (the eval-time warning is the source of truth); a local binding shadowing one of these builtins is vanishingly rare.

## Testing

- Go tests: warning content + call-site location, per-call-site dedup, LSP diagnostic (severity/tag/range) and code-action (title/kind/edit/range-overlap) behavior.
- `builtins_test.go` asserts the three are present and deprecated.
- `tests/test_to_json_deprecated.dang` round-trips all three against their successors.
- Full `dagger check` green (lint, go tests, docs-go tests).
