### PR TITLE
Finish GraphQL value conversion: Float args + lossless numbers

### DIFF
--- a/pkg/dang/builtins.go
+++ b/pkg/dang/builtins.go
@@ -2,6 +2,7 @@ package dang
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -128,6 +129,20 @@ func ToValue(v any) (Value, error) {
 		return FloatValue{Val: float64(val)}, nil
 	case float64:
 		return FloatValue{Val: val}, nil
+
+	case json.Number:
+		// Untyped fallback (no declared type to honor): keep the JSON author's
+		// intent — a bare integer literal becomes an Int, anything fractional a
+		// Float. Typed GraphQL/codec leaves never reach here; they convert
+		// against their declared type.
+		if i, err := val.Int64(); err == nil && int64(int(i)) == i {
+			return IntValue{Val: int(i)}, nil
+		}
+		f, err := val.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("cannot convert number %q to a Dang Value", val.String())
+		}
+		return FloatValue{Val: f}, nil
 
 	case bool:
 		return BoolValue{Val: val}, nil

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -860,10 +860,23 @@ func dangValueToGo(val Value) (any, error) {
 		return v.Val, nil
 	case IntValue:
 		return v.Val, nil
+	case FloatValue:
+		return v.Val, nil
 	case BoolValue:
 		return v.Val, nil
 	case NullValue:
 		return nil, nil
+	case MapValue:
+		// Convert map to a Go map (used for input objects / map-shaped scalars)
+		result := make(map[string]any, len(v.Entries))
+		for key, fieldVal := range v.Entries {
+			goVal, err := dangValueToGo(fieldVal)
+			if err != nil {
+				return nil, fmt.Errorf("converting map entry %q: %w", key, err)
+			}
+			result[key] = goVal
+		}
+		return result, nil
 	case ListValue:
 		// Convert list elements to Go slice
 		result := make([]any, len(v.Elements))

--- a/pkg/dang/eval.go
+++ b/pkg/dang/eval.go
@@ -820,94 +820,32 @@ func graphQLResultToValue(raw any, typeRef *introspection.TypeRef, expectedType 
 	return ToValue(raw)
 }
 
+// graphQLIntResultToValue and graphQLFloatResultToValue convert a GraphQL
+// number to a Dang value. GraphQL responses are decoded with UseNumber (see
+// querybuilder.unpack), so numbers arrive as json.Number — the same shape the
+// codec path produces — letting both paths share decodedNumberToInt.
 func graphQLIntResultToValue(raw any) (Value, error) {
-	val, err := graphQLNumberToInt(raw)
+	num, ok := raw.(json.Number)
+	if !ok {
+		return nil, fmt.Errorf("expected number for GraphQL Int, got %T", raw)
+	}
+	val, err := decodedNumberToInt(num)
 	if err != nil {
-		return nil, fmt.Errorf("expected integral number for GraphQL Int, got %v", raw)
+		return nil, fmt.Errorf("expected integral number for GraphQL Int, got %q", num.String())
 	}
 	return IntValue{Val: val}, nil
 }
 
-func graphQLNumberToInt(raw any) (int, error) {
-	switch n := raw.(type) {
-	case int:
-		return n, nil
-	case int8:
-		return int(n), nil
-	case int16:
-		return int(n), nil
-	case int32:
-		return int(n), nil
-	case int64:
-		if int64(int(n)) != n {
-			return 0, fmt.Errorf("integer out of range")
-		}
-		return int(n), nil
-	case uint:
-		if uint(int(n)) != n {
-			return 0, fmt.Errorf("integer out of range")
-		}
-		return int(n), nil
-	case uint8:
-		return int(n), nil
-	case uint16:
-		return int(n), nil
-	case uint32:
-		if uint32(int(n)) != n {
-			return 0, fmt.Errorf("integer out of range")
-		}
-		return int(n), nil
-	case uint64:
-		if uint64(int(n)) != n {
-			return 0, fmt.Errorf("integer out of range")
-		}
-		return int(n), nil
-	case float32:
-		return decodedNumberToInt(json.Number(strconv.FormatFloat(float64(n), 'f', -1, 32)))
-	case float64:
-		return decodedNumberToInt(json.Number(strconv.FormatFloat(n, 'f', -1, 64)))
-	case json.Number:
-		return decodedNumberToInt(n)
-	default:
-		return 0, fmt.Errorf("not a number")
-	}
-}
-
 func graphQLFloatResultToValue(raw any) (Value, error) {
-	switch n := raw.(type) {
-	case float64:
-		return FloatValue{Val: n}, nil
-	case float32:
-		return FloatValue{Val: float64(n)}, nil
-	case int:
-		return FloatValue{Val: float64(n)}, nil
-	case int8:
-		return FloatValue{Val: float64(n)}, nil
-	case int16:
-		return FloatValue{Val: float64(n)}, nil
-	case int32:
-		return FloatValue{Val: float64(n)}, nil
-	case int64:
-		return FloatValue{Val: float64(n)}, nil
-	case uint:
-		return FloatValue{Val: float64(n)}, nil
-	case uint8:
-		return FloatValue{Val: float64(n)}, nil
-	case uint16:
-		return FloatValue{Val: float64(n)}, nil
-	case uint32:
-		return FloatValue{Val: float64(n)}, nil
-	case uint64:
-		return FloatValue{Val: float64(n)}, nil
-	case json.Number:
-		val, err := n.Float64()
-		if err != nil {
-			return nil, fmt.Errorf("invalid number %q", n.String())
-		}
-		return FloatValue{Val: val}, nil
-	default:
+	num, ok := raw.(json.Number)
+	if !ok {
 		return nil, fmt.Errorf("expected number for GraphQL Float, got %T", raw)
 	}
+	val, err := num.Float64()
+	if err != nil {
+		return nil, fmt.Errorf("invalid number %q", num.String())
+	}
+	return FloatValue{Val: val}, nil
 }
 
 // Helper function to convert Dang values to Go values for GraphQL

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -1,6 +1,7 @@
 package querybuilder
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,16 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"golang.org/x/sync/errgroup"
 )
+
+// decodeJSON unmarshals JSON into v with UseNumber, so numbers landing in an
+// interface{} are preserved as json.Number rather than collapsed to float64.
+// This keeps integers exact through the decode and lets the value layer decide
+// Int vs Float from the declared GraphQL type instead of the value's shape.
+func decodeJSON(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
 
 // QueryBuilder represents a GraphQL query builder using a chain-based approach
 type QueryBuilder struct {
@@ -336,7 +347,7 @@ func (q *QueryBuilder) unpack(data any) error {
 				if err != nil {
 					return err
 				}
-				if err := json.Unmarshal(marshalled, i.bind); err != nil {
+				if err := decodeJSON(marshalled, i.bind); err != nil {
 					return err
 				}
 			}
@@ -358,7 +369,7 @@ func (q *QueryBuilder) unpack(data any) error {
 				if err != nil {
 					return err
 				}
-				if err := json.Unmarshal(marshalled, i.bind); err != nil {
+				if err := decodeJSON(marshalled, i.bind); err != nil {
 					return err
 				}
 			}
@@ -376,7 +387,7 @@ func (q *QueryBuilder) unpack(data any) error {
 			if err != nil {
 				return err
 			}
-			if err := json.Unmarshal(marshalled, i.bind); err != nil {
+			if err := decodeJSON(marshalled, i.bind); err != nil {
 				return err
 			}
 		}
@@ -406,16 +417,26 @@ func (q *QueryBuilder) Execute(ctx context.Context) error {
 	payload := opType + " " + opName + " " + query
 	slog.DebugContext(ctx, "executing GraphQL request", "query", payload)
 
-	var response any
+	// Capture the raw "data" bytes and decode them ourselves with UseNumber,
+	// rather than letting the client decode into interface{} (which would
+	// collapse every number to float64 before we can honor the declared type).
+	var rawData json.RawMessage
 	err = q.client.MakeRequest(ctx,
 		&graphql.Request{
 			Query:  payload,
 			OpName: opName,
 		},
-		&graphql.Response{Data: &response},
+		&graphql.Response{Data: &rawData},
 	)
 	if err != nil {
 		return err
+	}
+
+	var response any
+	if len(rawData) > 0 {
+		if err := decodeJSON(rawData, &response); err != nil {
+			return err
+		}
 	}
 
 	return q.unpack(response)

--- a/tests/gqlserver/generated.go
+++ b/tests/gqlserver/generated.go
@@ -77,6 +77,8 @@ type ComplexityRoot struct {
 
 	Query struct {
 		AddBigInt         func(childComplexity int, a string, b string) int
+		AverageRating     func(childComplexity int) int
+		EchoFloat         func(childComplexity int, value float64) int
 		FavoriteNodeID    func(childComplexity int) int
 		FavoriteUserID    func(childComplexity int) int
 		FavoriteUserIDs   func(childComplexity int) int
@@ -184,6 +186,8 @@ type QueryResolver interface {
 	SearchConnection(ctx context.Context, query string) (*SearchResultConnection, error)
 	UsersByStatus(ctx context.Context, status Status) ([]*User, error)
 	SortedUsers(ctx context.Context, sort UserSort) ([]*User, error)
+	AverageRating(ctx context.Context) (float64, error)
+	EchoFloat(ctx context.Context, value float64) (float64, error)
 }
 type UserResolver interface {
 	Posts(ctx context.Context, obj *User, first *int, after *string, last *int, before *string) (*PostConnection, error)
@@ -324,6 +328,23 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.AddBigInt(childComplexity, args["a"].(string), args["b"].(string)), true
+	case "Query.averageRating":
+		if e.complexity.Query.AverageRating == nil {
+			break
+		}
+
+		return e.complexity.Query.AverageRating(childComplexity), true
+	case "Query.echoFloat":
+		if e.complexity.Query.EchoFloat == nil {
+			break
+		}
+
+		args, err := ec.field_Query_echoFloat_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.EchoFloat(childComplexity, args["value"].(float64)), true
 	case "Query.favoriteNodeID":
 		if e.complexity.Query.FavoriteNodeID == nil {
 			break
@@ -932,6 +953,17 @@ func (ec *executionContext) field_Query_addBigInt_args(ctx context.Context, rawA
 		return nil, err
 	}
 	args["b"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_echoFloat_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "value", ec.unmarshalNFloat2float64)
+	if err != nil {
+		return nil, err
+	}
+	args["value"] = arg0
 	return args, nil
 }
 
@@ -2989,6 +3021,76 @@ func (ec *executionContext) fieldContext_Query_sortedUsers(ctx context.Context, 
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_sortedUsers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_averageRating(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_averageRating,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().AverageRating(ctx)
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_averageRating(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_echoFloat(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_echoFloat,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().EchoFloat(ctx, fc.Args["value"].(float64))
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_echoFloat(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_echoFloat_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -6313,6 +6415,50 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "averageRating":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_averageRating(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "echoFloat":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_echoFloat(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -7075,6 +7221,22 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 func (ec *executionContext) unmarshalNCreateUserInput2githubᚗcomᚋvitoᚋdangᚋv2ᚋtestsᚋgqlserverᚐCreateUserInput(ctx context.Context, v any) (CreateUserInput, error) {
 	res, err := ec.unmarshalInputCreateUserInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v any) (float64, error) {
+	res, err := graphql.UnmarshalFloatContext(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalFloatContext(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return graphql.WrapContextMarshaler(ctx, res)
 }
 
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v any) (string, error) {

--- a/tests/gqlserver/resolvers.go
+++ b/tests/gqlserver/resolvers.go
@@ -373,6 +373,16 @@ func (r *queryResolver) SortedUsers(ctx context.Context, sort UserSort) ([]*User
 	return result, nil
 }
 
+// AverageRating is the resolver for the averageRating field.
+func (r *queryResolver) AverageRating(ctx context.Context) (float64, error) {
+	return 4.5, nil
+}
+
+// EchoFloat is the resolver for the echoFloat field.
+func (r *queryResolver) EchoFloat(ctx context.Context, value float64) (float64, error) {
+	return value, nil
+}
+
 // Posts is the resolver for the posts field.
 func (r *userResolver) Posts(ctx context.Context, obj *User, first *int, after *string, last *int, before *string) (*PostConnection, error) {
 	// Get all posts for this user

--- a/tests/gqlserver/schema.graphqls
+++ b/tests/gqlserver/schema.graphqls
@@ -56,6 +56,9 @@ type Query {
   searchConnection(query: String!): SearchResultConnection!
   usersByStatus(status: Status!): [User!]!
   sortedUsers(sort: UserSort!): [User!]!
+  # Float round-trip: a Float result reused as a Float argument.
+  averageRating: Float!
+  echoFloat(value: Float!): Float!
 }
 
 enum UserSortField {

--- a/tests/test_graphql_float_result_as_float_argument.dang
+++ b/tests/test_graphql_float_result_as_float_argument.dang
@@ -1,0 +1,9 @@
+import Test
+
+let rating_from_graphql_float = averageRating
+assert { rating_from_graphql_float == 4.5 }
+
+assert { echoFloat(value: rating_from_graphql_float) == 4.5 }
+assert { echoFloat(value: 2.5) == 2.5 }
+
+print("GraphQL Float result can be reused as a Float argument")


### PR DESCRIPTION
Follow-up to #159, which fixed GraphQL `Int` results coming back as `FloatValue`. That fix was correct but one-directional; this finishes the conversion boundary on both sides and removes the lossy/duplicated bits underneath it.

## What was still wrong after #159

- **Float arguments couldn't be serialized at all.** #159 made `Int` *results* round-trip back as `Int` arguments, but `dangValueToGo` (Dang value → GraphQL argument) had no `FloatValue` case. Passing a `Float` value to a `Float` argument failed with `unsupported value type: dang.FloatValue` — the exact mirror of the bug that was just fixed in the other direction.
- **Numbers were decoded shape-first, then reclassified.** GraphQL responses decode into `interface{}`, where the standard library turns every number into `float64`. #159 worked around this by formatting the `float64` back into a string and re-parsing it, and carried a pile of `int*`/`uint*`/`float32` switch arms that the GraphQL path can never actually produce.

## What this does

**`querybuilder: decode GraphQL numbers via declared type`** — Capture the `data` payload and decode it ourselves with `UseNumber`, so numbers arrive as `json.Number` (the same shape the codec/`materialize` path already produces) instead of `float64`. The declared GraphQL type then decides `Int` vs `Float`. Integers stay exact through the decode, the `Int`/`Float` converters share `decodedNumberToInt` with the codec materializer instead of duplicating a float-to-int dance, and the unreachable numeric branches are deleted. `ToValue` gains a `json.Number` case for the one remaining *untyped* fallback (no declared type to honor — a bare integer stays an `Int`, anything fractional becomes a `Float`).

**`graphql: pass Float and Map values as arguments`** — Add `FloatValue` to `dangValueToGo`, plus `MapValue` for symmetry with `*Object` (so a map can feed an input object or map-shaped scalar). The test server gains an `averageRating` field and an `echoFloat` argument, and a new `.dang` test reuses a `Float` result as a `Float` argument end to end, mirroring the existing `Int` test.

## What this deliberately does *not* do

It does not merge `graphQLResultToValue` and `materializeDecoded` into one function. They share the number primitive now, but they are driven by genuinely different inputs — a GraphQL `TypeRef` vs. a resolved Dang `hm.Type` — and they differ on purpose: the `@expectedType` directive remaps an `ID` to an object *type* statically while the runtime value stays an ID string, and the GraphQL path trusts the server's enum values where the codec path validates untrusted input. Forcing them together would trade those distinctions for a worse abstraction.

Full Go suite green via Dagger (`dang:test:go`, 1144 passing incl. the new test) and `dang:lint`.
