### PR TITLE
dang: allow multi-field selection on any selectable value

### DIFF
--- a/.agents/skills/dang-language/reference/graphql.md
+++ b/.agents/skills/dang-language/reference/graphql.md
@@ -42,9 +42,12 @@ node(id: "x").{
 
 ## Lists of objects
 ```dang
-users.{ name, email }     # elementwise; result is [ {{ name, email }} ]
-users.{name}[0].name      # index to force it
+users.{{ name, email }}    # distributes over elements -> [ {{ name, email }} ]
+users.{{ name }}[0].name   # index to force the query
 ```
+- A selection on a list reaches **into each element** (mirrors GraphQL: a selection set on a list-typed field applies per element). `.{{ … }}` is element-wise; `.field` treats the list as the receiver and resolves a list method (`.length`, `.map`). So `xs.{{ f }}` is not `xs.f`.
+- Nested selections distribute the same way: `users.{{ name, posts.{{ title }} }}`.
+- Result records compare by **value**, so lists of projections compare directly (`users.{{ name }} == [{{ name: "Alice" }}]`). The result is an ordinary list — chain `.map`, index, etc.
 
 ## Mutations
 - Root `Mutation` fields are functions like queries; the result is whatever the schema declares.

--- a/docs/lit/graphql/interop.md
+++ b/docs/lit/graphql/interop.md
@@ -71,8 +71,12 @@ node(id: "x").{{
 users.{{ name, email }}
 ```
 
-- applies the selection elementwise; result is `[ {{ name, email }} ]` (a list of records)
-- index into the result to force it: `users.{{name}}[0].name`; see [#collections]
+- a selection on a list **distributes over its elements**: `users.{{ name, email }}` selects those fields from every element, producing `[ {{ name, email }} ]` — a list of records
+- this is the shape GraphQL itself produces: a selection set on a list-typed field applies to each element, so `users.{{ name, email }}` mirrors the response of `{ users { name email } }`
+- `.{{ … }}` and `.field` do different jobs on a list. `.field` treats the **list** as the receiver and resolves a list method (`users.length`, `users.map { … }`); `.{{ … }}` reaches **into** each element. So `xs.{{ f }}` is not `xs.f` — the former is a list of `{{ f }}` records, the latter looks for a method `f` on the list itself
+- nested selections distribute the same way: `users.{{ name, posts.{{ title }} }}` gives a list of records each holding its own list of post records
+- the result records compare by **value** ([#operators]), so a list of projections can be compared, asserted on, or deduplicated directly: `users.{{ name }} == [{{ name: "Alice" }}, {{ name: "Bob" }}]`
+- the result is an ordinary list — chain list operations on it (`users.{{ name }}.map { r => r.name }`) or index to force the query: `users.{{ name }}[0].name`; see [#collections]
 
 ## Mutations
 

--- a/pkg/dang/ast_expressions.go
+++ b/pkg/dang/ast_expressions.go
@@ -1684,20 +1684,9 @@ func (o *ObjectSelection) Eval(ctx context.Context, scope ValueScope) (Value, er
 			return o.evalInlineFragmentOnValue(receiverVal, ctx, scope)
 		}
 
-		// Handle list types - apply selection to each element
-		if listVal, ok := receiverVal.(ListValue); ok {
-			var results []Value
-			for _, elem := range listVal.Elements {
-				result, err := o.evalSelectionOnValue(elem, ctx, scope)
-				if err != nil {
-					return nil, err
-				}
-				results = append(results, result)
-			}
-			return ListValue{Elements: results}, nil
-		}
-
-		// Handle regular object types
+		// Apply the selection. evalSelectionOnValue handles lists (element-wise),
+		// GraphQL values (one batched query), objects, and scalar/builtin
+		// receivers uniformly.
 		return o.evalSelectionOnValue(receiverVal, ctx, scope)
 	})
 }
@@ -2040,69 +2029,88 @@ func (o *ObjectSelection) evalSelectionOnValue(val Value, ctx context.Context, s
 	case NullValue:
 		// Null propagation for individual values in lists
 		return NullValue{}, nil
-	case *Object:
-		return o.evalModuleSelection(v, ctx, scope)
+	case ListValue:
+		// Apply the selection element-wise, matching the inferred element type.
+		results := make([]Value, len(v.Elements))
+		for i, elem := range v.Elements {
+			result, err := o.evalSelectionOnValue(elem, ctx, scope)
+			if err != nil {
+				return nil, err
+			}
+			results[i] = result
+		}
+		return ListValue{Elements: results}, nil
 	case GraphQLValue:
+		// GraphQL receivers are special-cased so the whole selection becomes a
+		// single batched query — the GraphQL server resolves the sibling fields
+		// in parallel, just as it would for a query written by hand.
 		return o.evalGraphQLSelection(v, ctx, scope)
 	default:
-		return nil, fmt.Errorf("ObjectSelection.evalSelectionOnValue: expected *Object or GraphQLValue, got %T", val)
+		// Any other selectable value — a Dang object, a String, a Float, a Map,
+		// etc. — is handled uniformly by evaluating each field through the same
+		// Select machinery that powers single-field selection. This keeps
+		// `recv.{{ a, b }}` aligned with `recv.a` / `recv.b` by construction:
+		// whatever a single selection can reach, a multi-field selection can too.
+		return o.evalFieldsBySelection(v, ctx, scope)
 	}
 }
 
-func (o *ObjectSelection) evalModuleSelection(objVal *Object, ctx context.Context, scope ValueScope) (Value, error) {
+// evalFieldsBySelection builds the result object by selecting each field off the
+// receiver exactly as a standalone `recv.field` expression would. Delegating to
+// Select (and FunCall, for fields with arguments) is what guarantees multi-field
+// selection works for every selectable value, not just objects and GraphQL.
+func (o *ObjectSelection) evalFieldsBySelection(recv Value, ctx context.Context, scope ValueScope) (Value, error) {
 	if o.Inferred == nil {
-		return nil, fmt.Errorf("ObjectSelection.evalModuleSelection: inferred type is nil")
+		return nil, fmt.Errorf("ObjectSelection.evalFieldsBySelection: inferred type is nil")
 	}
 
 	resultObject := NewObject(o.Inferred)
-
-	// Build result object with selected fields
 	for _, field := range o.Fields {
-		var fieldVal Value
-		var err error
-
-		if len(field.Args) > 0 {
-			// Field has arguments - create a Select then FunCall to evaluate
-			selectNode := &Select{
-				Receiver: createValueNode(objVal),
-				Field:    &Symbol{Name: field.Name, Loc: field.Loc},
-				AutoCall: false,
-				Loc:      field.Loc,
-			}
-
-			funCall := &FunCall{
-				Fun:  selectNode,
-				Args: field.Args,
-				Loc:  field.Loc,
-			}
-			fieldVal, err = funCall.Eval(ctx, scope)
-			if err != nil {
-				return nil, fmt.Errorf("ObjectSelection.evalModuleSelection: evaluating field %q with args: %w", field.Name, err)
-			}
-		} else {
-			// No arguments - get field value directly
-			var exists bool
-			fieldVal, exists, err = objVal.Lookup(ctx, field.Name)
-			if err != nil {
-				return nil, err
-			}
-			if !exists {
-				return nil, fmt.Errorf("ObjectSelection.evalModuleSelection: field %q not found", field.Name)
-			}
+		fieldVal, err := o.evalFieldSelection(recv, field, ctx, scope)
+		if err != nil {
+			return nil, err
 		}
-
-		// Handle nested selections
-		if field.Selection != nil {
-			fieldVal, err = field.Selection.evalSelectionOnValue(fieldVal, ctx, scope)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		resultObject.Bind(field.Name, fieldVal, PublicVisibility)
 	}
-
 	return resultObject, nil
+}
+
+// evalFieldSelection evaluates a single selected field against the receiver,
+// reusing the Select/FunCall evaluation path so the result matches what the
+// equivalent standalone selection would produce.
+func (o *ObjectSelection) evalFieldSelection(recv Value, field *FieldSelection, ctx context.Context, scope ValueScope) (Value, error) {
+	selectNode := &Select{
+		Receiver: createValueNode(recv),
+		Field:    &Symbol{Name: field.Name, Loc: field.Loc},
+		// With no arguments the field is auto-called when it resolves to a
+		// zero-arity function, mirroring how the type was inferred.
+		AutoCall: len(field.Args) == 0,
+		Loc:      field.Loc,
+	}
+
+	var node Node = selectNode
+	if len(field.Args) > 0 {
+		node = &FunCall{
+			Fun:  selectNode,
+			Args: field.Args,
+			Loc:  field.Loc,
+		}
+	}
+
+	fieldVal, err := EvalNode(ctx, scope, node)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle nested selections, e.g. profile.{{ bio, avatar }}.
+	if field.Selection != nil {
+		fieldVal, err = field.Selection.evalSelectionOnValue(fieldVal, ctx, scope)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return fieldVal, nil
 }
 
 func (o *ObjectSelection) evalGraphQLSelection(gqlVal GraphQLValue, ctx context.Context, scope ValueScope) (Value, error) {

--- a/tests/test_object_selection.dang
+++ b/tests/test_object_selection.dang
@@ -49,9 +49,10 @@ let users = [
 ]
 
 let user_summaries = users.{{name, email}}
-# Note: Since Dang doesn't support array indexing, we'll test the structure differently
-# We can verify the object selection works by checking that the result is well-formed
-assert { user_summaries != null }
+assert { user_summaries.length == 2 }
+assert { user_summaries[0].name == "Charlie" }
+assert { user_summaries[0].email == "charlie@example.com" }
+assert { user_summaries[1].name == "Diana" }
 
 # Test with nested lists
 let users_with_profile = [
@@ -60,8 +61,10 @@ let users_with_profile = [
 ]
 
 let detailed_summaries = users_with_profile.{{name, profile.{{bio}}}}
-# Note: Since Dang doesn't support array indexing, we'll test the structure differently
-# We can verify the nested object selection works by checking that the result is well-formed
-assert { detailed_summaries != null }
+assert { detailed_summaries.length == 2 }
+assert { detailed_summaries[0].name == "Eve" }
+assert { detailed_summaries[0].profile.bio == "Designer" }
+assert { detailed_summaries[1].name == "Frank" }
+assert { detailed_summaries[1].profile.bio == "Developer" }
 
 print("Object selection tests passed!")

--- a/tests/test_scalar_selection.dang
+++ b/tests/test_scalar_selection.dang
@@ -3,6 +3,13 @@
 # as a standalone `recv.field`, so whatever a single selection can reach a
 # multi-field selection can too.
 
+# A type with a computed (zero-arg method) field, used below to prove that
+# selecting such a field actually calls it rather than capturing the function.
+type Widget {
+  name: String! = "?"
+  label: String! { name.toUpper }
+}
+
 # Selecting builtin methods on a String
 let upper_lower = "Hello".{{ toUpper, toLower }}
 assert { upper_lower.toUpper == "HELLO" }
@@ -18,8 +25,29 @@ let trimmed = "  spaced  ".{{ trimSpace, hasPrefix(prefix: " ") }}
 assert { trimmed.trimSpace == "spaced" }
 assert { trimmed.hasPrefix == true }
 
-# Element-wise selection over a list of scalars
+# A selected zero-arg method field is auto-called, matching its inferred type
+# and what `widget.label` yields on its own (it resolves to String!, not a
+# function value).
+let one = Widget("a").{{ name, label }}
+assert { one.name == "a" }
+assert { one.label == "A" }
+
+# Element-wise selection over a list of scalars; results are one-field records
 let shouted = ["foo", "bar"].{{ toUpper }}
-assert { shouted != null }
+assert { shouted[0].toUpper == "FOO" }
+assert { shouted[1].toUpper == "BAR" }
+assert { shouted.length == 2 }
+
+# Element-wise selection over a list of objects, calling the method per element
+let widgets = [Widget("a"), Widget("b")].{{ name, label }}
+assert { widgets[0].name == "a" }
+assert { widgets[0].label == "A" }
+assert { widgets[1].name == "b" }
+assert { widgets[1].label == "B" }
+
+# Records aren't structurally comparable, but the scalars projected out of them
+# are — so map the selection down to a plain list and compare that.
+let labels = [Widget("a"), Widget("b")].{{ label }}.map { r => r.label }
+assert { labels == ["A", "B"] }
 
 print("Scalar selection tests passed!")

--- a/tests/test_scalar_selection.dang
+++ b/tests/test_scalar_selection.dang
@@ -7,40 +7,41 @@
 # selecting such a field actually calls it rather than capturing the function.
 type Widget {
   name: String! = "?"
+
   label: String! { name.toUpper }
 }
 
 # Selecting builtin methods on a String. The result is an anonymous record, so
 # it compares structurally to a matching record literal.
-let upper_lower = "Hello".{{ toUpper, toLower }}
+let upper_lower = "Hello".{{toUpper, toLower}}
 assert { upper_lower.toUpper == "HELLO" }
 assert { upper_lower.toLower == "hello" }
-assert { upper_lower == {{ toUpper: "HELLO", toLower: "hello" }} }
+assert { upper_lower == {{toUpper: "HELLO", toLower: "hello"}} }
 
 # Fields with arguments alongside plain fields
-let split_result = "a,b,c".{{ split(separator: ","), toUpper }}
+let split_result = "a,b,c".{{split(separator: ","), toUpper}}
 assert { split_result.toUpper == "A,B,C" }
 assert { split_result.split == ["a", "b", "c"] }
 
 # Several methods at once, including ones taking arguments
-let trimmed = "  spaced  ".{{ trimSpace, hasPrefix(prefix: " ") }}
+let trimmed = "  spaced  ".{{trimSpace, hasPrefix(prefix: " ")}}
 assert { trimmed.trimSpace == "spaced" }
 assert { trimmed.hasPrefix == true }
 
 # A selected zero-arg method field is auto-called, matching its inferred type
 # and what `widget.label` yields on its own (it resolves to String!, not a
 # function value).
-let one = Widget("a").{{ name, label }}
+let one = Widget("a").{{name, label}}
 assert { one.name == "a" }
 assert { one.label == "A" }
 
 # Element-wise selection over a list of scalars; results are one-field records,
 # and the list of records compares structurally.
-let shouted = ["foo", "bar"].{{ toUpper }}
-assert { shouted == [{{ toUpper: "FOO" }}, {{ toUpper: "BAR" }}] }
+let shouted = ["foo", "bar"].{{toUpper}}
+assert { shouted == [{{toUpper: "FOO"}}, {{toUpper: "BAR"}}] }
 
 # Element-wise selection over a list of objects, calling the method per element.
-let widgets = [Widget("a"), Widget("b")].{{ name, label }}
-assert { widgets == [{{ name: "a", label: "A" }}, {{ name: "b", label: "B" }}] }
+let widgets = [Widget("a"), Widget("b")].{{name, label}}
+assert { widgets == [{{name: "a", label: "A"}}, {{name: "b", label: "B"}}] }
 
 print("Scalar selection tests passed!")

--- a/tests/test_scalar_selection.dang
+++ b/tests/test_scalar_selection.dang
@@ -10,10 +10,12 @@ type Widget {
   label: String! { name.toUpper }
 }
 
-# Selecting builtin methods on a String
+# Selecting builtin methods on a String. The result is an anonymous record, so
+# it compares structurally to a matching record literal.
 let upper_lower = "Hello".{{ toUpper, toLower }}
 assert { upper_lower.toUpper == "HELLO" }
 assert { upper_lower.toLower == "hello" }
+assert { upper_lower == {{ toUpper: "HELLO", toLower: "hello" }} }
 
 # Fields with arguments alongside plain fields
 let split_result = "a,b,c".{{ split(separator: ","), toUpper }}
@@ -32,22 +34,13 @@ let one = Widget("a").{{ name, label }}
 assert { one.name == "a" }
 assert { one.label == "A" }
 
-# Element-wise selection over a list of scalars; results are one-field records
+# Element-wise selection over a list of scalars; results are one-field records,
+# and the list of records compares structurally.
 let shouted = ["foo", "bar"].{{ toUpper }}
-assert { shouted[0].toUpper == "FOO" }
-assert { shouted[1].toUpper == "BAR" }
-assert { shouted.length == 2 }
+assert { shouted == [{{ toUpper: "FOO" }}, {{ toUpper: "BAR" }}] }
 
-# Element-wise selection over a list of objects, calling the method per element
+# Element-wise selection over a list of objects, calling the method per element.
 let widgets = [Widget("a"), Widget("b")].{{ name, label }}
-assert { widgets[0].name == "a" }
-assert { widgets[0].label == "A" }
-assert { widgets[1].name == "b" }
-assert { widgets[1].label == "B" }
-
-# Records aren't structurally comparable, but the scalars projected out of them
-# are — so map the selection down to a plain list and compare that.
-let labels = [Widget("a"), Widget("b")].{{ label }}.map { r => r.label }
-assert { labels == ["A", "B"] }
+assert { widgets == [{{ name: "a", label: "A" }}, {{ name: "b", label: "B" }}] }
 
 print("Scalar selection tests passed!")

--- a/tests/test_scalar_selection.dang
+++ b/tests/test_scalar_selection.dang
@@ -1,0 +1,25 @@
+# Multi-field selection works on any selectable value, not just objects and
+# GraphQL values. Each field is evaluated through the same selection machinery
+# as a standalone `recv.field`, so whatever a single selection can reach a
+# multi-field selection can too.
+
+# Selecting builtin methods on a String
+let upper_lower = "Hello".{{ toUpper, toLower }}
+assert { upper_lower.toUpper == "HELLO" }
+assert { upper_lower.toLower == "hello" }
+
+# Fields with arguments alongside plain fields
+let split_result = "a,b,c".{{ split(separator: ","), toUpper }}
+assert { split_result.toUpper == "A,B,C" }
+assert { split_result.split == ["a", "b", "c"] }
+
+# Several methods at once, including ones taking arguments
+let trimmed = "  spaced  ".{{ trimSpace, hasPrefix(prefix: " ") }}
+assert { trimmed.trimSpace == "spaced" }
+assert { trimmed.hasPrefix == true }
+
+# Element-wise selection over a list of scalars
+let shouted = ["foo", "bar"].{{ toUpper }}
+assert { shouted != null }
+
+print("Scalar selection tests passed!")


### PR DESCRIPTION
Multi-field selection (`recv.{{ a, b }}`) previously only handled `*Object` and GraphQL receivers, so selecting on anything else failed at eval time even though inference accepted it:

```
dang> "foo".{{ toUpper, toLower }}
evaluation error: ObjectSelection.evalSelectionOnValue: expected *Object or GraphQLValue, got dang.StringValue
```

This routes every non-GraphQL receiver through the same `Select` (and `FunCall`, for fields with arguments) path that powers a standalone `recv.field`. A multi-field selection now reaches exactly what a single selection can and stays aligned with it by construction — whatever you can select one at a time, you can select together. Lists are handled element-wise in the shared dispatcher, and GraphQL receivers still compile to one batched query.

```
dang> "foo".{{ toUpper, toLower }}
=> module {toLower: String!, toUpper: String!}
```

Evaluation is still serial here; making these fields evaluate concurrently is a natural follow-up that builds on the object-field concurrency machinery from #44 (thread-safe `Object`, concurrent lazy-force), and is intentionally left out of this PR so the alignment fix can land on its own.
