### PR TITLE
dang: let type methods call top-level functions

### DIFF
--- a/pkg/dang/block.go
+++ b/pkg/dang/block.go
@@ -218,14 +218,21 @@ func EvaluateDeclaredFormsWithPhases(ctx context.Context, forms []Node, scope Va
 }
 
 // InferFormsWithPhases implements phased compilation:
-// 1. Parse all files (already done)
-// 2. Build dependency graph of all declarations
-// 3. Import external schemas
-// 4. Hoist local type names so annotations shadow imported types immediately
-// 5. Typecheck constants and types (which can reference each other)
-// 6. Declare function signatures (without bodies)
-// 7. Typecheck variables in dependency order (can now reference function signatures)
-// 8. Typecheck function bodies last (can reference all package-level declarations)
+//  1. Parse all files (already done)
+//  2. Build dependency graph of all declarations
+//  3. Import external schemas
+//  4. Hoist local type names so annotations shadow imported types immediately
+//  5. Typecheck constants
+//  6. Declare variable signatures
+//  7. Declare function signatures (without bodies)
+//  8. Typecheck types, including method/computed-field bodies (which can now
+//     reference variable and function signatures declared above)
+//  9. Typecheck variables in dependency order
+//  10. Typecheck function bodies last (can reference all package-level declarations)
+//
+// Function signatures only need type names (hoisted in step 4), not inferred type
+// bodies, so declaring them before types lets type method bodies call top-level
+// functions. Function *bodies* stay last, so nothing loses access to later declarations.
 //
 // This function collects all errors instead of failing fast, allowing partial inference
 // to succeed and providing better error messages showing all problems at once.
@@ -252,11 +259,11 @@ func InferFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh h
 		{"variable signatures", func(errs *InferenceErrors) (hm.Type, error) {
 			return declareVariableSignaturesPhaseResilient(ctx, classified.Variables, env, fresh, errs)
 		}},
-		{"types", func(errs *InferenceErrors) (hm.Type, error) {
-			return inferTypesPhaseResilient(ctx, classified.Types, env, fresh, errs)
-		}},
 		{"function signatures", func(errs *InferenceErrors) (hm.Type, error) {
 			return declareFunctionSignaturesPhaseResilient(ctx, classified.Functions, env, fresh, errs)
+		}},
+		{"types", func(errs *InferenceErrors) (hm.Type, error) {
+			return inferTypesPhaseResilient(ctx, classified.Types, env, fresh, errs)
 		}},
 		{"variables", func(errs *InferenceErrors) (hm.Type, error) {
 			return inferVariablesPhaseResilient(ctx, classified.Variables, env, fresh, errs)

--- a/pkg/dang/block.go
+++ b/pkg/dang/block.go
@@ -166,11 +166,11 @@ func DeclareFormsWithPhases(ctx context.Context, forms []Node, env hm.Env, fresh
 		{"variable signatures", func(errs *InferenceErrors) (hm.Type, error) {
 			return declareVariableSignaturesPhaseResilient(ctx, classified.Variables, env, fresh, errs)
 		}},
-		{"type signatures", func(errs *InferenceErrors) (hm.Type, error) {
-			return declareTypeSignaturesPhaseResilient(ctx, classified.Types, env, fresh, errs)
-		}},
 		{"function signatures", func(errs *InferenceErrors) (hm.Type, error) {
 			return declareFunctionSignaturesPhaseResilient(ctx, classified.Functions, env, fresh, errs)
+		}},
+		{"type signatures", func(errs *InferenceErrors) (hm.Type, error) {
+			return declareTypeSignaturesPhaseResilient(ctx, classified.Types, env, fresh, errs)
 		}},
 	}
 

--- a/tests/test_type_method_top_level_function.dang
+++ b/tests/test_type_method_top_level_function.dang
@@ -1,0 +1,42 @@
+# Regression test for issue #162: a method (or computed field) inside a `type`
+# must be able to reference a top-level function. Function signatures are now
+# declared before type bodies are type-checked, so all of the top-level
+# declaration kinds below resolve from a method body.
+
+# Public top-level function.
+inc(x: Int!): Int! { x + 1 }
+
+# Private (`let`) top-level function.
+let dbl(x: Int!): Int! { x * 2 }
+
+# Top-level value and constructor, which already resolved, kept here to guard
+# against regressing them.
+let base = 40
+
+type Helper {
+  bump(x: Int!): Int! { x + 100 }
+}
+
+type T {
+  # Computed field calling a public top-level function.
+  compute: Int! { inc(41) }
+
+  # Method calling both a public and a private top-level function.
+  combine(x: Int!): Int! { inc(dbl(x)) }
+
+  # Method reaching a top-level value and constructor.
+  viaValueAndCtor: Int! { Helper.bump(base) }
+
+  # Function reference to a top-level function from a method body.
+  viaRef: Int! {
+    let f = &inc
+    f(9)
+  }
+}
+
+assert { T.compute == 42 }
+assert { T.combine(20) == 41 }
+assert { T.viaValueAndCtor == 140 }
+assert { T.viaRef == 10 }
+
+print("Type method top-level function tests passed!")


### PR DESCRIPTION
Fixes #162.

A method or computed field inside a `type` couldn't reference a top-level **function** — inference failed with `"<name>" not found`. Top-level *values* and *constructors* resolved fine from the same method body; only functions didn't.

## Root cause

`InferFormsWithPhases` (`pkg/dang/block.go`) type-checked type bodies *before* declaring top-level function signatures, so a method body checked in the `types` phase saw no function signatures. Values worked because variable signatures are declared earlier; constructors worked because type names are hoisted earlier still.

## Fix

Move the `function signatures` phase ahead of `types`. Function signatures only need type *names* (already hoisted), not inferred type *bodies*, so declaring them earlier is safe. Function *bodies* still infer last, so nothing loses access to later declarations. The stale phase-order doc comment above the function is corrected to match.

## Verification

The issue's repro now prints `42`. Added `tests/test_type_method_top_level_function.dang` covering a public function, a `let` function, a `&`-reference, and (as guards) a value and constructor reached from method bodies. `go test ./pkg/dang/ ./tests/` passes, including the format-preservation pass over the new file.
