### PR TITLE
repl: tree-sitter syntax highlighting + ANSI 16-color palette

### DIFF
--- a/.agents/skills/editor-syntaxes/SKILL.md
+++ b/.agents/skills/editor-syntaxes/SKILL.md
@@ -58,6 +58,17 @@ git add editors/zed editors/nvim editors/vscode/syntaxes/dang.tmLanguage.json
 git commit -m "chore(editors): ..."
 ```
 
+## Embedded highlight query (REPL)
+
+The REPL highlights its input with the same Zed `highlights.scm`, embedded
+into the binary at `pkg/dang/highlights.scm` (a generated copy, since
+`go:embed` can't follow the `treesitter/queries/highlights.scm` symlink into
+the submodule). `./hack/generate` (via `go generate ./...`) refreshes it with
+`cp`, so it tracks the query automatically — just re-run generation after
+editing the Zed query. New capture names also need a case in `captureClass`
+in `pkg/dang/highlight_common.go` (kept in lockstep with
+`docs/go/highlight.go`).
+
 ## Checklist
 
 When a language keyword or token changes:
@@ -65,4 +76,5 @@ When a language keyword or token changes:
 1. [ ] Update `editors/zed/languages/dang/highlights.scm`
 2. [ ] Update `editors/nvim/queries/dang/highlights.scm`
 3. [ ] Update `editors/vscode/syntaxes/dang.tmLanguage.json`
-4. [ ] Commit submodules, then parent repo
+4. [ ] Re-run `./hack/generate` to refresh the embedded `pkg/dang/highlights.scm`
+5. [ ] Commit submodules, then parent repo

--- a/cmd/dang-playground/main.go
+++ b/cmd/dang-playground/main.go
@@ -196,7 +196,7 @@ func evalSource(source, token string) map[string]any {
 
 	value := ""
 	if last != nil {
-		value = fmt.Sprint(last.String())
+		value = dang.Repr(last)
 	}
 	return result(value, strings.TrimRight(out.String(), "\n"), "", "")
 }
@@ -263,7 +263,7 @@ func evalForms(ctx context.Context, source string, typeScope dang.TypeScope, val
 	value := ""
 	lastIsDecl := false
 	if last != nil {
-		value = fmt.Sprint(last.String())
+		value = dang.Repr(last)
 		lastIsDecl = len(lastNode.DeclaredSymbols()) > 0
 	}
 	return value, lastIsDecl, nil, ""

--- a/cmd/dang/repl.go
+++ b/cmd/dang/repl.go
@@ -25,11 +25,16 @@ func (e *replEntry) writeLog(s string)     { e.logs.WriteString(s) }
 func (e *replEntry) writeLogLine(s string) { e.logs.WriteString(s); e.logs.WriteByte('\n') }
 func (e *replEntry) writeResult(s string)  { e.result.WriteString(s); e.result.WriteByte('\n') }
 
-// Styles (REPL-specific, shared between repl_pitui.go and repl_commands.go)
+// Styles (REPL-specific, shared between repl_tuist.go and repl_commands.go).
+//
+// The whole REPL/TUI sticks to the ANSI 16-color palette (colors "0".."15"),
+// so it honors the user's terminal theme instead of hard-coding 256-color
+// shades. Syntax-highlighting colors live in repl_highlight.go and draw from
+// the same palette.
 var (
-	promptStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Bold(true)
-	resultStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	welcomeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
-	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	promptStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true) // magenta
+	resultStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))            // green
+	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))            // red
+	welcomeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))            // magenta
+	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))            // bright black
 )

--- a/cmd/dang/repl_highlight.go
+++ b/cmd/dang/repl_highlight.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/vito/dang/v2/pkg/dang"
+	"github.com/vito/tuist"
+)
+
+// Syntax highlighting for the REPL. Source is classified by tree-sitter in
+// pkg/dang (the same grammar and query the editors and docs use), and each
+// token class is colored from the ANSI 16-color palette so the theme follows
+// the user's terminal. Highlighting is best-effort: without CGo (or on a
+// parse failure) dang.Highlight returns no spans and code renders plain.
+//
+// The class → color choices mirror the docs' Rosé Pine palette, collapsed
+// onto the 16 colors: the two blues (strings vs. functions) can't both be
+// blue here, so strings take green.
+var classStyles = map[string]lipgloss.Style{
+	dang.ClassKeyword:   lipgloss.NewStyle().Foreground(lipgloss.Color("5")), // magenta
+	dang.ClassOperator:  lipgloss.NewStyle().Foreground(lipgloss.Color("5")), // magenta
+	dang.ClassType:      lipgloss.NewStyle().Foreground(lipgloss.Color("3")), // yellow
+	dang.ClassNumber:    lipgloss.NewStyle().Foreground(lipgloss.Color("3")), // yellow
+	dang.ClassString:    lipgloss.NewStyle().Foreground(lipgloss.Color("2")), // green
+	dang.ClassEscape:    lipgloss.NewStyle().Foreground(lipgloss.Color("6")), // cyan
+	dang.ClassComment:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")), // bright black
+	dang.ClassFunction:  lipgloss.NewStyle().Foreground(lipgloss.Color("4")), // blue
+	dang.ClassBuiltin:   lipgloss.NewStyle().Foreground(lipgloss.Color("6")), // cyan
+	dang.ClassDirective: lipgloss.NewStyle().Foreground(lipgloss.Color("8")), // bright black
+	dang.ClassSelf:      lipgloss.NewStyle().Foreground(lipgloss.Color("1")), // red
+	dang.ClassProperty:  lipgloss.NewStyle().Foreground(lipgloss.Color("1")), // red
+	dang.ClassLabel:     lipgloss.NewStyle().Foreground(lipgloss.Color("1")), // red
+	// variable and punct intentionally absent: they keep the default
+	// foreground, matching the docs.
+}
+
+// classStylers caches a width-preserving styling closure per class so we don't
+// re-wrap lipgloss.Style.Render (variadic) on every span.
+var classStylers = func() map[string]func(string) string {
+	m := make(map[string]func(string) string, len(classStyles))
+	for class, style := range classStyles {
+		s := style
+		m[class] = func(text string) string { return s.Render(text) }
+	}
+	return m
+}()
+
+// isReplCommand reports whether a line is a REPL meta-command (":help", etc.)
+// rather than Dang code; those aren't highlighted.
+func isReplCommand(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), ":")
+}
+
+// highlightSpans builds tuist.StyleSpans for live input highlighting in the
+// text editor. Returns nil for REPL commands and unhighlightable input.
+func highlightSpans(value string) []tuist.StyleSpan {
+	if isReplCommand(value) {
+		return nil
+	}
+	var spans []tuist.StyleSpan
+	for _, hs := range dang.Highlight(value) {
+		styler, ok := classStylers[hs.Class]
+		if !ok {
+			continue
+		}
+		spans = append(spans, tuist.StyleSpan{Start: hs.Start, End: hs.End, Style: styler})
+	}
+	return spans
+}
+
+// highlightCode returns code with ANSI styling applied, for echoing submitted
+// input into the scrollback. Styling is clipped at newlines so the result is
+// safe to split into display lines (a style never bleeds across a line break).
+func highlightCode(code string) string {
+	if isReplCommand(code) {
+		return code
+	}
+	spans := dang.Highlight(code)
+	if len(spans) == 0 {
+		return code
+	}
+	runes := []rune(code)
+	var b strings.Builder
+	prev := 0
+	for _, sp := range spans {
+		if sp.Start > prev {
+			b.WriteString(string(runes[prev:sp.Start]))
+		}
+		seg := string(runes[sp.Start:sp.End])
+		if styler, ok := classStylers[sp.Class]; ok {
+			writeStyledLines(&b, seg, styler)
+		} else {
+			b.WriteString(seg)
+		}
+		prev = sp.End
+	}
+	if prev < len(runes) {
+		b.WriteString(string(runes[prev:]))
+	}
+	return b.String()
+}
+
+// writeStyledLines styles seg one line at a time, leaving newlines unstyled,
+// so the styling never spans a line break (e.g. inside a multiline string).
+func writeStyledLines(b *strings.Builder, seg string, styler func(string) string) {
+	for i, line := range strings.Split(seg, "\n") {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if line != "" {
+			b.WriteString(styler(line))
+		}
+	}
+}

--- a/cmd/dang/repl_highlight_test.go
+++ b/cmd/dang/repl_highlight_test.go
@@ -55,3 +55,11 @@ func TestHighlightSkipsReplCommands(t *testing.T) {
 	assert.Nil(t, highlightSpans(":help"))
 	assert.Equal(t, ":type foo", highlightCode(":type foo"))
 }
+
+// REPL result echoing highlights the value as a Dang literal: strings are
+// quoted and colored with the string class, exactly like input.
+func TestResultReprQuotesAndHighlights(t *testing.T) {
+	out := highlightCode(dang.Repr(dang.StringValue{Val: "hi"}))
+	assert.Equal(t, `"hi"`, ansi.Strip(out))
+	assert.Contains(t, out, classStyles[dang.ClassString].Render(`"hi"`))
+}

--- a/cmd/dang/repl_highlight_test.go
+++ b/cmd/dang/repl_highlight_test.go
@@ -1,0 +1,57 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vito/dang/v2/pkg/dang"
+)
+
+func TestHighlightCodeStylesAndPreservesText(t *testing.T) {
+	code := `let greeting = "hi"`
+	out := highlightCode(code)
+
+	// Styling was added but visible text is unchanged (width-preserving).
+	assert.NotEqual(t, code, out, "expected ANSI styling")
+	assert.Contains(t, out, "\x1b[", "expected ANSI escape codes")
+	assert.Equal(t, code, ansi.Strip(out), "styling must preserve the visible text")
+
+	// The keyword "let" is wrapped in the keyword color, the string in the
+	// string color — exactly as the class styles render them.
+	assert.Contains(t, out, classStyles[dang.ClassKeyword].Render("let"))
+	assert.Contains(t, out, classStyles[dang.ClassString].Render(`"hi"`))
+}
+
+func TestHighlightCodeMultilineSplitsSafely(t *testing.T) {
+	// A style must never bleed across a line break, so each display line can be
+	// rendered independently. Every line, when stripped, is plain source.
+	code := "let x = 1\nlet y = 2"
+	out := highlightCode(code)
+	lines := strings.Split(out, "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "let x = 1", ansi.Strip(lines[0]))
+	assert.Equal(t, "let y = 2", ansi.Strip(lines[1]))
+}
+
+func TestHighlightSpansWiring(t *testing.T) {
+	spans := highlightSpans(`let x = 1`)
+	require.NotEmpty(t, spans)
+	for _, sp := range spans {
+		assert.Less(t, sp.Start, sp.End)
+		require.NotNil(t, sp.Style)
+		// Style is width-preserving.
+		styled := sp.Style("x")
+		assert.Equal(t, "x", ansi.Strip(styled))
+	}
+}
+
+func TestHighlightSkipsReplCommands(t *testing.T) {
+	assert.Nil(t, highlightSpans(":help"))
+	assert.Equal(t, ":type foo", highlightCode(":type foo"))
+}

--- a/cmd/dang/repl_tuist.go
+++ b/cmd/dang/repl_tuist.go
@@ -106,7 +106,7 @@ func newEntryView(entry *replEntry) *entryView {
 	return ev
 }
 
-func (ev *entryView) Render(ctx tuist.Context) tuist.RenderResult {
+func (ev *entryView) Render(ctx tuist.Context) {
 	// Snapshot entry data.
 	input := ev.entry.input
 	logs := ev.entry.logs.String()
@@ -143,7 +143,7 @@ func (ev *entryView) Render(ctx tuist.Context) tuist.RenderResult {
 		}
 	}
 
-	return tuist.RenderResult{Lines: lines}
+	ctx.Lines(lines...)
 }
 
 // (completion menu overlay and detail bubble are now provided by tuist.CompletionMenu)
@@ -203,6 +203,7 @@ func newReplComponent(ctx context.Context, importConfigs []dang.ImportConfig, de
 
 	ti := tuist.NewTextInput(promptStyle.Render("dang> "))
 	ti.ContinuationPrompt = promptStyle.Render("  ... ")
+	ti.Highlight = highlightSpans // live tree-sitter syntax highlighting
 
 	r := &replComponent{
 		importConfigs:  importConfigs,
@@ -220,7 +221,7 @@ func newReplComponent(ctx context.Context, importConfigs []dang.ImportConfig, de
 	// Spinner
 	sp := tuist.NewSpinner()
 	sp.Style = func(s string) string {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Render(s)
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Render(s)
 	}
 	sp.Label = dimStyle.Render("Evaluating... (Ctrl+C to cancel)")
 	r.spinner = sp
@@ -307,8 +308,10 @@ func (r *replComponent) onSubmit(ctx tuist.Context, line string) bool {
 
 	r.history.Add(line)
 
-	// Format the echoed input: first line with prompt, continuation lines with "  ... ".
-	inputLines := strings.Split(line, "\n")
+	// Format the echoed input: syntax-highlight the source, then prefix the
+	// first line with the prompt and continuation lines with "  ... ".
+	// highlightCode clips styling at newlines, so splitting stays safe.
+	inputLines := strings.Split(highlightCode(line), "\n")
 	var echoedLines []string
 	for i, l := range inputLines {
 		if i == 0 {
@@ -577,7 +580,7 @@ func runREPLTUI(ctx context.Context, moduleDir string, debug bool) error {
 
 		loadSp := tuist.NewSpinner()
 		loadSp.Style = func(s string) string {
-			return lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Render(s)
+			return lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Render(s)
 		}
 		loadSp.Label = dimStyle.Render(fmt.Sprintf("Loading Dagger module from %s... (Ctrl+C to cancel)", moduleDir))
 

--- a/cmd/dang/repl_tuist.go
+++ b/cmd/dang/repl_tuist.go
@@ -480,7 +480,9 @@ func (r *replComponent) startEval(ectx tuist.Context, expr string) {
 				return
 			}
 
-			results = append(results, resultStyle.Render(fmt.Sprintf("=> %s", val.String())))
+			// Echo the result as a highlighted Dang literal (quoted strings,
+			// same grammar as the input), behind a green "=> " marker.
+			results = append(results, resultStyle.Render("=> ")+highlightCode(dang.Repr(val)))
 			if debug {
 				results = append(results, dimStyle.Render(fmt.Sprintf("%# v", pretty.Formatter(val))))
 			}

--- a/docs/go/literate.go
+++ b/docs/go/literate.go
@@ -164,7 +164,9 @@ func (p Plugin) literateBlock(code booklit.Content, label string) (booklit.Conte
 		partials["Stdout"] = booklit.String(stdout)
 	}
 	if value != "" {
-		partials["Value"] = booklit.String(value)
+		// Highlight the result with bare token spans, matching the client-side
+		// highlighting so the baked output and its enhanced replay agree.
+		partials["Value"] = highlightResult(value)
 	}
 
 	return booklit.Styled{
@@ -299,7 +301,7 @@ func literateEval(source string, sess *literateSession) (string, string, error) 
 
 	value := ""
 	if lastVal != nil && (last == nil || len(last.DeclaredSymbols()) == 0) {
-		value = lastVal.String()
+		value = dang.Repr(lastVal)
 	}
 	return strings.TrimRight(out.String(), "\n"), value, nil
 }

--- a/docs/go/literate_test.go
+++ b/docs/go/literate_test.go
@@ -2,12 +2,26 @@ package dangdocs
 
 import (
 	"fmt"
+	"html"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/vito/booklit"
 )
+
+// valueText returns the plain text of a literate block's Value partial,
+// stripping the syntax-highlight markup the result is now rendered with
+// (tags and HTML entities).
+var htmlTagRE = regexp.MustCompile(`<[^>]*>`)
+
+func valueText(c booklit.Content) string {
+	if c == nil {
+		return ""
+	}
+	return html.UnescapeString(htmlTagRE.ReplaceAllString(c.String(), ""))
+}
 
 // \literate-fences covers the section it's called in and its sub-sections —
 // not the parent or siblings.
@@ -65,7 +79,7 @@ func TestCodeBlockLiterateRouting(t *testing.T) {
 	}
 
 	second := render(lit, "dang", "x + 1")
-	if got := second.Partials["Value"]; got == nil || got.String() != "43" {
+	if got := second.Partials["Value"]; got == nil || valueText(got) != "43" {
 		t.Errorf("second fence should see first fence's `x`: Value = %v, want 43", got)
 	}
 
@@ -77,6 +91,32 @@ func TestCodeBlockLiterateRouting(t *testing.T) {
 	outside := render(plain, "dang", "undefinedNameNeverEvaluated")
 	if outside.Style != booklit.StyleCodeBlock {
 		t.Errorf("dang fence outside scope: style %q, want %q", outside.Style, booklit.StyleCodeBlock)
+	}
+}
+
+// A literate block's result is echoed as a quoted Dang literal (via Repr) and
+// highlighted under the same grammar as the input, so the baked output matches
+// what the reader sees after client-side enhancement.
+func TestLiterateResultQuotedAndHighlighted(t *testing.T) {
+	root := &booklit.Section{Path: "result-test.md"}
+	lit := &booklit.Section{Parent: root}
+	Plugin{section: lit}.LiterateFences()
+
+	content, err := Plugin{section: lit}.CodeBlock("dang", booklit.Preformatted{booklit.String(`"hi"`)})
+	if err != nil {
+		t.Fatalf("CodeBlock: %v", err)
+	}
+	value := content.(booklit.Styled).Partials["Value"]
+	if value == nil {
+		t.Fatal("string result baked no Value partial")
+	}
+	// Quoted (Repr), not the bare `hi` that String() would produce.
+	if got := valueText(value); got != `"hi"` {
+		t.Errorf("result text = %q, want %q", got, `"hi"`)
+	}
+	// Highlighted as a string token (same classes as the input).
+	if html := value.String(); !strings.Contains(html, `class="tok-string"`) {
+		t.Errorf("result not highlighted as a string: %s", html)
 	}
 }
 
@@ -138,7 +178,7 @@ func TestCodeBlockFailureRouting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fence after failures: %v", err)
 	}
-	if got := after.Partials["Value"]; got == nil || got.String() != "43" {
+	if got := after.Partials["Value"]; got == nil || valueText(got) != "43" {
 		t.Errorf("fence after failures: Value = %v, want 43", got)
 	}
 

--- a/docs/go/render.go
+++ b/docs/go/render.go
@@ -156,3 +156,36 @@ func renderCode(section *booklit.Section, language, source string, links []linkS
 
 	return seq
 }
+
+// highlightResult renders a REPL result value as inline highlighted HTML:
+// bare tok-* spans with no .syntax wrapper. This matches what playground.js's
+// highlightHtml produces for the same value client-side, so the baked literate
+// result and its enhanced replay look identical, and unstyled characters
+// inherit the result line's color (.dang-playground-result, green). Without a
+// grammar (or cgo) it degrades to escaped plain text.
+func highlightResult(value string) booklit.Content {
+	classes := classifyCode("dang", value)
+	classAt := func(i int) string {
+		if classes == nil {
+			return ""
+		}
+		return classes[i]
+	}
+
+	var raw strings.Builder
+	for i := 0; i < len(value); {
+		cls := classAt(i)
+		j := i + 1
+		for j < len(value) && classAt(j) == cls {
+			j++
+		}
+		text := html.EscapeString(value[i:j])
+		if cls != "" {
+			raw.WriteString(`<span class="` + cls + `">` + text + `</span>`)
+		} else {
+			raw.WriteString(text)
+		}
+		i = j
+	}
+	return booklit.Styled{Style: "raw-html", Content: booklit.String(raw.String())}
+}

--- a/docs/js/playground.js
+++ b/docs/js/playground.js
@@ -263,7 +263,8 @@
     var line = document.createElement("div");
     if (res.ok) {
       line.className = "dang-playground-result";
-      line.textContent = "=> " + res.value;
+      // Highlight the result like the input (highlightHtml escapes it).
+      line.innerHTML = "=&gt; " + highlightHtml(res.value);
     } else {
       out.classList.add("is-error");
       line.className = "dang-playground-error";
@@ -516,7 +517,8 @@
       if (res.value !== "") {
         var line = document.createElement("div");
         line.className = "dang-playground-result";
-        line.textContent = "=> " + res.value;
+        // Highlight the result like the input (highlightHtml escapes it).
+        line.innerHTML = "=&gt; " + highlightHtml(res.value);
         out.appendChild(line);
       }
     } else {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Khan/genqlient v0.8.1
 	github.com/charmbracelet/fang v0.4.4
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/jrpc2 v1.3.3
 	github.com/dagger/otel-go v1.43.1-0.20260515012101-af7cd0684887
 	github.com/dagger/testctx v0.1.2
@@ -19,14 +20,13 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/vektah/gqlparser/v2 v2.5.30
-	github.com/vito/tuist v0.0.6-0.20260317030317-5530ade64acd
+	github.com/vito/tuist v0.0.7-0.20260617202722-ed3f1d64aee6
 	golang.org/x/sync v0.20.0
 	gotest.tools/v3 v3.5.2
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -161,10 +161,6 @@ github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsL
 github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/vito/pigeon v0.0.0-20260530031413-6ddc6a5a5a53 h1:6od1Xihcqxz4Ebv89ngBGRYW6rAZvsJj+W9EmtsKMFY=
 github.com/vito/pigeon v0.0.0-20260530031413-6ddc6a5a5a53/go.mod h1:XjNXeCGWAXtMkTaQQ0U4QTqJwZFfkTONME5a0uwpjpU=
-github.com/vito/tuist v0.0.7-0.20260617191526-ae2d0e490bbb h1:qyv4z2VqUmuUVfAkXHDoiPV85y9CTU1W9mubStuw/zU=
-github.com/vito/tuist v0.0.7-0.20260617191526-ae2d0e490bbb/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
-github.com/vito/tuist v0.0.7-0.20260617202527-a2010468cb93 h1:+M1EaGbLpQp6RM8CzRZZXWOlvnfjQxM7acUZz5Y3+l4=
-github.com/vito/tuist v0.0.7-0.20260617202527-a2010468cb93/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
 github.com/vito/tuist v0.0.7-0.20260617202722-ed3f1d64aee6 h1:IPtxrF8bghyJTOcUGw5aFdZRoul2/XJugGiWPdOWo88=
 github.com/vito/tuist v0.0.7-0.20260617202722-ed3f1d64aee6/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,12 @@ github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsL
 github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/vito/pigeon v0.0.0-20260530031413-6ddc6a5a5a53 h1:6od1Xihcqxz4Ebv89ngBGRYW6rAZvsJj+W9EmtsKMFY=
 github.com/vito/pigeon v0.0.0-20260530031413-6ddc6a5a5a53/go.mod h1:XjNXeCGWAXtMkTaQQ0U4QTqJwZFfkTONME5a0uwpjpU=
-github.com/vito/tuist v0.0.6-0.20260317030317-5530ade64acd h1:MBBx427mAOvv5agM9UDJ1kwkYHF3MhKJ+5n3fWj2EJs=
-github.com/vito/tuist v0.0.6-0.20260317030317-5530ade64acd/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
+github.com/vito/tuist v0.0.7-0.20260617191526-ae2d0e490bbb h1:qyv4z2VqUmuUVfAkXHDoiPV85y9CTU1W9mubStuw/zU=
+github.com/vito/tuist v0.0.7-0.20260617191526-ae2d0e490bbb/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
+github.com/vito/tuist v0.0.7-0.20260617202527-a2010468cb93 h1:+M1EaGbLpQp6RM8CzRZZXWOlvnfjQxM7acUZz5Y3+l4=
+github.com/vito/tuist v0.0.7-0.20260617202527-a2010468cb93/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
+github.com/vito/tuist v0.0.7-0.20260617202722-ed3f1d64aee6 h1:IPtxrF8bghyJTOcUGw5aFdZRoul2/XJugGiWPdOWo88=
+github.com/vito/tuist v0.0.7-0.20260617202722-ed3f1d64aee6/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/pkg/dang/generate.go
+++ b/pkg/dang/generate.go
@@ -1,3 +1,10 @@
 package dang
 
 //go:generate go run github.com/mna/pigeon -support-left-recursion -o dang.peg.go dang.peg
+
+// Refresh the embedded highlight query (highlight_ts.go go:embeds it) from the
+// canonical copy in the editors/zed submodule, symlinked into treesitter/queries.
+// cp -L follows the symlink to capture the query's content. It's best-effort:
+// if the submodule isn't checked out the symlink dangles, the copy is skipped,
+// and the committed pkg/dang/highlights.scm stays as the fallback.
+//go:generate sh -c "cp -L ../../treesitter/queries/highlights.scm highlights.scm 2>/dev/null || true"

--- a/pkg/dang/highlight_common.go
+++ b/pkg/dang/highlight_common.go
@@ -1,0 +1,76 @@
+package dang
+
+import "strings"
+
+// HighlightSpan is a styled region of source code identified by tree-sitter.
+// Start and End are rune offsets into the source, half-open [Start, End).
+// Class is a presentation-neutral token class (see the constants below);
+// callers map it onto colors/styles for their medium.
+type HighlightSpan struct {
+	Start, End int
+	Class      string
+}
+
+// Token classes returned in HighlightSpan.Class. These collapse the
+// editors' fine-grained tree-sitter captures into the handful of roles a
+// terminal palette distinguishes. Class "" means unstyled.
+const (
+	ClassKeyword   = "keyword"   // let, pub, if, type, and/or, ...
+	ClassType      = "type"      // capitalized type names
+	ClassNumber    = "number"    // int/float/bool/null and other constants
+	ClassString    = "string"    // string and template literals, docstrings
+	ClassEscape    = "escape"    // escapes within strings
+	ClassComment   = "comment"   // comments
+	ClassOperator  = "operator"  // =, +=, ??, ->, &, comparisons, ...
+	ClassFunction  = "function"  // function/method names
+	ClassBuiltin   = "builtin"   // builtin functions (assert, print, ...)
+	ClassDirective = "directive" // @directive names
+	ClassSelf      = "self"      // the self keyword
+	ClassLabel     = "label"     // language tags on templates
+	ClassProperty  = "property"  // argument/key names
+	ClassVariable  = "variable"  // bare identifiers
+	ClassPunct     = "punct"     // brackets, separators
+)
+
+// captureClass maps a tree-sitter highlight query capture name onto a token
+// class. It mirrors docs/go/highlight.go's captureClass (which maps the same
+// captures onto the docs site's CSS classes); the two must stay in lockstep
+// so the REPL, editors, and docs classify code identically. Unhandled
+// captures (notably @error) return "" to stay unstyled.
+func captureClass(name string) string {
+	switch name {
+	case "variable.special":
+		return ClassSelf
+	case "function.builtin":
+		return ClassBuiltin
+	case "function.macro":
+		return ClassDirective
+	case "string.escape":
+		return ClassEscape
+	case "property":
+		return ClassProperty
+	case "label":
+		return ClassLabel
+	case "type":
+		return ClassType
+	}
+	switch strings.SplitN(name, ".", 2)[0] {
+	case "keyword":
+		return ClassKeyword
+	case "constant", "number":
+		return ClassNumber
+	case "string":
+		return ClassString
+	case "comment":
+		return ClassComment
+	case "operator":
+		return ClassOperator
+	case "punctuation":
+		return ClassPunct
+	case "function":
+		return ClassFunction
+	case "variable":
+		return ClassVariable
+	}
+	return ""
+}

--- a/pkg/dang/highlight_nocgo.go
+++ b/pkg/dang/highlight_nocgo.go
@@ -1,0 +1,7 @@
+//go:build !cgo
+
+package dang
+
+// Highlight returns no spans without CGo, where tree-sitter is unavailable;
+// callers render plain text.
+func Highlight(source string) []HighlightSpan { return nil }

--- a/pkg/dang/highlight_test.go
+++ b/pkg/dang/highlight_test.go
@@ -1,0 +1,76 @@
+//go:build cgo
+
+package dang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// classOf returns the class covering the first rune of needle within source,
+// or "" if needle isn't found / isn't styled. Used to assert highlighting
+// without pinning exact span boundaries.
+func classOf(t *testing.T, source, needle string) string {
+	t.Helper()
+	idx := runeIndex(source, needle)
+	require.GreaterOrEqual(t, idx, 0, "needle %q not found in %q", needle, source)
+	for _, sp := range Highlight(source) {
+		if idx >= sp.Start && idx < sp.End {
+			return sp.Class
+		}
+	}
+	return ""
+}
+
+func runeIndex(source, needle string) int {
+	runes := []rune(source)
+	nr := []rune(needle)
+	for i := 0; i+len(nr) <= len(runes); i++ {
+		if string(runes[i:i+len(nr)]) == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestHighlightClasses(t *testing.T) {
+	src := `let x = 42
+let s = "hello"
+# a comment
+let c: Container = null`
+
+	assert.Equal(t, ClassKeyword, classOf(t, src, "let"))
+	assert.Equal(t, ClassNumber, classOf(t, src, "42"))
+	assert.Equal(t, ClassString, classOf(t, src, `"hello"`))
+	assert.Equal(t, ClassComment, classOf(t, src, "# a comment"))
+	// Capitalized names in type position are types (in expression position
+	// they're variables — matching the editors and docs).
+	assert.Equal(t, ClassType, classOf(t, src, "Container"))
+	assert.Equal(t, ClassOperator, classOf(t, src, "="))
+}
+
+func TestHighlightSpansSortedNonOverlapping(t *testing.T) {
+	spans := Highlight(`let greeting = "hi"`)
+	require.NotEmpty(t, spans)
+	prevEnd := 0
+	for _, sp := range spans {
+		assert.GreaterOrEqual(t, sp.Start, prevEnd, "spans overlap or unsorted: %+v", spans)
+		assert.Less(t, sp.Start, sp.End, "empty span")
+		assert.NotEmpty(t, sp.Class)
+		prevEnd = sp.End
+	}
+}
+
+func TestHighlightUnicodeRuneOffsets(t *testing.T) {
+	// A multibyte rune before a keyword must not shift the keyword's span:
+	// offsets are in runes, not bytes.
+	src := `"café" let x = 1`
+	assert.Equal(t, ClassKeyword, classOf(t, src, "let"))
+	assert.Equal(t, ClassString, classOf(t, src, `"café"`))
+}
+
+func TestHighlightEmptyAndPlain(t *testing.T) {
+	assert.Empty(t, Highlight(""))
+}

--- a/pkg/dang/highlight_ts.go
+++ b/pkg/dang/highlight_ts.go
@@ -1,0 +1,137 @@
+//go:build cgo
+
+package dang
+
+import (
+	_ "embed"
+	"log/slog"
+	"sort"
+	"sync"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	"github.com/vito/dang/v2/pkg/dang/danglang"
+)
+
+// highlights.scm is the same tree-sitter highlight query the editors and the
+// docs site use (it lives in the editors/zed submodule, symlinked into
+// treesitter/queries). It is embedded here so the binary highlights without
+// needing the repo or submodule at runtime; ./hack/generate refreshes the
+// copy from the symlink.
+//
+//go:embed highlights.scm
+var highlightsQuery string
+
+var (
+	highlightQuery     *tree_sitter.Query
+	highlightCaptures  []string
+	highlightQueryOnce sync.Once
+	highlightQueryErr  error
+)
+
+func compileHighlightQuery() {
+	q, err := tree_sitter.NewQuery(danglang.Language(), highlightsQuery)
+	if err != nil {
+		highlightQueryErr = err
+		return
+	}
+	highlightQuery = q
+	highlightCaptures = q.CaptureNames()
+}
+
+// Highlight classifies source with tree-sitter and returns styling spans in
+// rune offsets, coalesced into maximal runs of one class. Bytes covered by no
+// capture (or by captures that map to no class) produce no span. It degrades
+// gracefully: a parse/query failure yields no spans, so callers render plain.
+func Highlight(source string) []HighlightSpan {
+	highlightQueryOnce.Do(compileHighlightQuery)
+	if highlightQueryErr != nil {
+		slog.Debug("highlight query failed to compile", "error", highlightQueryErr)
+		return nil
+	}
+
+	src := []byte(source)
+
+	// tree-sitter parsers are not thread-safe; serialize access (shared with
+	// completion's parser).
+	tsMu.Lock()
+	tree := tsParser.Parse(src, nil)
+	tsMu.Unlock()
+	if tree == nil {
+		return nil
+	}
+	defer tree.Close()
+
+	// Per-byte class, then narrower (and later) captures override wider ones,
+	// mirroring how the editors and docs resolve the same query.
+	type span struct {
+		start, end int
+		class      string
+	}
+	var spans []span
+
+	cursor := tree_sitter.NewQueryCursor()
+	defer cursor.Close()
+	captures := cursor.Captures(highlightQuery, tree.RootNode(), src)
+	for {
+		match, idx := captures.Next()
+		if match == nil {
+			break
+		}
+		c := match.Captures[idx]
+		class := captureClass(highlightCaptures[c.Index])
+		if class == "" {
+			continue
+		}
+		spans = append(spans, span{
+			start: int(c.Node.StartByte()),
+			end:   int(c.Node.EndByte()),
+			class: class,
+		})
+	}
+
+	// Wider captures first so narrower (and later) ones overwrite them.
+	sort.SliceStable(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		return spans[i].end-spans[i].start > spans[j].end-spans[j].start
+	})
+
+	byteClass := make([]string, len(src))
+	for _, s := range spans {
+		for b := s.start; b < s.end && b < len(byteClass); b++ {
+			byteClass[b] = s.class
+		}
+	}
+
+	return coalesceRuneSpans(source, byteClass)
+}
+
+// coalesceRuneSpans walks source rune by rune, reading each rune's class from
+// the class of its first byte, and merges consecutive runes of the same
+// non-empty class into HighlightSpans addressed in rune offsets.
+func coalesceRuneSpans(source string, byteClass []string) []HighlightSpan {
+	var out []HighlightSpan
+	runeIdx := 0
+	curClass := ""
+	curStart := 0
+	flush := func(end int) {
+		if curClass != "" {
+			out = append(out, HighlightSpan{Start: curStart, End: end, Class: curClass})
+		}
+	}
+	for bytePos := range source { // range over string yields byte index of each rune
+		class := ""
+		if bytePos < len(byteClass) {
+			class = byteClass[bytePos]
+		}
+		if class != curClass {
+			flush(runeIdx)
+			curClass = class
+			curStart = runeIdx
+		}
+		runeIdx++
+	}
+	flush(runeIdx)
+	return out
+}

--- a/pkg/dang/highlights.scm
+++ b/pkg/dang/highlights.scm
@@ -1,0 +1,190 @@
+;; Keywords
+[
+  (let_token)
+  (pub_token)
+] @keyword
+[
+  (type_token)
+  (interface_token)
+  (union_token)
+  (implements_token)
+  (enum_token)
+  (scalar_token)
+  (if_token)
+  (else_token)
+  (break_token)
+  (continue_token)
+  (case_token)
+  (directive_token)
+  (on_token)
+  (import_token)
+  (new_token)
+  (try_token)
+  (catch_token)
+  (raise_token)
+  (return_token)
+
+  (and_token)
+  (or_token)
+] @keyword.control
+
+(self_keyword) @variable.special
+
+;; Literals
+(string) @string
+(string (immediate_escape) @string.escape) @string
+(doc_string) @string
+(triple_quote_string) @string
+(single_template "`" @string)
+(single_template
+  (single_template_part !e) @string)
+(multi_template
+  (multi_template_open_token) @string)
+(multi_template
+  (multi_template_close_token) @string)
+(multi_template
+  (multi_template_part !e) @string)
+(multi_template
+  (lang_tag_part (lang_tag_name) @label))
+(int) @constant.numeric
+(float) @constant.numeric
+(boolean) @constant.builtin.boolean
+(null) @constant.builtin
+
+;; Comments
+(comment_token) @comment.line
+(upper_token) @type
+
+;; Directives
+(directive_name) @function.macro
+(directive_application
+  (id) @function.macro)
+(directive_location
+  (upper_id) @constant.builtin)
+
+;; Operators and punctuation
+[
+  (equal_token)
+  (plus_equal_token)
+  (double_interro_token)
+  (bang_token)
+  (arrow_token)
+  (ampersand_token)
+  (equality_op)
+  (relational_op)
+  (additive_op)
+  (multiplicative_op)
+  (double_colon_token)
+] @operator
+
+(unary_expr "!" @operator)
+
+["{{" "}}" "{" "}" "[" "]" "(" ")"] @punctuation.bracket
+[
+  (comma_token)
+  (semi_token)
+  (dot_token)
+  (colon_token)
+] @punctuation.delimiter
+["@" "|"] @punctuation.special
+
+(spread_token) @punctuation.special
+
+;; Whitespace before `${` is parsed as part of the interpolation token because
+;; whitespace is normally an extra; keep that prefix highlighted as string.
+((single_template_part
+  "${" @string
+  e: (_)
+  "}")
+  (#offset! @string 0 0 0 -2))
+((multi_template_part
+  "${" @string
+  e: (_)
+  "}")
+  (#offset! @string 0 0 0 -2))
+
+;; Template interpolation delimiters. Keep these after the generic bracket
+;; captures so the closing `}` is highlighted as interpolation punctuation.
+((single_template_part
+  "${" @punctuation.special
+  e: (_)
+  "}")
+  (#trim! @punctuation.special 0 1 0 0))
+((single_template_part
+  "${"
+  e: (_)
+  "}" @punctuation.special)
+  (#trim! @punctuation.special 0 1 0 0))
+((multi_template_part
+  "${" @punctuation.special
+  e: (_)
+  "}")
+  (#trim! @punctuation.special 0 1 0 0))
+((multi_template_part
+  "${"
+  e: (_)
+  "}" @punctuation.special)
+  (#trim! @punctuation.special 0 1 0 0))
+
+;; Identifiers - using more generic patterns
+(symbol) @variable
+(auto_call_symbol (id) @variable)
+(call (symbol) @function.method)
+(symbol_block (symbol) @function.method)
+
+;; Key-value pairs
+(key_value
+  (word_token) @property)
+
+;; Special highlighting for built-in functions
+((call
+  (symbol) @function.builtin)
+  (#match? @function.builtin "^(assert|print|loop|toJSON|toString)$"))
+((symbol_block
+  (symbol) @function.builtin)
+  (#match? @function.builtin "^(assert|print|loop|toJSON|toString)$"))
+
+;; Field selections
+(select_or_call
+  (field_id) @function.method)
+
+;; Object selection (multi-field selection)
+(object_selection) @punctuation.bracket
+(field_selection
+  (id) @property)
+
+;; Error highlighting
+(ERROR) @error
+
+;; Field definitions
+(type_and_block_field
+  (symbol) @function.method)
+(type_and_args_field
+  (symbol) @function.method)
+(type_and_args_and_block_field
+  (symbol) @function.method)
+(type_and_value_field
+  (symbol) @function.method)
+(value_only_field
+  (symbol) @function.method)
+(type_only_field
+  (symbol) @function.method)
+(type_only_fun_field
+  (symbol) @function.method)
+
+(arg_with_block_default
+  (symbol) @variable.parameter)
+(arg_with_type
+  (symbol) @variable.parameter)
+(arg_with_default
+  (symbol) @variable.parameter)
+(block_param
+  (symbol) @variable.parameter)
+
+;; Object definitions
+(object_decl (symbol) @type)
+(implements (symbol) @type)
+(interface_decl (symbol) @type)
+(enum_decl (symbol) @type)
+(enum_decl (caps_symbol) @property)
+(scalar_decl (symbol) @type)

--- a/pkg/dang/repr.go
+++ b/pkg/dang/repr.go
@@ -1,0 +1,50 @@
+package dang
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Repr renders a value as Dang source syntax: strings are quoted, and lists
+// and maps recurse so their nested strings are quoted too. It's the form used
+// to echo REPL results, where the output should read back as the literal that
+// produced it (and highlight under the same grammar).
+//
+// This differs from String(), which renders strings bare (so print and string
+// interpolation emit raw text). Types without a distinct literal form — modules,
+// functions, enums, scalars — fall back to String().
+func Repr(v Value) string {
+	switch v := v.(type) {
+	case StringValue:
+		return strconv.Quote(v.Val)
+	case ListValue:
+		var b strings.Builder
+		b.WriteString("[")
+		for i, elem := range v.Elements {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(Repr(elem))
+		}
+		b.WriteString("]")
+		return b.String()
+	case MapValue:
+		if len(v.Keys) == 0 {
+			return "[:]"
+		}
+		var b strings.Builder
+		b.WriteString("[")
+		for i, k := range v.Keys {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(strconv.Quote(k))
+			b.WriteString(": ")
+			b.WriteString(Repr(v.Entries[k]))
+		}
+		b.WriteString("]")
+		return b.String()
+	default:
+		return v.String()
+	}
+}

--- a/pkg/dang/repr_test.go
+++ b/pkg/dang/repr_test.go
@@ -1,0 +1,44 @@
+package dang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepr(t *testing.T) {
+	str := StringValue{Val: "hi"}
+	list := ListValue{Elements: []Value{IntValue{1}, StringValue{Val: "a"}, BoolValue{true}}}
+	mapv := MapValue{
+		Keys:    []string{"name"},
+		Entries: map[string]Value{"name": StringValue{Val: "Bob"}},
+	}
+
+	tests := []struct {
+		name string
+		val  Value
+		want string
+	}{
+		{"string is quoted", str, `"hi"`},
+		{"string escapes", StringValue{Val: "a\"b\n"}, `"a\"b\n"`},
+		{"int unchanged", IntValue{42}, "42"},
+		{"bool unchanged", BoolValue{true}, "true"},
+		{"null unchanged", NullValue{}, "null"},
+		{"list quotes nested strings", list, `[1, "a", true]`},
+		{"empty list", ListValue{}, "[]"},
+		{"map quotes keys and values", mapv, `["name": "Bob"]`},
+		{"empty map", MapValue{}, "[:]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Repr(tt.val))
+		})
+	}
+}
+
+// Repr must not change String(): print and interpolation still emit raw text.
+func TestReprLeavesStringUnchanged(t *testing.T) {
+	s := StringValue{Val: "hi"}
+	assert.Equal(t, "hi", s.String())
+	assert.Equal(t, `"hi"`, Repr(s))
+}

--- a/pkg/repl/completion.go
+++ b/pkg/repl/completion.go
@@ -230,14 +230,16 @@ var kindOrder = [...]string{
 	KindInput:     "input",
 }
 
+// kindColors uses the ANSI 16-color palette ("0".."15") so completion-kind
+// tags follow the user's terminal theme.
 var kindColors = [...]string{
-	KindField:     "117",
-	KindType:      "213",
-	KindInterface: "141",
-	KindEnum:      "221",
-	KindScalar:    "114",
-	KindUnion:     "209",
-	KindInput:     "183",
+	KindField:     "6",  // cyan
+	KindType:      "3",  // yellow
+	KindInterface: "5",  // magenta
+	KindEnum:      "2",  // green
+	KindScalar:    "4",  // blue
+	KindUnion:     "1",  // red
+	KindInput:     "13", // bright magenta
 }
 
 func (k ItemKind) Label() string {
@@ -251,7 +253,7 @@ func (k ItemKind) Color() string {
 	if int(k) < len(kindColors) {
 		return kindColors[k]
 	}
-	return "247"
+	return "7" // default foreground
 }
 
 // DocItem is a single entry in the doc browser or completion detail.
@@ -470,11 +472,11 @@ func UnwrapType(t hm.Type) hm.Type {
 
 var (
 	DetailTitleStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("255")).Bold(true)
-	DocTextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("249"))
-	ArgNameStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
-	ArgTypeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	DimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+				Foreground(lipgloss.Color("15")).Bold(true) // bright white
+	DocTextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("7")) // white
+	ArgNameStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")) // cyan
+	ArgTypeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8")) // bright black
+	DimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8")) // bright black
 )
 
 // RenderDetailLines renders a DocItem for the completion detail panel.

--- a/pkg/repl/doc_browser_overlay.go
+++ b/pkg/repl/doc_browser_overlay.go
@@ -13,16 +13,18 @@ import (
 
 // ── styles ──────────────────────────────────────────────────────────────────
 
+// Styles use the ANSI 16-color palette ("0".."15") so the doc browser follows
+// the user's terminal theme.
 var (
-	DocTitleStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("63"))
-	DocActiveTitle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
-	DocSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Bold(true)
-	DocDocTextStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("249"))
-	DocArgNameStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
-	DocArgTypeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	DocDimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	DocSepStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
-	DocHoverStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Background(lipgloss.Color("237"))
+	DocTitleStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("5"))  // magenta
+	DocActiveTitle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("13")) // bright magenta
+	DocSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true) // bright magenta
+	DocDocTextStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("7"))             // white
+	DocArgNameStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))             // cyan
+	DocArgTypeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))             // bright black
+	DocDimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))             // bright black
+	DocSepStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))             // bright black
+	DocHoverStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Background(lipgloss.Color("8"))
 )
 
 // ── breadcrumb crumb ────────────────────────────────────────────────────────
@@ -35,17 +37,17 @@ type BreadcrumbCrumb struct {
 	OnClick func()
 }
 
-func (b *BreadcrumbCrumb) Render(_ tuist.Context) tuist.RenderResult {
+func (b *BreadcrumbCrumb) Render(ctx tuist.Context) {
 	var st lipgloss.Style
 	switch {
 	case b.Active:
-		st = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
+		st = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("13")) // bright magenta
 	case b.Hovered:
-		st = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Underline(true)
+		st = lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Underline(true)
 	default:
-		st = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Underline(true)
+		st = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Underline(true) // magenta
 	}
-	return tuist.RenderResult{Lines: []string{st.Render(b.Label)}}
+	ctx.Line(st.Render(b.Label))
 }
 
 func (b *BreadcrumbCrumb) HandleMouse(_ tuist.Context, ev tuist.MouseEvent) bool {
@@ -81,7 +83,7 @@ type DocColumnComp struct {
 	ScrollOffset int
 }
 
-func (c *DocColumnComp) Render(ctx tuist.Context) tuist.RenderResult {
+func (c *DocColumnComp) Render(ctx tuist.Context) {
 	w := ctx.Width
 	col := c.Browser.Columns[c.ColIdx]
 	isFiltering := c.Browser.Filtering && c.IsActive
@@ -100,7 +102,7 @@ func (c *DocColumnComp) Render(ctx tuist.Context) tuist.RenderResult {
 	filterLineH := 0
 	if len(col.Items) > 0 && (isFiltering || col.Filter != "") {
 		filterLineH = 1
-		filterStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+		filterStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3")) // yellow
 		filterText := "/" + col.Filter
 		if isFiltering {
 			filterText += "_"
@@ -180,7 +182,7 @@ func (c *DocColumnComp) Render(ctx tuist.Context) tuist.RenderResult {
 		lines[i] = PadRight(line, w)
 	}
 
-	return tuist.RenderResult{Lines: lines}
+	ctx.Lines(lines...)
 }
 
 func (c *DocColumnComp) HandleMouse(_ tuist.Context, ev tuist.MouseEvent) bool {
@@ -399,14 +401,15 @@ func (d *DocBrowserOverlay) handleFilterKey(key uv.Key) {
 	}
 }
 
-func (d *DocBrowserOverlay) Render(ctx tuist.Context) tuist.RenderResult {
+func (d *DocBrowserOverlay) Render(ctx tuist.Context) {
 	width := ctx.Width
 	height := ctx.Height
 	if height == 0 && ctx.ScreenHeight() > 0 {
 		height = ctx.ScreenHeight()
 	}
 	if width < 20 {
-		return tuist.RenderResult{Lines: []string{"(too narrow)"}}
+		ctx.Line("(too narrow)")
+		return
 	}
 
 	if height > 0 {
@@ -435,7 +438,7 @@ func (d *DocBrowserOverlay) Render(ctx tuist.Context) tuist.RenderResult {
 		if ci == len(d.ColComps)-1 {
 			w = lastColW
 		}
-		r := d.RenderChild(ctx.Resize(w, listH+2), cc)
+		r := d.RenderChildResult(ctx.Resize(w, listH+2), cc)
 		colRendered = append(colRendered, r.Lines)
 	}
 
@@ -458,7 +461,7 @@ func (d *DocBrowserOverlay) Render(ctx tuist.Context) tuist.RenderResult {
 		c.Active = i == d.ActiveCol
 		c.Label = d.Columns[i].Title
 		c.Update()
-		r := d.RenderChild(ctx.Resize(width, 1), c)
+		r := d.RenderChildResult(ctx.Resize(width, 1), c)
 		text := ""
 		if len(r.Lines) > 0 {
 			text = r.Lines[0]
@@ -480,7 +483,7 @@ func (d *DocBrowserOverlay) Render(ctx tuist.Context) tuist.RenderResult {
 		}
 	}
 
-	return tuist.RenderResult{Lines: result}
+	ctx.Lines(result...)
 }
 
 // SyncCrumbs ensures Crumbs has exactly ActiveCol+1 entries.


### PR DESCRIPTION
Adds tree-sitter syntax highlighting to the REPL and moves the whole REPL/TUI onto the ANSI 16-color palette so colors follow the user's terminal theme.

## Highlighting

A new `dang.Highlight(source)` classifies Dang source into rune-offset token spans using the **same tree-sitter grammar and `highlights.scm` query the editors and docs site use**, so every surface highlights identically. Tree-sitter captures are folded into a small set of presentation-neutral classes (`keyword`, `type`, `string`, `function`, …) by `captureClass`, kept in lockstep with `docs/go/highlight.go`.

It's wired into the REPL two ways:
- **Live, as you type** — via a new `Highlight` hook on tuist's `TextInput` ([vito/tuist#2](https://github.com/vito/tuist/pull/2), now merged). Styling is applied per visual segment so it survives word-wrapping, and the cursor is computed from the raw runes so it never drifts.
- **Scrollback** — submitted code is re-highlighted when echoed.

REPL meta-commands (lines starting with `:`) are left unstyled.

The query is embedded into the binary (a generated copy of the symlinked Zed query), so highlighting works without the repo or the `editors/zed` submodule present at runtime. `./hack/generate` refreshes it best-effort. The highlighter is cgo-gated like the existing tree-sitter completion code, with a no-op fallback when built without cgo.

## ANSI 16-color palette

Every REPL/TUI style is converted off hard-coded 256-color shades onto the 16-color palette — prompt, result, error, dim, spinner, completion-kind tags, and the doc browser — plus the token-class → color mapping for highlighting. The class colors mirror the docs' Rosé Pine palette collapsed onto the 16 colors (e.g. strings take green since the two blues can't both fit).

## Notes

- Bumps tuist to pick up the `Highlight` hook, which also moves components onto tuist's new `ctx.Line` render API; `entryView` and the doc browser's `Render` methods are adapted accordingly.
- Full `dagger check` is green: lint, `test:go`, `test:docs-go`, `test:treesitter`, docs, fmt, generate.