### PR TITLE
docs: rewrite the mutation page as live examples

### DIFF
--- a/docs/lit/types/mutation.md
+++ b/docs/lit/types/mutation.md
@@ -1,82 +1,161 @@
 \use-plugin{dang}
+\literate-fences
 
 # Mutation and copy-on-write {#mutation}
 
-> Meta: this is the page that prevents a *lot* of confusion. The thesis: methods look mutating but return a forked copy. Show the canonical `Foo(42).incr.a == 43` example up front.
-
-## Values are immutable
-
-- a value, once constructed, never changes
-- "mutation" inside a method creates a forked copy of the receiver
-
-## The classic example
+```dang
+type Counter {
+  value: Int! = 0
+  incr: Counter! {
+    value += 1   # bare field write forks the receiver; `self.value += 1` is the equivalent explicit form
+    self
+  }
+  # a method can recurse: the naked `incrBy` call forks self just like `self.incrBy` would
+  incrBy(n: Int!): Counter! { if (n <= 0) { self } else { incr.incrBy(n - 1) } }
+}
+```
 
 ```dang
-type Foo {
-  a: Int!
-  incr: Foo! {
-    a += 1
+# a "mutating" method returns a fork — the original is untouched
+let answer = Counter(42)
+[answer.incr.value, answer.value]
+```
+
+```dang
+# recursion forks per call too: it accumulates into the returned fork and
+# leaves the original untouched
+let start = Counter(0)
+[start.incrBy(3).value, start.value]
+```
+
+```dang
+type Image {
+  packages: [String!]! = []
+
+  # chainable methods return the concrete type name — there is no `Self` keyword
+  with(pkg: String!): Image! {
+    packages += [pkg]
+    self
+  }
+
+  withAll(pkgs: [String!]!): Image! {
+    pkgs.each { p => packages += [p] }   # bare field write works inside a closure too
     self
   }
 }
-
-Foo(42).incr.a == 43
 ```
 
-- each `.incr` allocates a fresh `Foo` with `a + 1`
-- the original `Foo(42)` is untouched
-- `Foo(42).incr.a == 43`; and `let original = Foo(10); original.incr` leaves `original.a == 10`
-- note `a += 1` here mutates the *field* with no `self.` prefix (bare field write still forks); `self.a += 1` is the equivalent explicit form
-
-## What `self.field = value` actually does
-
-- forks the current receiver
-- substitutes the new field value
-- subsequent `self` references in the same method see the forked version
-- the forked instance is what the method returns (typically `self`)
-
-## Fork-per-call semantics
-
 ```dang
-let c1 = Counter(0)
-let c2 = c1.incr     # c2.value == 1
-let c3 = c1.incr     # c3.value == 1, c1.value still 0
+# each call forks from the receiver, so forks of one base never compound,
+# and `base` itself is never modified
+let base = Image
+[base.with("git").packages, base.with("curl").packages, base.packages]
 ```
 
-- two calls on the same receiver don't compound — each call forks from the original receiver, not from the previous call's result: 5x `withAlpine(branch).withPackages(packages)` all equal, not accumulated
-- holds for recursion and across module boundaries
-
-## Within a method, mutations accumulate inside one fork
+```dang
+# within a single call, writes accumulate onto one fork
+Image.withAll(["git", "curl", "tini"]).packages
+```
 
 ```dang
-addAll(source: [String!]!): Builder! {
-  source.each { item => self.items += [item] }
-  self
+# pure functions have no `self`, so nothing forks — they just compute
+double(x: Int!): Int! { x * 2 }
+double(21)
+```
+
+```dang
+# plain bindings are not copy-on-write: a bare write to a local just rebinds it
+let n = 1
+n = 2
+n
+```
+
+```dang
+type Greeting {
+  text: String!
+  new(text: String!) {
+    # `self.` is needed only to disambiguate from a same-named arg/local;
+    # bare `text = ...` would rebind the arg, not the field
+    self.text = "hello, " + text
+    self
+  }
 }
 ```
 
-- the loop builds up a single forked value, then returns it
-- the return type is the concrete type name (`Builder!`), not `Self!` — there is no `Self` type keyword in the language; the grammar only defines lowercase `self`
+```dang
+Greeting("world").text
+```
 
-## Nested field assignment
+```dang
+type Leaf { c: Int! }
+type Node { leaf: Leaf! }
+type Tree {
+  node: Node!
+  # assignment through a path forks each step; subtrees off the path are shared
+  bump: Tree! { self.node.leaf.c += 100; self }
+}
+```
 
-- `self.a.b.c = x` (or bare `data.a.b.c = x`) clones every link on the path from root to leaf, leaving the original tree untouched: `original.data.a.b.c` stays `42` while copies diverge
-- compound forms work too: `data.a.b.c += 10`
-- supported but expensive — avoid deep nesting if you can
+```dang
+# the original is untouched at any depth
+let tree = Tree(Node(Leaf(42)))
+[tree.bump.node.leaf.c, tree.node.leaf.c]
+```
 
-## Bare reassignment vs. field mutation
+```dang
+# a loop threads one shared accumulator: writes are visible to the next
+# iteration and outlive the loop
+let total = 0
+[1, 2, 3].each { x => total += x }
+total
+```
 
-- name resolution at the write site decides the target:
-  - if `x` is a local/arg in scope → `x = value` rebinds it, no fork; mutating arg `foo` does not touch `self.foo`
-  - if `x` is a field (not shadowed) → bare `x = value` / `x += 1` forks `self` and sets the field
-- `self.x = value` — always forks `self`, sets the field; required only to disambiguate when a same-named local/arg shadows the field
-- inside a constructor with a field-shadowing arg, this distinction matters most
+```dang
+# every `{{ }}` evaluates its fields concurrently, each in its own fork:
+# `b` can't see `a`'s write, and the outer `counter` stays untouched
+let counter = 0
+let pair = {{
+  a: { counter += 1; counter },
+  b: { counter += 10; counter }
+}}
+[pair.a, pair.b, counter]
+```
 
-> Meta: a diagram (boxes-and-arrows) would help a lot here. Even ASCII would do.
+```dang
+# fields coordinate by value in any order (a field naming a sibling waits for it)
+{{ total: a + b, a: 1, b: 2 }}.total
+```
 
-## When not to think in CoW
+```dang-failure
+# a genuine cycle between fields is a compile error
+{{ x: y, y: x }}
+```
 
-- pure functions — no `self`, no forking
-- top-level bindings (bare or `let`) — plain bindings, no `self` to fork (see [#blocks])
-- the *values themselves* are immutable regardless
-- see [#objects] for `type`/`self`/constructor mechanics that this page builds on
+```dang-failure
+# concurrent fields fail fast, but the reported error is always the
+# lowest in source order — never whichever lost the race
+{{ a: raise "first", b: raise "second" }}
+```
+
+```dang-failure
+# deterministic even when the lower field finishes last:
+# `slow` (field 0) surfaces though `fast` raises first
+{{
+  slow: { [1, 2, 3, 4].each { _ => 0 }; raise "from slow" },
+  fast: raise "from fast"
+}}
+```
+
+```dang
+# a selection over a list fans out across its elements (also concurrent);
+# the result is a list of records, compared by value
+type User { name: String! }
+[User("Alice"), User("Bob")].{{ name }} == [{{ name: "Alice" }}, {{ name: "Bob" }}]
+```
+
+```dang-static
+# over a GraphQL receiver the same `{{ }}` concurrency is batched I/O:
+# a multi-field selection is one round trip; a record of selections runs its
+# queries in parallel
+{{ users: users.{{ name }}, repos: repos.{{ name }} }}
+```


### PR DESCRIPTION
Rewrites the `/mutation` (Mutation and copy-on-write) page from a bulleted outline into a sequence of **runnable examples** under `\literate-fences`. The docs build evaluates each fence and bakes its result, so every behavior is demonstrated and can't rot. Following the literate style of the blocks/errors pages, but trimmed down to examples-first: the important note for each example lives in a code comment rather than surrounding prose, leaving the narrative to be shaped on top.

## What it covers

Everything the old outline described, each as a live example:

- a "mutating" method returns a fork; the original is untouched
- **recursion** forks per call too (depends on #155, now merged) — `[start.incrBy(3).value, start.value]` → `[3, 0]`
- fork-per-call independence off a shared base
- within-call accumulation
- bare vs. `self.` writes, and `self.` only being needed to disambiguate a shadowing arg
- nested-path assignment (clones the spine, shares the rest)
- the boundaries where copy-on-write doesn't apply (pure functions, plain `let` bindings)

Plus the recently merged concurrency semantics, framed as the payoff of immutable values:

- `{{ }}` record literals / selections evaluate fields **concurrently**, each in its own fork — `counter` stays `0` while fields independently compute `[1, 10]`, contrasted with a sequential `.each` accumulator
- fields coordinate by value, in any order; a cycle is a compile error
- deterministic fail-fast (lowest source-order error wins, even when it's the slower field)
- selection over a list fans out across elements
- over a GraphQL receiver the same `{{ }}` is batched I/O (cross-referenced to the interop page)

## Verification

Every `dang` fence evaluates to its expected value, all three `dang-failure` fences fail as required, and the `dang-static` GraphQL fence is skipped. The full book renders clean.
