### PR TITLE
eval: make naked self-calls behave like self.foo()

### DIFF
--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -1193,14 +1193,30 @@ func (f FunctionValue) MarshalJSON() ([]byte, error) {
 }
 
 func (f FunctionValue) Call(ctx context.Context, scope ValueScope, args map[string]Value) (Value, error) {
+	// A naked self-call to a sibling method or computed field (`foo()` rather
+	// than `self.foo()`, recursion included) must behave exactly like
+	// `self.foo()`: each call forks `self` into its own sealed receiver, so the
+	// body's field writes stay isolated copy-on-write generations. Dispatch it
+	// through the same path as an explicit method call. Running the body against
+	// the closure scope instead (the fall-through below) shares one `self` cell
+	// across recursive calls and lets bare field writes leak out to the original
+	// instance through the lexical parent chain — scrambling state. Block
+	// arguments are excluded: they intentionally share the enclosing method's
+	// `self` (so `xs.each { self.x += ... }` accumulates), and BoundMethod.Call
+	// would re-dispatch a block straight back here.
+	if f.IsDynamic && !f.IsBlockArg {
+		if self, ok := scope.Self(); ok {
+			if recv, ok := self.(ValueScope); ok {
+				return BoundMethod{Method: f, Receiver: recv}.Call(ctx, scope, args)
+			}
+		}
+	}
+
 	fnScope := f.Closure.Derive(false)
 
 	if f.IsDynamic {
-		// Propagate dynamic scope from calling environment
-		//
-		// A dynamic FunctionValue being called will ALWAYS mean we're coming from a
-		// 'naked' self-call (foo() instead of self.foo()) from a sibling method, so
-		// we can inherit the caller's `self`.
+		// A block argument inherits the caller's `self` by sharing its cell, so
+		// mutations inside the block stay visible to the enclosing method.
 		if dynScope, hasDynScope := scope.Self(); hasDynScope {
 			fnScope.MutateSelf(dynScope)
 		}

--- a/tests/test_cow_recursive_naked.dang
+++ b/tests/test_cow_recursive_naked.dang
@@ -11,6 +11,7 @@
 # Bare field write, then naked recursion.
 type Bumper {
   value: Int! = 0
+
   up(n: Int!): Bumper! {
     if (n <= 0) { self } else { value += 1; up(n - 1) }
   }
@@ -28,7 +29,9 @@ assert("still untouched after a second call") { a.value == 0 }
 # Naked recursion routed through a mutating computed field.
 type ViaField {
   value: Int! = 0
+
   incr: ViaField! { value += 1; self }
+
   by(n: Int!): ViaField! {
     if (n <= 0) { self } else { incr.by(n - 1) }
   }
@@ -42,7 +45,9 @@ assert("computed-field recursion leaves the original alone") { c.value == 0 }
 # building a running sum (4 + 3 + 2 + 1 == 10).
 type Summer {
   acc: Int! = 0
+
   add(x: Int!): Summer! { acc += x; self }
+
   sumTo(n: Int!): Summer! {
     if (n <= 0) { self } else { add(n).sumTo(n - 1) }
   }

--- a/tests/test_cow_recursive_naked.dang
+++ b/tests/test_cow_recursive_naked.dang
@@ -1,0 +1,53 @@
+# Regression: a naked self-call that recurses (`foo()` rather than `self.foo()`)
+# must keep copy-on-write semantics, exactly like an explicit `self.foo()` call.
+# Each call forks `self` into its own generation, so writes accumulate down the
+# recursion and never leak back to the caller's value. Before the fix a naked
+# self-recursion ran its body against the closure scope instead of a forked
+# receiver, sharing one `self` cell across calls and leaking writes to the
+# original instance (e.g. `a.up(3)` left `a` mutated and returned the wrong
+# value). See test_cow_recursive.dang for the explicit-receiver recursion that
+# already worked.
+
+# Bare field write, then naked recursion.
+type Bumper {
+  value: Int! = 0
+  up(n: Int!): Bumper! {
+    if (n <= 0) { self } else { value += 1; up(n - 1) }
+  }
+}
+
+let a = Bumper(0)
+let bumped = a.up(3)
+assert("naked recursion accumulates into the returned fork") { bumped.value == 3 }
+assert("the original receiver is untouched") { a.value == 0 }
+
+# Two independent naked-recursion calls on the same receiver must not compound.
+assert("calls fork independently") { a.up(2).value == 2 }
+assert("still untouched after a second call") { a.value == 0 }
+
+# Naked recursion routed through a mutating computed field.
+type ViaField {
+  value: Int! = 0
+  incr: ViaField! { value += 1; self }
+  by(n: Int!): ViaField! {
+    if (n <= 0) { self } else { incr.by(n - 1) }
+  }
+}
+
+let c = ViaField(0)
+assert("computed-field recursion accumulates") { c.by(5).value == 5 }
+assert("computed-field recursion leaves the original alone") { c.value == 0 }
+
+# Naked recursion routed through a sibling method that takes an argument,
+# building a running sum (4 + 3 + 2 + 1 == 10).
+type Summer {
+  acc: Int! = 0
+  add(x: Int!): Summer! { acc += x; self }
+  sumTo(n: Int!): Summer! {
+    if (n <= 0) { self } else { add(n).sumTo(n - 1) }
+  }
+}
+
+let s = Summer(0)
+assert("sibling-method recursion sums correctly") { s.sumTo(4).acc == 10 }
+assert("sibling-method recursion leaves the original alone") { s.acc == 0 }


### PR DESCRIPTION
## What

A naked self-call to a sibling method or computed field — `foo()` rather than `self.foo()`, recursion included — broke copy-on-write semantics, mutating the original receiver and returning the wrong value.

```dang
type Counter {
  value: Int! = 0
  up(n: Int!): Counter! { if (n <= 0) { self } else { value += 1; up(n - 1) } }
}

let a = Counter(0)
let b = a.up(3)
[b.value, a.value]   # was [1, 2]; should be [3, 0]
```

## Why

`self.foo()` and naked `foo()` dispatched through different paths. `BoundMethod.Call` forks the receiver into its own sealed copy-on-write generation (`Derive(true)`) with a fresh `self` cell. The naked path in `FunctionValue.Call` (the `IsDynamic` branch) instead ran the body against `f.Closure.Derive(false)` — the closure, unsealed — and pointed a *shared* `self` cell at the caller's self. Under recursion the shared cell and unsealed closure scope scrambled state: `self` was the same object at every level and bare field writes leaked out to the original instance through the lexical parent chain.

This predates the recent concurrency work — it reproduces as far back as **v1.0.0**.

## Fix

Dispatch a naked self-call through `BoundMethod.Call` with the current `self` as receiver, so it forks per call exactly like `self.foo()` — one path, one semantics. Block arguments stay on the old path: they intentionally share the enclosing method's `self` (so `xs.each { self.x += ... }` accumulates), and routing a block through `BoundMethod.Call` would loop straight back here.

## Tests

`tests/test_cow_recursive_naked.dang` covers bare-write recursion, computed-field recursion, and sibling-method recursion, plus per-call independence and original-untouched checks. It fails without the fix and passes with it. The existing `test_cow_recursive.dang` missed this by recursing through an explicit receiver (`let x = increment; x.incrementN(...)`), which always took the correct path.

Full `./tests/` and `./pkg/dang/` suites pass, including under `-race`.
