### PR TITLE
dang: structural value equality for anonymous records and named-type objects (#150)

### DIFF
--- a/.agents/skills/dang-internals/SKILL.md
+++ b/.agents/skills/dang-internals/SKILL.md
@@ -133,6 +133,18 @@ When adding a new subtyping relationship, the asymmetry direction matters:
 the *more specific* type's `Eq` should return true against the *more
 general* type, not vice versa.
 
+Because `Type.Eq` is asymmetric (and its anonymous branch duck-types
+structurally), runtime value equality must **not** route through it.
+`objectsEqual` (`ast.go`, behind `valuesEqual`'s `*Object` case, used by
+`==`/`case`/`contains`/`uniq`) instead gates on the module directly: both
+anonymous → structural `AsRecord().Eq`; either named → **pointer** comparison
+of the `*Type`s. That keeps `==` commutative (a named-vs-anonymous compare can't
+flip on operand order) and nominal (distinct `*Type`s, even same-named ones
+from different namespaces, never match). It then compares stored data fields via
+`lookupValue` **without forcing** — pending initializers and computed `{ }`
+members (function-typed in the module) are skipped, so the comparison stays pure
+(no `ctx`, no I/O, no error path). See issue #150.
+
 ## When adding a new type-like declaration
 
 Checklist:

--- a/.agents/skills/dang-language/reference/graphql.md
+++ b/.agents/skills/dang-language/reference/graphql.md
@@ -54,8 +54,9 @@ users.{name}[0].name      # index to force it
 GraphQL field access is **lazy**. A GraphQL value accumulates a query chain (`.field`, `.{...}`, args); no request is sent until the value is **forced** — materialized at an expected-type boundary (assertion, `print`, assignment to a typed field, indexing into a result, etc.). Forcing runs the built-up selection as a single request. This is what makes `user.{ name, posts.{ title } }` one round-trip.
 
 ## Equality
-- `==`/`!=` on GraphQL objects compare by **reference identity**, exactly like native `type` objects — no network call. A GraphQL object's identity is the query that produced it, so the same handle equals itself, but two independent constructions don't, even when they denote the same server object: `primaryUser == user(id: "1")` is `false` (just as `Rabbit("x") == Rabbit("x")` is `false`).
+- `==`/`!=` on GraphQL objects compare by **reference identity** — no network call. A GraphQL object's identity is the query that produced it, so the same handle equals itself, but two independent constructions don't, even when they denote the same server object: `primaryUser == user(id: "1")` is `false`.
 - To ask whether two objects are the *same server entity*, compare an identifying field explicitly: `a.id == b.id`. That forces the fetch where it's visible rather than hiding I/O inside `==`.
+- A `.{{ }}` selection is different: it materializes an **anonymous record**, which compares by **value** (same fields + equal values ⇒ equal). Reference identity applies to the GraphQL object *handle*, not to a selected record. See the object-equality rules in `objects.md`.
 
 ## Errors from the server
 - Non-null violations and GraphQL errors **raise** — catchable via `try`/`catch`.

--- a/.agents/skills/dang-language/reference/objects.md
+++ b/.agents/skills/dang-language/reference/objects.md
@@ -162,6 +162,12 @@ fullName: String! { firstName + " " + lastName }
 - A member with a type and a body but no arg list — a zero-arg function evaluated on `self` each access (no call parens). Recomputes against the current receiver.
 - A defaulted-value member (`computedField: String! = config.name + "_computed"`) is computed once at construction; a `{ body }` computed field is re-evaluated per access.
 
+### Equality (`==` / `!=`)
+- **Anonymous records** (`{{…}}` literals and `.{{…}}` selections) compare by **value**: equal when they have the same fields and every field is equal. `{{a: 1}} == {{a: 1}}` is `true`; `{{a: 1}} == {{a: 2}}` and `{{a: 1}} == {{a: 1, b: 2}}` are `false`. Nested records recurse.
+- **Named-type objects** compare by **type identity, then stored fields**: equal only when both sides are the same named type *and* every data field is equal. `Rabbit("x") == Rabbit("x")` is `true`; `Rabbit("x") == Rabbit("y")` is `false`. Distinct named types never match (`Rabbit == Hare` is `false`, even with identical shape), and a named object never equals an anonymous record of the same shape.
+- **Computed members are ignored** — a `{ body }` field is behavior, not stored state (re-evaluated per access), so it never participates in equality.
+- **GraphQL object handles** compare by **reference identity** (the query that produced them), not structurally — see `graphql.md`. A `.{{ }}` selection, though, materializes an anonymous record and compares by value.
+
 ## Mutation and copy-on-write
 
 **Values are immutable.** "Mutation" inside a method creates a **forked copy** of the receiver.

--- a/.agents/skills/dang-language/reference/syntax.md
+++ b/.agents/skills/dang-language/reference/syntax.md
@@ -99,9 +99,10 @@ greet(
 
 ### Comparison
 - `< <= > >=` on **numbers only** (`Int`/`Float`, mixed allowed) — NOT on strings.
-- `== !=` are type-safe: mismatched types compare `false`, no coercion (`num == str` is `false`). Work on numbers, strings, bools, null, lists, records. Return `Boolean!`.
-- Objects compare by **reference identity**, never structurally — equal only when the same instance, so two separately built objects with matching fields are not equal (`Rabbit("x") == Rabbit("x")` is `false`).
-- Same for GraphQL objects: identity is the query that produced them, so `primaryUser == user(id: "1")` is `false` even though both denote the same user — no network call. To compare GraphQL objects as the *same server entity*, compare a field explicitly: `a.id == b.id`.
+- `== !=` are type-safe: mismatched types compare `false`, no coercion (`num == str` is `false`). Work on numbers, strings, bools, null, lists, maps, records. Return `Boolean!`.
+- **Anonymous records** (`{{…}}` literals and `.{{…}}` selections) compare by **value**: equal when they have the same fields and every field is equal (`{{a: 1}} == {{a: 1}}` is `true`, `{{a: 1}} == {{a: 2}}` is `false`).
+- **Named-type objects** compare by **type identity, then stored fields**: equal only when both are the same named type *and* every data field is equal. So `Rabbit("x") == Rabbit("x")` is `true`, `Rabbit("x") == Rabbit("y")` is `false`, distinct types never match (`Rabbit == Hare` is `false`), and a named object never equals an anonymous record of the same shape. Computed members (`field: T { … }`) are behavior, not state, so they're ignored.
+- **GraphQL objects** compare by **reference identity**: identity is the query that produced them, so `primaryUser == user(id: "1")` is `false` even though both denote the same user — no network call. To compare GraphQL objects as the *same server entity*, compare a field explicitly: `a.id == b.id`. (A `.{{ }}` selection materializes an anonymous record and so compares by value.)
 
 ### Logical
 - `and`, `or` short-circuit (keywords, not `&&`/`||`); result `Boolean!`.

--- a/docs/lit/graphql/interop.md
+++ b/docs/lit/graphql/interop.md
@@ -85,8 +85,9 @@ users.{{ name, email }}
 
 ## Object equality
 
-- `==`/`!=` compare GraphQL objects by **reference identity**, the same way native `type` objects compare — there's no network call. A GraphQL object's identity is the query that produced it, so the same handle equals itself but two independent constructions don't, even when they denote the same server object: `primaryUser == user(id: "1")` is `false` (just as `Rabbit("x") == Rabbit("x")` is `false`)
+- `==`/`!=` compare GraphQL objects by **reference identity** — there's no network call. A GraphQL object's identity is the query that produced it, so the same handle equals itself but two independent constructions don't, even when they denote the same server object: `primaryUser == user(id: "1")` is `false`
 - to ask whether two objects are the *same server entity*, compare an identifying field explicitly — `a.id == b.id` — which forces the necessary fetch where you can see it, instead of hiding I/O inside `==`
+- a `.{{ }}` selection is different: it materializes an **anonymous record**, which compares by **value**, so two selections with the same fields and equal values are equal (see [#operators])
 
 ## Errors from the server
 

--- a/docs/lit/language/operators.md
+++ b/docs/lit/language/operators.md
@@ -37,9 +37,10 @@ Precedence follows the `DefaultExpr → … → MultiplicativeExpr → Term` cha
 
 - `<` `<=` `>` `>=` on numbers (`Int`/`Float`, mixed allowed) or strings (compared lexicographically) — operands must match (`"a" < 1` is a static type error)
 - `==` `!=` are type-safe — mismatched types compare `false`, no coercion (`num == str` is `false`)
-- `==`/`!=` work on numbers, strings, bools, null, lists, records; both return `Boolean!`
-- objects compare by **reference identity**, never by structure — equal only when they're the same instance, so two separately constructed objects with matching fields are not equal (`Rabbit("x") == Rabbit("x")` is `false`)
-- this applies to both native (`type`) objects and GraphQL objects; a GraphQL object's identity is the query that produced it, so `primaryUser == user(id: "1")` is `false` even though both denote the same user. To ask whether two GraphQL objects are the *same server entity*, compare an identifying field, e.g. `a.id == b.id`
+- `==`/`!=` work on numbers, strings, bools, null, lists, maps, and records; both return `Boolean!`
+- **anonymous records** (`{{…}}` literals and `.{{…}}` selections) compare by **value**: equal when they have the same fields and every field is equal, so `{{a: 1}} == {{a: 1}}` is `true` and `{{a: 1}} == {{a: 2}}` is `false`
+- **named-type objects** compare by **type identity, then by their stored fields**: equal only when both are the same named type *and* every data field is equal. So `Rabbit("x") == Rabbit("x")` is `true`, `Rabbit("x") == Rabbit("y")` is `false`, distinct types never match (`Rabbit == Hare` is `false`), and a named object never equals an anonymous record of the same shape. Computed members (`field: T { … }`) are behavior, not stored state, so they're ignored
+- **GraphQL objects** compare by **reference identity** — a GraphQL object's identity is the query that produced it, so `primaryUser == user(id: "1")` is `false` even though both denote the same user. To ask whether two GraphQL objects are the *same server entity*, compare an identifying field, e.g. `a.id == b.id`
 
 ## Logical
 

--- a/docs/lit/language/syntax.md
+++ b/docs/lit/language/syntax.md
@@ -90,6 +90,7 @@ Backtick templates in detail — backticks switch the lexer into template mode:
 - always non-null
 - the same `{{ ... }}` syntax is also a record *type* annotation: `x :: {{foo: Int!, bar: Status!}}!`
 - nestable: `{{user: {{id: 1, active: true}}, count: 100}}`
+- compared by **value** — two records with the same fields and equal values are equal, `{{a: 1}} == {{a: 1}}` (see [#operators]); this is the structural cousin of a named `type`, which compares by type identity
 - serialized to JSON with keys sorted alphabetically, not declaration order (see [#json-yaml]): `{{count: 100, user: ...}}` → `{"count":100,"user":...}`
 
 > Meta: explicitly call out the double-brace syntax — it's the unusual one and the first reaction is "is that a typo?"

--- a/pkg/dang/ast.go
+++ b/pkg/dang/ast.go
@@ -307,9 +307,10 @@ func valuesEqual(left, right Value) bool {
 			return true
 		}
 	case *Object:
-		// Reference equality: equal only if the same instance.
+		// Value semantics for anonymous records, nominal identity for named
+		// types. See objectsEqual and issue #150.
 		if r, ok := right.(*Object); ok {
-			return l == r
+			return objectsEqual(l, r)
 		}
 	case GraphQLValue:
 		// Reference equality: a GraphQL object's identity is its query chain,
@@ -322,6 +323,75 @@ func valuesEqual(left, right Value) bool {
 
 	// Different types or unsupported comparison
 	return false
+}
+
+// objectsEqual compares two *Object values: structural value semantics for
+// anonymous records ({{…}} literals and .{{…}} selections), nominal identity
+// for named types. See issue #150.
+//
+// A "type/shape gate" decides whether two objects are even comparable: both
+// anonymous requires a matching structural shape (same field names + types);
+// either named requires the *Types to be the same pointer (a Rabbit is only
+// ever comparable to that same Rabbit type — not to another type, not across
+// namespaces, not to an anonymous record of the same shape). Pointer equality
+// is written out explicitly rather than delegated to Type.Eq, which keys off
+// the receiver's name and would make the result order-dependent — == must be
+// commutative.
+//
+// If the gate passes, the stored data fields are compared structurally.
+// Methods and computed `{ }` members are excluded: they carry function types in
+// the module and are behavior, not state (re-evaluated on each read, never
+// written back). Fields are resolved across the copy-on-write Parent chain
+// without forcing pending initializers, so the comparison stays pure — no ctx,
+// no I/O, no error path (the #145 constraint that keeps case/contains/uniq
+// usable).
+func objectsEqual(l, r *Object) bool {
+	if l == r {
+		// Same instance: fast path.
+		return true
+	}
+	lt, lok := l.Mod.(*Type)
+	rt, rok := r.Mod.(*Type)
+	if !lok || !rok {
+		// Non-*Type module: nothing structural to compare; instance identity
+		// (ruled out above) is the only equality.
+		return false
+	}
+	if lt.Named != "" || rt.Named != "" {
+		// Either side named: nominal identity via pointer-equal *Types.
+		if lt != rt {
+			return false
+		}
+	} else if !lt.AsRecord().Eq(rt.AsRecord()) {
+		// Both anonymous: structural type match.
+		return false
+	}
+	// Shapes match (so both modules declare the same fields). Compare each
+	// declared data field's stored value.
+	for name, scheme := range lt.Bindings(PrivateVisibility) {
+		if t, _ := scheme.Type(); isMethodType(t) {
+			continue
+		}
+		lv, lfound := l.lookupValue(name)
+		rv, rfound := r.lookupValue(name)
+		if lfound != rfound {
+			return false
+		}
+		if lfound && !valuesEqual(lv, rv) {
+			return false
+		}
+	}
+	return true
+}
+
+// isMethodType reports whether a module member's declared type is a function
+// type — a method or computed `{ }` member — unwrapping a non-null wrapper.
+func isMethodType(t hm.Type) bool {
+	if nn, ok := t.(hm.NonNullType); ok {
+		t = nn.Type
+	}
+	_, ok := t.(*hm.FunctionType)
+	return ok
 }
 
 // isTruthy determines if a value should be considered true for assertion purposes

--- a/tests/test_object_equality.dang
+++ b/tests/test_object_equality.dang
@@ -83,6 +83,29 @@ assert { {{a: {{b: 1}}}} != {{a: {{b: 2}}}} }
 assert { (jeff == {{name: "jeffrey"}}) == false }
 assert { ({{name: "jeffrey"}} == jeff) == false } # commutative
 
+# Recursion through a named-type data field: two Hats holding distinct-but-equal
+# Rabbits are equal; a differing nested field breaks it.
+let hatBun = Hat.insert(Rabbit("bun"))
+let hatBun2 = Hat.insert(Rabbit("bun"))
+assert("nested named field: equal") { hatBun == hatBun2 }
+let hatHop = Hat.insert(Rabbit("hop"))
+assert("nested named field: differ") { hatBun != hatHop }
+
+# Records of named types compare element-wise / field-wise
+assert { [Rabbit("a"), Rabbit("b")] == [Rabbit("a"), Rabbit("b")] }
+assert { [Rabbit("a"), Rabbit("b")] != [Rabbit("a"), Rabbit("c")] }
+
+# Crossing the boundary: an anonymous record wrapping a named type
+assert { {{pet: Rabbit("bun")}} == {{pet: Rabbit("bun")}} }
+assert { {{pet: Rabbit("bun")}} != {{pet: Rabbit("hop")}} }
+
+# ...and a named type wrapping an anonymous record
+type Cage {
+  contents: {{food: String!}}!
+}
+assert { Cage({{food: "hay"}}) == Cage({{food: "hay"}}) }
+assert { Cage({{food: "hay"}}) != Cage({{food: "pellets"}}) }
+
 # Structural equality stays pure, so it composes with case / contains / uniq
 let kind = case ({{a: 1}}) {
   {{a: 1}} => "one"

--- a/tests/test_object_equality.dang
+++ b/tests/test_object_equality.dang
@@ -103,6 +103,7 @@ assert { {{pet: Rabbit("bun")}} != {{pet: Rabbit("hop")}} }
 type Cage {
   contents: {{food: String!}}!
 }
+
 assert { Cage({{food: "hay"}}) == Cage({{food: "hay"}}) }
 assert { Cage({{food: "hay"}}) != Cage({{food: "pellets"}}) }
 

--- a/tests/test_object_equality.dang
+++ b/tests/test_object_equality.dang
@@ -1,4 +1,6 @@
-# Test object equality (reference equality for *Object values)
+# Test object equality:
+#   - anonymous records ({{…}}) compare by value (structural)
+#   - named types compare by *type* identity, then by their data fields
 
 type Hat {
   animal: Animal = null
@@ -21,6 +23,12 @@ type Rabbit implements Animal {
   coat: Coat! { Coat.FUR }
 }
 
+type Hare implements Animal {
+  name: String!
+
+  coat: Coat! { Coat.FUR }
+}
+
 let jeff = Rabbit("jeffrey")
 let hat = Hat
 let withJeff = hat.insert(jeff)
@@ -28,11 +36,64 @@ assert { hat.animal == null }
 assert { withJeff.animal == jeff }
 assert { withJeff.animal.coat == Coat.FUR }
 
-# A distinct object with the same contents is not reference-equal
-let otherJeff = Rabbit("jeffrey")
-assert("distinct objects are not equal") { (jeff == otherJeff) == false }
-
 # Same object reference is equal to itself
 assert("same reference is equal") { jeff == jeff }
+assert { withJeff == withJeff }
+
+# Named types: two instances of the same type with equal data fields are equal.
+# The computed `coat` member is behavior, not state, so it is ignored.
+let otherJeff = Rabbit("jeffrey")
+assert("same type + equal fields are equal") { jeff == otherJeff }
+assert { otherJeff == jeff } # commutative
+
+# Same type, differing data field
+let roger = Rabbit("roger")
+assert("same type + differing field are not equal") { jeff != roger }
+assert { (jeff == roger) == false }
+
+# Distinct named types never compare equal, even with the same shape and data
+let jeffHare = Hare("jeffrey")
+assert("distinct named types are not equal") { jeff != jeffHare }
+assert { jeffHare != jeff } # commutative
+
+# Two fresh Hats with the same (default) data are equal
+assert { Hat == Hat }
+# A mutation (copy-on-write) produces a structurally different object
+assert { (hat == withJeff) == false }
+
+# Anonymous records compare by value
+assert { {{a: 1}} == {{a: 1}} }
+assert { {{a: 1, b: 2}} == {{a: 1, b: 2}} }
+
+# Differing field value
+assert { {{a: 1}} != {{a: 2}} }
+assert { ({{a: 1}} == {{a: 2}}) == false }
+
+# Differing shape: extra field
+assert { {{a: 1}} != {{a: 1, b: 2}} }
+
+# Differing shape: different field name
+assert { {{a: 1}} != {{b: 1}} }
+
+# Nested anonymous records recurse structurally
+assert { {{a: {{b: 1}}}} == {{a: {{b: 1}}}} }
+assert { {{a: {{b: 1}}}} != {{a: {{b: 2}}}} }
+
+# A named type and an anonymous record of the same shape are never equal
+assert { (jeff == {{name: "jeffrey"}}) == false }
+assert { ({{name: "jeffrey"}} == jeff) == false } # commutative
+
+# Structural equality stays pure, so it composes with case / contains / uniq
+let kind = case ({{a: 1}}) {
+  {{a: 1}} => "one"
+  else => "other"
+}
+assert { kind == "one" }
+
+assert { [{{a: 1}}, {{a: 2}}].contains({{a: 1}}) }
+assert { [{{a: 1}}, {{a: 2}}].contains({{a: 3}}) == false }
+
+let deduped = [{{a: 1}}, {{a: 1}}, {{a: 2}}].uniq
+assert { deduped.length == 2 }
 
 print("Object equality tests completed")


### PR DESCRIPTION
Implements #150.

Object `==` was reference identity for every `*Object` (#145), so two structurally identical anonymous records — the value-like bag of fields produced by `{{…}}` literals and `.{{…}}` selections — never compared equal, even though `List` and `Map` beside them in `valuesEqual` are structural.

## Semantics

`objectsEqual` gates two objects by shape before comparing data:

1. **Same instance** → `true` (fast path).
2. **Type/shape gate:** both `Mod` anonymous (`Named == ""`) → structural type match via `AsRecord().Eq`; **either** side named → pointer equality of the `*Type`s. Pointer equality is written out rather than delegated to `Type.Eq`, whose name-keyed duck-typing branch is order-dependent and would break commutativity.
3. **Data-field compare:** when the gate passes, each declared non-method member is compared via `valuesEqual`, resolved across the copy-on-write `Parent` chain **without forcing**. Methods and computed `{ }` members carry function types in the module and are skipped — they are behavior, not state, which keeps the comparison pure (the #145 constraint that leaves `case`/`contains`/`uniq` untouched).

Named types stay nominal: a `Rabbit` only ever compares to that same `Rabbit` type, never across namespaces nor to an anonymous record of the same shape. Two instances of the same named type with equal data fields now compare equal, which they did not before. Nested `GraphQLValue` keeps its query-chain identity.

## Tests

Rewrote `tests/test_object_equality.dang` to cover the issue's worked-example table: anonymous structural equality (value, shape, nested), named-type identity gating, named-vs-anonymous always false, commutativity and `!=` mirrors, and `case`/`contains`/`uniq` composition.

- `go test ./tests/` passes (all three sub-suites, incl. format round-trip)
- `go test ./pkg/...` passes; `go vet` + `gofmt` clean
