### PR TITLE
deps: point pigeon back at upstream mna/master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/mna/pigeon v1.3.0 // indirect
+	github.com/mna/pigeon v1.3.1-0.20260627070130-aa1e61c16975 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/mango v0.1.0 // indirect
 	github.com/muesli/mango-cobra v1.2.0 // indirect
@@ -105,5 +105,3 @@ tool (
 	github.com/99designs/gqlgen
 	github.com/dagger/otel-go/cmd/otelgotest
 )
-
-replace github.com/mna/pigeon => github.com/vito/pigeon v0.0.0-20260530031413-6ddc6a5a5a53

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mna/pigeon v1.3.1-0.20260627070130-aa1e61c16975 h1:ZtOBrzDG6RAs0PJqiP9EaGCVv+79m7pS/XKfYT7GqRs=
+github.com/mna/pigeon v1.3.1-0.20260627070130-aa1e61c16975/go.mod h1:XjNXeCGWAXtMkTaQQ0U4QTqJwZFfkTONME5a0uwpjpU=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/mango v0.1.0 h1:DZQK45d2gGbql1arsYA4vfg4d7I9Hfx5rX/GCmzsAvI=
@@ -159,8 +161,6 @@ github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
 github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsLrN6kE=
 github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
-github.com/vito/pigeon v0.0.0-20260530031413-6ddc6a5a5a53 h1:6od1Xihcqxz4Ebv89ngBGRYW6rAZvsJj+W9EmtsKMFY=
-github.com/vito/pigeon v0.0.0-20260530031413-6ddc6a5a5a53/go.mod h1:XjNXeCGWAXtMkTaQQ0U4QTqJwZFfkTONME5a0uwpjpU=
 github.com/vito/tuist v0.0.7-0.20260617202722-ed3f1d64aee6 h1:IPtxrF8bghyJTOcUGw5aFdZRoul2/XJugGiWPdOWo88=
 github.com/vito/tuist v0.0.7-0.20260617202722-ed3f1d64aee6/go.mod h1:CsNN9DERASd6PBtcSqTcOJDV1ZX/+i+j+kxh9k8Fff0=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
The `replace` directive routed `github.com/mna/pigeon` through `vito/pigeon` to carry a fork patch. That patch has since been [merged upstream](https://github.com/mna/pigeon), so this drops the `replace` and depends on `mna/pigeon` at master directly.

Regenerating `pkg/dang/dang.peg.go` against upstream pigeon produces a byte-identical parser, `go build ./...` is clean, and the parser tests pass.