### PR TITLE
docs: fix search palette empty-list sliver and double-open

### DIFF
--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -40,10 +40,15 @@
     "}",
     ".dang-search-box input {",
     "  width: 100%; padding: .9rem 1rem; background: transparent; border: none;",
-    "  border-bottom: 1px solid var(--code-border); color: var(--fg);",
-    "  font: inherit; font-size: 1rem; outline: none;",
+    "  color: var(--fg); font: inherit; font-size: 1rem; outline: none;",
     "}",
-    ".dang-search-results { list-style: none; margin: 0; padding: .35rem; overflow-y: auto; }",
+    // The divider lives on the results list, not the input, so it only shows
+    // when there is something below it.
+    ".dang-search-results { list-style: none; margin: 0; padding: .35rem; overflow-y: auto;",
+    "  border-top: 1px solid var(--code-border); }",
+    // Just opened or query cleared: no list, so no border and no empty sliver
+    // under the input.
+    ".dang-search-results:empty { display: none; }",
     ".dang-search-results li { margin: 0; }",
     ".dang-search-results a {",
     "  display: block; padding: .5rem .65rem; border-radius: 6px; color: var(--fg);",

--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -10,6 +10,14 @@
 (function () {
   "use strict";
 
+  // Guard against double-initialization. This script injects a body-level
+  // overlay and a document-wide keydown listener, so running it twice stacks
+  // two independent search palettes — each opening on Ctrl+K and each needing
+  // its own backdrop click to dismiss. Be idempotent no matter how the script
+  // ends up evaluated more than once.
+  if (window.__dangSearchInit) return;
+  window.__dangSearchInit = true;
+
   var INDEX_URL = "search_index.json";
 
   // ---- styles ------------------------------------------------------------


### PR DESCRIPTION
Two fixes to the docs search palette (`docs/js/search.js`).

## Empty results list left a bordered sliver

When the palette first opens (or after the query is cleared) the results `<ul>` has no children, but it still rendered the input's `border-bottom` plus its own padding — an awkward bordered strip under the search field with nothing in it.

The divider now lives on the results list as a `border-top` instead of on the input as a `border-bottom`, and the list is hidden with `:empty`. An empty list therefore contributes no border and no height, so the open palette is just the input until you type. The "No results" message and real results still render with a clean divider, because the list isn't empty in those states.

## Ctrl+K opened two palettes

Pressing Ctrl+K popped up two overlapping search boxes — each opened on the shortcut and each needed its own backdrop click to dismiss — which is the signature of the script initializing twice (two body-level overlays, two `document` keydown listeners).

The template references `js/search.js` exactly once, so I couldn't pin the double-evaluation to a source include; it's happening in the built/served environment. Rather than chase that, the script now sets a `window` flag on first run and bails on any later run. The palette is a singleton no matter how the script ends up evaluated more than once, which is the right invariant for something that injects a global overlay and a document-wide listener anyway. (If a duplicate `<script>` does turn up in the deployed HTML, happy to remove it at the source too — a view-source count of `search.js` would confirm.)
