### PR TITLE
Object equality: compare by reference identity

### DIFF
--- a/.agents/skills/dang-language/reference/graphql.md
+++ b/.agents/skills/dang-language/reference/graphql.md
@@ -53,6 +53,10 @@ users.{name}[0].name      # index to force it
 ## Laziness / forcing
 GraphQL field access is **lazy**. A GraphQL value accumulates a query chain (`.field`, `.{...}`, args); no request is sent until the value is **forced** — materialized at an expected-type boundary (assertion, `print`, assignment to a typed field, indexing into a result, etc.). Forcing runs the built-up selection as a single request. This is what makes `user.{ name, posts.{ title } }` one round-trip.
 
+## Equality
+- `==`/`!=` on GraphQL objects compare by **reference identity**, exactly like native `type` objects — no network call. A GraphQL object's identity is the query that produced it, so the same handle equals itself, but two independent constructions don't, even when they denote the same server object: `primaryUser == user(id: "1")` is `false` (just as `Rabbit("x") == Rabbit("x")` is `false`).
+- To ask whether two objects are the *same server entity*, compare an identifying field explicitly: `a.id == b.id`. That forces the fetch where it's visible rather than hiding I/O inside `==`.
+
 ## Errors from the server
 - Non-null violations and GraphQL errors **raise** — catchable via `try`/`catch`.
 

--- a/.agents/skills/dang-language/reference/syntax.md
+++ b/.agents/skills/dang-language/reference/syntax.md
@@ -100,6 +100,8 @@ greet(
 ### Comparison
 - `< <= > >=` on **numbers only** (`Int`/`Float`, mixed allowed) — NOT on strings.
 - `== !=` are type-safe: mismatched types compare `false`, no coercion (`num == str` is `false`). Work on numbers, strings, bools, null, lists, records. Return `Boolean!`.
+- Objects compare by **reference identity**, never structurally — equal only when the same instance, so two separately built objects with matching fields are not equal (`Rabbit("x") == Rabbit("x")` is `false`).
+- Same for GraphQL objects: identity is the query that produced them, so `primaryUser == user(id: "1")` is `false` even though both denote the same user — no network call. To compare GraphQL objects as the *same server entity*, compare a field explicitly: `a.id == b.id`.
 
 ### Logical
 - `and`, `or` short-circuit (keywords, not `&&`/`||`); result `Boolean!`.

--- a/docs/lit/graphql/interop.md
+++ b/docs/lit/graphql/interop.md
@@ -83,6 +83,11 @@ users.{{ name, email }}
 
 > Laziness: GraphQL field access in Dang is lazy. A `GraphQLValue` accumulates a query chain (`.field`, `.{{...}}` selections, args); no request is sent until the value is **forced** — i.e. materialized at an expected-type boundary (assertion, `print`, assignment to a typed field, indexing into a result, etc.). Forcing runs the built-up selection as a single `Execute` against the endpoint. This is the desugaring that makes `user.{{ name, posts.{{ title }} }}` one round-trip. See [#mutation] for how forcing interacts with side effects.
 
+## Object equality
+
+- `==`/`!=` compare GraphQL objects by **reference identity**, the same way native `type` objects compare — there's no network call. A GraphQL object's identity is the query that produced it, so the same handle equals itself but two independent constructions don't, even when they denote the same server object: `primaryUser == user(id: "1")` is `false` (just as `Rabbit("x") == Rabbit("x")` is `false`)
+- to ask whether two objects are the *same server entity*, compare an identifying field explicitly — `a.id == b.id` — which forces the necessary fetch where you can see it, instead of hiding I/O inside `==`
+
 ## Errors from the server
 
 - non-null violations and GraphQL errors raise — catchable via `try`/`catch` (see [#errors])

--- a/docs/lit/language/operators.md
+++ b/docs/lit/language/operators.md
@@ -38,6 +38,8 @@ Precedence follows the `DefaultExpr → … → MultiplicativeExpr → Term` cha
 - `<` `<=` `>` `>=` on numbers (`Int`/`Float`, mixed allowed) or strings (compared lexicographically) — operands must match (`"a" < 1` is a static type error)
 - `==` `!=` are type-safe — mismatched types compare `false`, no coercion (`num == str` is `false`)
 - `==`/`!=` work on numbers, strings, bools, null, lists, records; both return `Boolean!`
+- objects compare by **reference identity**, never by structure — equal only when they're the same instance, so two separately constructed objects with matching fields are not equal (`Rabbit("x") == Rabbit("x")` is `false`)
+- this applies to both native (`type`) objects and GraphQL objects; a GraphQL object's identity is the query that produced it, so `primaryUser == user(id: "1")` is `false` even though both denote the same user. To ask whether two GraphQL objects are the *same server entity*, compare an identifying field, e.g. `a.id == b.id`
 
 ## Logical
 

--- a/pkg/dang/ast.go
+++ b/pkg/dang/ast.go
@@ -215,7 +215,15 @@ func createValueNode(val Value) *ValueNode {
 	return &ValueNode{Val: val, Loc: nil}
 }
 
-// valuesEqual compares two values for equality
+// valuesEqual compares two values for equality.
+//
+// Objects compare by reference identity, never by structure: two separately
+// constructed objects are unequal even if their fields match (just as
+// Rabbit("x") != Rabbit("x")). For native objects identity is the *Object
+// pointer; for GraphQL objects it's the query chain that produced them (an
+// immutable builder allocated fresh per construction and shared across copies
+// of a binding). To compare GraphQL objects as the *same server entity*,
+// compare an identifying field explicitly, e.g. a.id == b.id.
 func valuesEqual(left, right Value) bool {
 	// Handle null values
 	_, leftIsNull := left.(NullValue)
@@ -298,10 +306,21 @@ func valuesEqual(left, right Value) bool {
 			}
 			return true
 		}
+	case *Object:
+		// Reference equality: equal only if the same instance.
+		if r, ok := right.(*Object); ok {
+			return l == r
+		}
+	case GraphQLValue:
+		// Reference equality: a GraphQL object's identity is its query chain,
+		// so the same handle compares equal to itself but two independent
+		// constructions don't.
+		if r, ok := right.(GraphQLValue); ok {
+			return l.QueryChain == r.QueryChain
+		}
 	}
 
 	// Different types or unsupported comparison
-	// TODO: object comparison?
 	return false
 }
 

--- a/tests/test_graphql_object_equality.dang
+++ b/tests/test_graphql_object_equality.dang
@@ -1,0 +1,18 @@
+# Test GraphQL object equality (reference identity, like native objects)
+
+import Test
+
+# The same handle is equal to itself.
+let u = primaryUser
+assert("same handle is equal") { u == u }
+
+# Two independent constructions are NOT equal, even when they denote the same
+# server object — exactly as Rabbit("x") != Rabbit("x"). Compare a field (e.g.
+# .id) when you want to ask whether two objects are the same server entity.
+assert("independent constructions are not equal") { (primaryUser == user(id: "1")) == false }
+
+# != mirrors ==.
+assert("inequality holds for independent constructions") { primaryUser != user(id: "1") }
+assert("inequality is false for the same handle") { (u != u) == false }
+
+print("GraphQL object equality tests passed!")

--- a/tests/test_object_equality.dang
+++ b/tests/test_object_equality.dang
@@ -1,0 +1,38 @@
+# Test object equality (reference equality for *Object values)
+
+type Hat {
+  animal: Animal = null
+
+  insert(animal: Animal!): Hat! {
+    self.animal = animal
+    self
+  }
+}
+
+interface Animal {
+  coat: Coat!
+}
+
+enum Coat { SKIN FUR FEATHERS }
+
+type Rabbit implements Animal {
+  name: String!
+
+  coat: Coat! { Coat.FUR }
+}
+
+let jeff = Rabbit("jeffrey")
+let hat = Hat
+let withJeff = hat.insert(jeff)
+assert { hat.animal == null }
+assert { withJeff.animal == jeff }
+assert { withJeff.animal.coat == Coat.FUR }
+
+# A distinct object with the same contents is not reference-equal
+let otherJeff = Rabbit("jeffrey")
+assert("distinct objects are not equal") { (jeff == otherJeff) == false }
+
+# Same object reference is equal to itself
+assert("same reference is equal") { jeff == jeff }
+
+print("Object equality tests completed")


### PR DESCRIPTION
## Why

Object equality silently fell through to `false`. `valuesEqual` had a `TODO` for the object case, so `==` on two objects was never true — even an object compared with itself. This failed on the `withJeff.animal == jeff` assertion in the repro below:

```dang
type Hat {
  animal: Animal = null
  insert(animal: Animal!): Hat! {
    self.animal = animal
    self
  }
}
interface Animal { coat: Coat! }
enum Coat { SKIN FUR FEATHERS }
type Rabbit implements Animal {
  name: String!
  coat: Coat! { Coat.FUR }
}

let jeff = Rabbit("jeffrey")
let withJeff = Hat.insert(jeff)
assert { withJeff.animal == jeff }   # was false
```

## What changed

Objects now compare by **reference identity** — never by structure — for both native and GraphQL objects:

- **Native objects** (`*Object`): equal only when the same instance. Two separately constructed objects with matching fields are not equal (`Rabbit("x") == Rabbit("x")` is `false`).
- **GraphQL objects**: same rule. A `GraphQLValue` is an immutable lazy query chain, so its identity *is* that chain (allocated fresh per construction, shared across copies of a binding). The same handle equals itself, but two independent constructions don't — `primaryUser == user(id: "1")` is `false`, consistent with `Rabbit("x") == Rabbit("x")`.

To ask whether two GraphQL objects are the *same server entity*, compare an identifying field explicitly: `a.id == b.id`. That forces the fetch where the caller can see it, rather than hiding network I/O inside `==`.

`valuesEqual` stays a pure, context-free function — no I/O, no error path threaded through `case` / `contains` / `uniq`.

> [!NOTE]
> An alternative considered was comparing GraphQL objects by their server `id` (so the same entity across different queries would compare equal). It was rejected: it's inconsistent with native-object identity and would make `==` do hidden network I/O. Reference identity is the consistent, pure model; entity identity is left to an explicit `.id` comparison.

## Tests

- `tests/test_object_equality.dang` — the repro plus same-reference and distinct-but-identical cases (red/green TDD)
- `tests/test_graphql_object_equality.dang` — same handle is equal; two independent constructions are not; `!=` mirrors `==`

Full `./tests/` suite passes (language, format round-trip, error suites).

## Docs

Documented reference-identity equality — and the explicit `.id` comparison for entity identity — in the operator reference, GraphQL interop docs, and the dang-language skill.

