### PR TITLE
docs: add the inkstained base16 theme

### DIFF
--- a/docs/cmd/curatethemes/main.go
+++ b/docs/cmd/curatethemes/main.go
@@ -177,6 +177,22 @@ func main() {
 		}
 	}
 
+	// Repo-local schemes live in docs/schemes-local because the schemes
+	// submodule is upstream's tinted-theming/schemes and can't carry our own
+	// additions. They load last so a local scheme overrides an upstream one of
+	// the same name, matching genthemes.
+	localPaths, err := filepath.Glob(filepath.Join("schemes-local", "*.yaml"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, p := range localPaths {
+		s, err := parseScheme(p)
+		if err != nil {
+			log.Fatal(err)
+		}
+		schemes[s.name] = s
+	}
+
 	var names []string
 	for name := range schemes {
 		names = append(names, name)

--- a/docs/cmd/genthemes/main.go
+++ b/docs/cmd/genthemes/main.go
@@ -97,6 +97,22 @@ func main() {
 		}
 	}
 
+	// Repo-local schemes live in docs/schemes-local because the schemes
+	// submodule is upstream's tinted-theming/schemes and can't carry our own
+	// additions. They load last so a local scheme overrides an upstream one of
+	// the same name.
+	localPaths, err := filepath.Glob(filepath.Join("schemes-local", "*.yaml"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, p := range localPaths {
+		s, err := parseScheme(p)
+		if err != nil {
+			log.Fatal(err)
+		}
+		schemes[s.name] = s
+	}
+
 	outDir := filepath.Join("css", "base16")
 	if err := os.RemoveAll(outDir); err != nil {
 		log.Fatal(err)

--- a/docs/cmd/genthemes/main.go
+++ b/docs/cmd/genthemes/main.go
@@ -122,7 +122,18 @@ func main() {
 	}
 	for name, s := range schemes {
 		out := filepath.Join(outDir, "base16-"+name+".css")
-		if err := os.WriteFile(out, []byte(s.css()), 0o644); err != nil {
+		css := s.css()
+		// Append a repo-local progressive enhancement, if the scheme ships
+		// one. switcher.js swaps a single <link> between these files, so any
+		// rules past the :root variables apply only while this scheme is
+		// active — letting a scheme reach beyond the 16 base16 slots (bold
+		// tokens, extra palette accents) without touching any other.
+		if enh, err := os.ReadFile(filepath.Join("schemes-local", name+".css")); err == nil {
+			css += "\n" + string(enh)
+		} else if !os.IsNotExist(err) {
+			log.Fatal(err)
+		}
+		if err := os.WriteFile(out, []byte(css), 0o644); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/docs/html/base16-options.tmpl
+++ b/docs/html/base16-options.tmpl
@@ -222,6 +222,7 @@
 <option value="icy">icy</option>
 <option value="idea">idea</option>
 <option value="idle-toes">idle-toes</option>
+<option value="inkstained">inkstained</option>
 <option value="irblack">irblack</option>
 <option value="isotope">isotope</option>
 <option value="jabuti">jabuti</option>

--- a/docs/js/switcher.js
+++ b/docs/js/switcher.js
@@ -294,6 +294,7 @@ var curatedLightStyles = [
   "gruvbox-light-soft",
   "gruvbox-material-light-medium",
   "gruvbox-material-light-soft",
+  "inkstained",
   "kissa-latte",
   "measured-light",
   "nord-light",

--- a/docs/schemes-local/inkstained.css
+++ b/docs/schemes-local/inkstained.css
@@ -1,0 +1,65 @@
+/* Inkstained — progressive enhancement layered on the base16 :root above.
+ *
+ * genthemes appends this to the generated base16-inkstained.css, and
+ * switcher.js swaps a single <link> between the css/base16/*.css files, so
+ * every rule here applies only while Inkstained is the active scheme. That
+ * lets the theme reach past the 16 base16 slots into yuttie's full
+ * inkstained-vim palette (https://github.com/yuttie/inkstained-vim): bold ink
+ * identifiers, the signature pale-teal box behind literals and inline code, a
+ * sparing wash of magenta on headings, and a violet tint on asides.
+ *
+ * The active scheme's stylesheet loads before page.tmpl's inline <style>, so
+ * the prose rules below are scoped to `main` both to clear that later style on
+ * specificity and to stay clear of the same tags in the sidebar/ToC nav. */
+
+:root {
+  /* yuttie's full inkstained-vim palette, kept here so the rules below can use
+     shades the base16 slots leave out. `-tint` are the pale backgrounds. */
+  --ink-red-tint: #edb8c4;     --ink-red: #aa586e;
+  --ink-teal-tint: #cfd9d9;    --ink-teal: #608f8e;
+  --ink-cyan-tint: #cbd7dc;    --ink-cyan: #447487;
+  --ink-cyan-2: #5e99b1;       --ink-cyan-3: #6f9db0;
+  --ink-blue: #56759a;         --ink-blue-2: #7593bb;    --ink-blue-3: #91a8c9;
+  --ink-violet-tint: #d7d3dc;  --ink-violet: #7c6a93;
+  --ink-violet-2: #9784ae;     --ink-violet-3: #ac99c4;
+  --ink-magenta-tint: #dcd1d8; --ink-magenta: #a05b89;
+  --ink-magenta-2: #b0789b;    --ink-magenta-3: #c190ae;
+}
+
+/* Identifiers and keywords are set in bold ink — inkstained's most
+   recognizable trait. (JetBrains Mono is monospace at every weight, so the
+   bold tokens stay column-aligned in code blocks.) */
+.tok-function,
+.tok-keyword { font-weight: 700; }
+
+/* The signature pale-teal box behind literals: strings and the
+   true/false/null/number constants, rendered as dark teal on the teal tint.
+   Background only — no padding — so code stays aligned. */
+.tok-string,
+.tok-number {
+  color: var(--ink-teal);
+  background-color: var(--ink-teal-tint);
+  border-radius: 3px;
+}
+
+/* Code set inside paragraphs gets the same teal box, so inline references read
+   like the literals they usually are. page.tmpl keeps the padding and radius;
+   this only recolors. */
+main p code {
+  color: var(--ink-teal);
+  background-color: var(--ink-teal-tint);
+}
+
+/* A sparing wash of magenta marks the prose headings. */
+main h1,
+main h2,
+main h3 { color: var(--ink-magenta); }
+
+/* Asides take a quiet violet tint — another inkstained hue the base16 slots
+   don't surface on their own. page.tmpl's 3px solid left border stays; only
+   its color and the background change. */
+main blockquote,
+main .inset {
+  border-left-color: var(--ink-violet);
+  background-color: var(--ink-violet-tint);
+}

--- a/docs/schemes-local/inkstained.yaml
+++ b/docs/schemes-local/inkstained.yaml
@@ -1,0 +1,28 @@
+system: "base16"
+name: "Inkstained"
+author: "yuttie (inkstained-vim), base16 port for the dang docs"
+slug: "inkstained"
+variant: "light"
+# A base16 translation of yuttie's inkstained-vim
+# (https://github.com/yuttie/inkstained-vim): ink on warm, aged paper. The
+# greyscale ramp (base00-base07) and the cool accents (red/teal/cyan/blue/
+# violet) come straight from the vim palette; inkstained has no orange,
+# yellow, or brown, so base09/base0A/base0F are muted sepia tones mixed to
+# fill the base16 rainbow without breaking the theme's quiet, cool mood.
+palette:
+  base00: "#e7e5e2" # page + code background (inkstained's lightest paper)
+  base01: "#dfddd7" # sidebar / selection background
+  base02: "#d3d1cc" # inline-code / hover background
+  base03: "#929cad" # comments (inkstained's muted comment grey)
+  base04: "#697383" # secondary labels (inkstained's body text)
+  base05: "#555f6f" # prose / default foreground (inkstained's darkest ink)
+  base06: "#434a57" # darker foreground
+  base07: "#2b313a" # darkest foreground
+  base08: "#aa586e" # red    — variables, tags, errors (inkstained red)
+  base09: "#98703f" # orange — numbers, constants, run button (sepia ink)
+  base0A: "#8a7a35" # yellow — types (muted gold)
+  base0B: "#608f8e" # green  — strings (inkstained teal)
+  base0C: "#447487" # cyan   — builtins, escapes (inkstained cyan)
+  base0D: "#56759a" # blue   — functions, links (inkstained blue)
+  base0E: "#7c6a93" # violet — keywords, operators (inkstained violet)
+  base0F: "#7d5f4a" # brown  — deprecations (sepia ink)


### PR DESCRIPTION
Adds **`inkstained`**, a custom theme for the docs, ported from yuttie's [inkstained-vim](https://github.com/yuttie/inkstained-vim): ink on warm, aged paper.

## The base16 scheme

The greyscale ramp and the cool accents (red / teal / cyan / blue / violet) come straight from the vim palette. inkstained has no orange, yellow, or brown, so those three base16 slots are muted sepia tones mixed to fill out the rainbow without disturbing the theme's quiet, cool mood. The palette is tuned to clear `curatethemes`' WCAG contrast floors, so it joins the **light** rotation.

| slot | | role |
|---|---|---|
| `base00` `#e7e5e2` | paper background | page + code bg |
| `base03` `#929cad` | muted grey | comments |
| `base05` `#555f6f` | darkest ink | prose / default fg |
| `base08` `#aa586e` | red | variables, tags, errors |
| `base09` `#98703f` | sepia | numbers, constants, run button |
| `base0A` `#8a7a35` | muted gold | types |
| `base0B` `#608f8e` | teal | strings |
| `base0C` `#447487` | cyan | builtins, escapes |
| `base0D` `#56759a` | blue | functions, links |
| `base0E` `#7c6a93` | violet | keywords, operators |
| `base0F` `#7d5f4a` | sepia | deprecations |

## Beyond base16

base16 alone can't capture what makes inkstained *itself*, so the theme is layered with progressive enhancement. `switcher.js` swaps a single `<link>` between the `css/base16/*.css` files, so any rules a scheme's stylesheet carries past its `:root` apply **only while that scheme is active**. `genthemes` now appends an optional `schemes-local/<name>.css` to each generated stylesheet, giving a scheme a place to reach beyond the 16 slots without affecting any other.

inkstained's enhancement layer:

- **Bold ink identifiers** — `.tok-function` and `.tok-keyword` go bold, inkstained's most recognizable trait. (JetBrains Mono is monospace at every weight, so code stays column-aligned.)
- **The signature teal box** — string and constant literals (`.tok-string`, `.tok-number`), and inline code in paragraphs, render as dark teal `#608f8e` on the pale teal tint `#cfd9d9`.
- **A sparing magenta** on prose headings.
- **A violet wash** on asides (blockquotes / insets).
- The **full inkstained-vim palette** is declared as `--ink-*` variables so the extras can use shades the base16 ramp leaves out.

The prose rules are scoped to `main`, which both clears page.tmpl's later inline `<style>` on specificity and keeps the colors off the identically-tagged sidebar nav. The disabled `alternate stylesheet` preloads mean these rules never leak into other themes.

## Where it lives

`docs/schemes/` is upstream's `tinted-theming/schemes` submodule and can't carry our own files, so repo-local schemes now live in a new `docs/schemes-local/` directory — `inkstained.yaml` (the base16 source) and `inkstained.css` (the enhancement). `genthemes` and `curatethemes` read it last, so a local scheme overrides an upstream name collision. This is the first custom scheme; the directory is the home for any future ones.

## Changes

- `docs/schemes-local/inkstained.yaml`, `docs/schemes-local/inkstained.css` — the scheme source and its enhancement layer.
- `docs/cmd/genthemes/main.go` — glob `schemes-local/*.yaml`, and append a scheme's optional `schemes-local/<name>.css` to its generated stylesheet.
- `docs/cmd/curatethemes/main.go` — also glob `schemes-local/*.yaml`.
- `docs/html/base16-options.tmpl` — adds the `inkstained` option (regenerated by the build step).
- `docs/js/switcher.js` — adds `inkstained` to `curatedLightStyles` (regenerated by `curatethemes -write`).

The generated `css/base16/base16-inkstained.css` is gitignored and produced at build time, like every other scheme.

## Verification

- `go vet ./cmd/genthemes ./cmd/curatethemes` clean; `genthemes` emits the 16 `--base*` variables plus the appended enhancement, and only inkstained's stylesheet gets the extra rules.
- `curatethemes -v` → `PASS light inkstained` — clears every contrast floor.
- Cascade verified by reading the `<head>` order: the active scheme stylesheet sits between `syntax.css` and page.tmpl's inline `<style>`, so token rules win over `syntax.css` and the `main`-scoped prose rules win on specificity.

> Note: I couldn't render the site headlessly here (no browser/node in the sandbox), so the enhancement layer is verified by cascade analysis and generated-output inspection rather than a screenshot. Worth an eyeball before merge: `cd docs && ./build.sh`, open `index.html`, pick "inkstained".
