### PR TITLE
docs: add the inkstained-dark theme

### DIFF
--- a/docs/html/base16-options.tmpl
+++ b/docs/html/base16-options.tmpl
@@ -222,6 +222,7 @@
 <option value="icy">icy</option>
 <option value="idea">idea</option>
 <option value="idle-toes">idle-toes</option>
+<option value="inkstained-dark">inkstained-dark</option>
 <option value="inkstained">inkstained</option>
 <option value="irblack">irblack</option>
 <option value="isotope">isotope</option>

--- a/docs/js/switcher.js
+++ b/docs/js/switcher.js
@@ -206,6 +206,7 @@ var curatedDarkStyles = [
   "ic-green-ppl",
   "ic-orange-ppl",
   "idle-toes",
+  "inkstained-dark",
   "irblack",
   "kanagawa",
   "kanagawa-dragon",

--- a/docs/schemes-local/inkstained-dark.css
+++ b/docs/schemes-local/inkstained-dark.css
@@ -1,0 +1,64 @@
+/* Inkstained Dark — progressive enhancement layered on the base16 :root above.
+ *
+ * The dark companion to inkstained.css, with the same four flourishes re-tuned
+ * for a dark ground: where the light theme paints dark ink on pale tints, this
+ * paints pale ink on deep tints. genthemes appends this to the generated
+ * base16-inkstained-dark.css, and switcher.js swaps a single <link> between the
+ * css/base16/*.css files, so every rule here applies only while Inkstained Dark
+ * is the active scheme.
+ *
+ * The active scheme's stylesheet loads before page.tmpl's inline <style>, so
+ * the prose rules below are scoped to `main` both to clear that later style on
+ * specificity and to stay clear of the same tags in the sidebar/ToC nav. */
+
+:root {
+  /* inkstained's accent families, lifted for the dark ground; the `-tint`
+     backgrounds are deep, desaturated washes that sit just above base00
+     (https://github.com/yuttie/inkstained-vim). */
+  --ink-red-tint: #3a2a31;     --ink-red: #d2899a;
+  --ink-teal-tint: #243531;    --ink-teal: #a6cecb;
+  --ink-cyan-tint: #233139;    --ink-cyan: #6f9db0;
+  --ink-blue: #91a8c9;         --ink-blue-2: #7593bb;
+  --ink-violet-tint: #2a2735;  --ink-violet: #9784ae;
+  --ink-violet-light: #ac99c4;
+  --ink-magenta-tint: #2f2531; --ink-magenta: #c190ae;
+  --ink-magenta-soft: #b0789b;
+}
+
+/* Identifiers and keywords are set in bold ink — inkstained's most
+   recognizable trait. (JetBrains Mono is monospace at every weight, so the
+   bold tokens stay column-aligned in code blocks.) */
+.tok-function,
+.tok-keyword { font-weight: 700; }
+
+/* The signature teal box behind literals: strings and the true/false/null/
+   number constants, now pale teal on a deep teal wash. Background only — no
+   padding — so code stays aligned. */
+.tok-string,
+.tok-number {
+  color: var(--ink-teal);
+  background-color: var(--ink-teal-tint);
+  border-radius: 3px;
+}
+
+/* Code set inside paragraphs gets the same teal box, so inline references read
+   like the literals they usually are. page.tmpl keeps the padding and radius;
+   this only recolors. */
+main p code {
+  color: var(--ink-teal);
+  background-color: var(--ink-teal-tint);
+}
+
+/* A sparing wash of magenta marks the prose headings. */
+main h1,
+main h2,
+main h3 { color: var(--ink-magenta); }
+
+/* Asides take a quiet violet tint — another inkstained hue the base16 slots
+   don't surface on their own. page.tmpl's 3px solid left border stays; only
+   its color and the background change. */
+main blockquote,
+main .inset {
+  border-left-color: var(--ink-violet);
+  background-color: var(--ink-violet-tint);
+}

--- a/docs/schemes-local/inkstained-dark.yaml
+++ b/docs/schemes-local/inkstained-dark.yaml
@@ -1,0 +1,30 @@
+system: "base16"
+name: "Inkstained Dark"
+author: "after yuttie's inkstained-vim, base16 dark variant for the dang docs"
+slug: "inkstained-dark"
+variant: "dark"
+# A dark companion to the inkstained theme. yuttie's inkstained-vim is a light
+# scheme (https://github.com/yuttie/inkstained-vim), but its greyscale ramp is
+# Solarized-style and its accents are a cool slate-blue / teal / cyan / violet
+# family — so this inverts the value of the ramp (deep slate ground, pale cool
+# ink) and lifts the accents to their lighter inkstained variants so they read
+# on the dark background. base09/base0A/base0F stay muted sepia, lifted to
+# match, the way the light scheme fills the base16 rainbow inkstained leaves
+# open.
+palette:
+  base00: "#1a1e26" # page + code background (deep ink slate)
+  base01: "#222732" # sidebar / selection background
+  base02: "#2b303b" # inline-code / hover background
+  base03: "#626c7e" # comments (dim slate)
+  base04: "#8b94a5" # secondary labels
+  base05: "#d7dae1" # prose / default foreground (pale cool ink)
+  base06: "#e6e8ec" # lighter foreground
+  base07: "#f3f4f6" # lightest foreground
+  base08: "#d2899a" # red    — variables, tags, errors (lifted inkstained rose)
+  base09: "#cf9b6a" # orange — numbers, constants, run button (lifted sepia)
+  base0A: "#c9b96b" # yellow — types (lifted gold)
+  base0B: "#88b5b1" # green  — strings (lifted inkstained teal)
+  base0C: "#6f9db0" # cyan   — builtins, escapes (inkstained cyan3)
+  base0D: "#91a8c9" # blue   — functions, links (inkstained blue3)
+  base0E: "#ac99c4" # violet — keywords, operators (inkstained violet3)
+  base0F: "#b08a6a" # brown  — deprecations (lifted sepia)


### PR DESCRIPTION
A dark companion to [`inkstained`](https://github.com/vito/dang/pull/140) (now on `main`): ink at night.

## The idea

yuttie's [inkstained-vim](https://github.com/yuttie/inkstained-vim) is a *light* scheme, but two things make a dark version natural: its greyscale ramp is Solarized-style (it already runs light→dark), and its accents are a cool slate-blue / teal / cyan / violet / magenta family. So this **inverts the ramp's value** — a deep slate ground with pale cool ink — and **lifts each accent to its lighter inkstained variant** (the palette conveniently ships `cyan3`, `blue3`, `violet3`, etc. for exactly this), so the cool hues read on the dark background. The sepia stand-ins for the orange/yellow/brown slots that inkstained leaves open are lifted to match.

| slot | | role |
|---|---|---|
| `base00` `#1a1e26` | deep ink slate | page + code bg |
| `base03` `#626c7e` | dim slate | comments |
| `base05` `#d7dae1` | pale cool ink | prose / default fg |
| `base08` `#d2899a` | lifted rose | variables, tags, errors |
| `base09` `#cf9b6a` | lifted sepia | numbers, constants, run button |
| `base0A` `#c9b96b` | lifted gold | types |
| `base0B` `#88b5b1` | lifted teal | strings |
| `base0C` `#6f9db0` | cyan3 | builtins, escapes |
| `base0D` `#91a8c9` | blue3 | functions, links |
| `base0E` `#ac99c4` | violet3 | keywords, operators |
| `base0F` `#b08a6a` | lifted sepia | deprecations |

## Beyond base16

The enhancement layer mirrors the light theme's four flourishes, re-tuned for a dark ground — where the light theme paints **dark ink on pale tints**, this paints **pale ink on deep tints**:

- **Bold ink identifiers** — `.tok-function` and `.tok-keyword` go bold.
- **The signature teal box** — string/constant literals and inline code render as pale teal `#a6cecb` on a deep teal wash `#243531`.
- **A sparing magenta** on prose headings (`#c190ae`).
- **A violet wash** on asides.

Same mechanism as before: `genthemes` appends `schemes-local/inkstained-dark.css` to the generated stylesheet, and because `switcher.js` swaps a single `<link>`, these rules apply only while Inkstained Dark is active.

## No generator changes

The `schemes-local` infrastructure landed in #140 already globs `schemes-local/*.yaml` and appends a scheme's optional `<name>.css`, so the dark variant is purely additive: a `.yaml`, a `.css`, and the two regenerated registries.

## Changes

- `docs/schemes-local/inkstained-dark.yaml`, `docs/schemes-local/inkstained-dark.css` — the dark scheme and its enhancement layer.
- `docs/html/base16-options.tmpl` — adds the `inkstained-dark` option (regenerated).
- `docs/js/switcher.js` — adds `inkstained-dark` to `curatedDarkStyles` (regenerated by `curatethemes -write`).

## Verification

- `go vet` clean; `genthemes` emits the 16 `--base*` variables plus the appended enhancement, only on this scheme.
- `curatethemes -v` → `PASS dark inkstained-dark` (and the light `inkstained` still passes) — clears every contrast floor, and is classified dark, so it joins the dark rotation.
- Both committed registries changed by exactly the one `inkstained-dark` line.

> Same caveat as #140: no browser/node in this sandbox, so this is verified by cascade analysis and generated-output inspection, not a screenshot. To eyeball: `cd docs && ./build.sh`, open `index.html`, pick "inkstained-dark".
