### PR TITLE
Native Dang module imports (local path imports)

### DIFF
--- a/.agents/skills/dang-language/reference/graphql.md
+++ b/.agents/skills/dang-language/reference/graphql.md
@@ -107,7 +107,7 @@ authorization = "Bearer ${API_TOKEN}"
 [imports.Remote.headers]
 X-Custom = "value"
 ```
-- One `[imports.<Name>]` per source; `<Name>` is the qualifier (`MyApi.User`). Must specify at least one of `dagger`, `schema`, `endpoint`, `service`.
+- One `[imports.<Name>]` per source; `<Name>` is the qualifier (`MyApi.User`). Must specify at least one of `dagger`, `schema`, `endpoint`, `service` — or `path` (native Dang module, below).
 - `schema` — path to a local `.graphqls` SDL file (relative to `dang.toml`); used for type-checking and the LSP.
 - `endpoint` — GraphQL HTTP URL for runtime queries; if set without `schema`, the schema is introspected (and cached) from it.
 - `service` — command starting a GraphQL server that prints its endpoint URL as the first stdout line; started lazily, killed on exit.
@@ -115,6 +115,12 @@ X-Custom = "value"
 - `authorization` — value for the `Authorization` header. `[imports.<Name>.headers]` — extra HTTP headers.
 - `authorization` / `endpoint` / `headers` support `${ENV_VAR}` expansion; `$(...)` command substitution is **not** supported. (The old `DANG_GRAPHQL_*` env config was dropped.)
 - Discovery walks **up** from the working directory, stopping at a `.git` boundary. Commit `dang.toml` — don't include credentials inline; reference env vars.
+
+### Native Dang module imports
+- `path = "./dir"` imports **another Dang module** (a directory of `.dang` files, relative to `dang.toml`) instead of a GraphQL source; mutually exclusive with `dagger`/`schema`/`endpoint`/`service` (`'path' cannot be combined with ...`).
+- The module's public (non-`let`) surface becomes the import's API; `let` stays private **across the boundary** (the [#fields] public/`let` rule, now enforced between modules).
+- **Per-module identity:** each importing module gets its own instance — two modules importing the same directory hold distinct copies of its types, and same-named types from different instances don't unify (`the "Widget" value here is a different type from the "Widget" expected ... share behavior through an interface instead`). No MVS/version reconciliation.
+- Transitive `path` imports resolve each module's own `dang.toml`; cycles are reported (`import cycle detected: a -> b -> a`).
 
 ### `import` declarations
 ```dang

--- a/docs/lit/graphql/modules.md
+++ b/docs/lit/graphql/modules.md
@@ -46,8 +46,8 @@ authorization = "Bearer ${API_TOKEN}"
 The `endpoint`, `authorization`, and `headers` values support `${VAR}`
 environment expansion; `$(...)` command substitution is not supported.
 
-- one `[imports.<Name>]` per imported GraphQL source; `<Name>` is the qualifier (`MyApi.User`)
-- must specify at least one of `dagger`, `schema`, `endpoint`, or `service`
+- one `[imports.<Name>]` per imported source; `<Name>` is the qualifier (`MyApi.User`)
+- must specify at least one of `dagger`, `schema`, `endpoint`, or `service` — or `path`, to import a native Dang module instead of a GraphQL source (see [#dang-imports])
 - `schema = "..."` — path to a local `.graphqls` SDL file (relative to `dang.toml`); used for type-checking and the LSP
 - `endpoint = "..."` — GraphQL HTTP URL for runtime queries; if set without `schema`, the schema is introspected (and cached) from it
 - `service = [...]` — command that starts a GraphQL server, printing its endpoint URL as the first stdout line; started lazily, killed on exit
@@ -56,6 +56,30 @@ environment expansion; `$(...)` command substitution is not supported.
 - `[imports.<Name>.headers]` — extra HTTP headers (table of key = value)
 - `authorization` / `endpoint` / `headers` values support `${ENV_VAR}` expansion (note: the old `DANG_GRAPHQL_*` env-var config was dropped)
 - runtime queries are GraphQL interop; see [#interop]
+
+## Importing another Dang module {#dang-imports}
+
+An import can point at **another Dang module** on disk instead of a GraphQL
+source. Its public surface becomes available under the qualifier, exactly like a
+GraphQL import.
+
+```toml
+[imports.Helpers]
+path = "./lib/helpers"
+```
+
+- `path = "..."` — a directory of `.dang` files (relative to `dang.toml`), compiled as a module
+- mutually exclusive with the GraphQL source kinds: `'path' cannot be combined with 'dagger', 'schema', 'endpoint', or 'service'`
+- the module's public (non-`let`) declarations are its API; `let` declarations stay private **across the import boundary** — the same public/`let` rule as [#fields], now enforced between modules
+- `import Helpers` then exposes `Helpers.Greeting` (qualified) and `Greeting` (unqualified), like any import
+- transitive `path` imports work (an imported module resolves its own `dang.toml` from its directory); import cycles are reported: `import cycle detected: a -> b -> a`
+
+### Per-module identity
+
+- each importing module gets its **own instance** of an imported module — nothing unifies across the boundary
+- two modules importing the same directory therefore hold **distinct copies** of its types: a `Widget` from one is not the `Widget` from the other, even when structurally identical
+- assigning across that boundary is rejected with a hint to share behavior through an interface: `the "Widget" value here is a different type from the "Widget" expected: they come from different modules and do not unify across the module boundary; share behavior through an interface instead`
+- there is no version reconciliation (no MVS): each `dang.toml` gets exactly what it declares
 
 ## `import` declarations
 

--- a/docs/lit/reference/cli.md
+++ b/docs/lit/reference/cli.md
@@ -71,7 +71,7 @@ Input keys: Tab completion, Up/Down history, Alt+Enter (or Shift+Enter under a K
 
 ## Configuration
 
-- GraphQL connections are configured per-import in `dang.toml` under `[imports.<Name>]`. Keys: `dagger`, `schema` (local `.graphqls` SDL path), `endpoint`, `service` (command that prints its endpoint/session JSON), `authorization`, `headers`.
+- GraphQL connections are configured per-import in `dang.toml` under `[imports.<Name>]`. Keys: `dagger`, `schema` (local `.graphqls` SDL path), `endpoint`, `service` (command that prints its endpoint/session JSON), `authorization`, `headers`. A `path` key instead imports a native Dang module (a local directory of `.dang` files); see [#dang-imports].
 - `endpoint`, `authorization`, and `headers` values support `${VAR}` environment expansion. `$(...)` command substitution is **not** supported (use an env var instead). See [#getting-started] and [#interop].
 - config is discovered by walking up from the working directory, stopping at a `.git` boundary.
 

--- a/pkg/dang/ast_declarations.go
+++ b/pkg/dang/ast_declarations.go
@@ -995,6 +995,11 @@ type ImportDecl struct {
 	client   graphql.Client
 	schema   *introspection.Schema
 	inferred TypeScope
+
+	// dangMod is set for native Dang module imports (config.DangModuleDir).
+	// It carries the compiled module reused at Eval, mirroring how client/schema
+	// are stashed for GraphQL imports.
+	dangMod *dangModule
 }
 
 type ImportConfig struct {
@@ -1010,6 +1015,12 @@ type ImportConfig struct {
 	// Dagger indicates this import connects to a Dagger Engine session.
 	// Used by the LSP to find the client for module introspection.
 	Dagger bool
+
+	// DangModuleDir, when non-empty, marks this as a native Dang module import
+	// (not a GraphQL schema). It is the resolved absolute path to the module's
+	// directory; the module is compiled from source and its `pub` declarations
+	// become the import's API. See import_dang.go.
+	DangModuleDir string
 }
 
 type importConfigsKey struct{}
@@ -1033,6 +1044,9 @@ func WithSchemaModuleCache(ctx context.Context, cache *sync.Map) context.Context
 func ContextWithImportConfigs(ctx context.Context, configs ...ImportConfig) context.Context {
 	if _, ok := ctx.Value(schemaModuleCacheKey{}).(*sync.Map); !ok {
 		ctx = WithSchemaModuleCache(ctx, &sync.Map{})
+	}
+	if _, ok := ctx.Value(dangModuleCacheKey{}).(*sync.Map); !ok {
+		ctx = WithDangModuleCache(ctx, &sync.Map{})
 	}
 	return context.WithValue(ctx, importConfigsKey{}, configs)
 }
@@ -1106,10 +1120,24 @@ func (i *ImportDecl) Infer(ctx context.Context, env hm.Env, fresh hm.Fresher) (h
 				if err != nil {
 					return nil, err
 				}
-				i.client = config.Client
-				i.schema = config.Schema
-				i.inferred = TypeScopeFromSchema(i.Name.Name, config.Schema)
-				cacheImportModule(ctx, i.Name.Name, i.inferred)
+				if config.DangModuleDir != "" {
+					// Native Dang module: compile the module directory under its
+					// own moduleScope and install its public type scope. Keyed by
+					// resolved dir in the ctx-scoped Dang-module cache, so every
+					// importer of the same dir gets one *Type identity and its
+					// types unify — the schema cache's guarantee, by directory.
+					mod, err := loadDangModule(ctx, config.DangModuleDir)
+					if err != nil {
+						return nil, err
+					}
+					i.dangMod = mod
+					i.inferred = mod.typeScope
+				} else {
+					i.client = config.Client
+					i.schema = config.Schema
+					i.inferred = TypeScopeFromSchema(i.Name.Name, config.Schema)
+					cacheImportModule(ctx, i.Name.Name, i.inferred)
+				}
 			}
 		}
 
@@ -1126,6 +1154,17 @@ func (i *ImportDecl) Eval(ctx context.Context, scope ValueScope) (Value, error) 
 		return nil, fmt.Errorf("ImportDecl.Eval: import not properly inferred")
 	}
 
+	// Native Dang module: evaluate its code (once, shared across importers) and
+	// install its public value scope.
+	if i.dangMod != nil {
+		importValueScope, err := i.dangMod.valueScope(ctx)
+		if err != nil {
+			return nil, err
+		}
+		installImportedValueScope(scope, i.Name.Name, importValueScope)
+		return importValueScope, nil
+	}
+
 	// Create evaluation environment for the imported schema
 	importValueScope := ValueScopeFromSchema(i.inferred, i.client, i.schema)
 
@@ -1139,6 +1178,11 @@ func (i *ImportDecl) Eval(ctx context.Context, scope ValueScope) (Value, error) 
 func (i *ImportDecl) loadImportConfig(ctx context.Context) (ImportConfig, error) {
 	for _, config := range importConfigsFromContext(ctx) {
 		if config.Name == i.Name.Name {
+			// Native Dang modules carry no GraphQL schema — the module is
+			// compiled from source in ImportDecl.Infer. Skip introspection.
+			if config.DangModuleDir != "" {
+				return config, nil
+			}
 			if config.Schema == nil {
 				var err error
 				config.Schema, err = introspectSchema(ctx, config.Client, config.Dagger)

--- a/pkg/dang/fields.go
+++ b/pkg/dang/fields.go
@@ -728,9 +728,14 @@ func (c *ObjectDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pa
 	}
 	c.ConstructorFnType = constructorType
 
-	// Add the constructor function type to the environment
+	// Add the constructor function type to the environment, carrying the
+	// declaration's visibility so the type name is exported (or kept private)
+	// across a module boundary. Without this the binding defaults to private and
+	// an importer can't reach the type unqualified — the eval side already binds
+	// the constructor with c.Visibility (see ConstructorFunction binding below).
 	constructorScheme := hm.NewScheme(nil, constructorType)
 	env.Add(c.Name.Name, constructorScheme)
+	mod.SetVisibility(c.Name.Name, c.Visibility)
 
 	// Link the implementation after all interface type names have been
 	// registered by pass 0.
@@ -1211,6 +1216,10 @@ func (e *EnumDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pass
 	// Note: We add the enum type itself, not wrapped in NonNullType, matching GraphQL enum behavior
 	enumScheme := hm.NewScheme(nil, NonNull(enumType))
 	env.Add(e.Name.Name, enumScheme)
+	// Carry the declaration's visibility so the enum's value binding is exported
+	// across a module boundary (the eval side binds it with e.Visibility). Without
+	// this it defaults to private and an importer can't reach it unqualified.
+	mod.SetVisibility(e.Name.Name, e.Visibility)
 
 	if pass > 0 {
 		// Add each enum value as a field in the enum module
@@ -1761,6 +1770,10 @@ func (i *InterfaceDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher,
 		// Add the interface type to the environment so it can be referenced.
 		interfaceScheme := hm.NewScheme(nil, iface)
 		env.Add(i.Name.Name, interfaceScheme)
+		// Carry the declaration's visibility so the interface's value binding is
+		// exported across a module boundary (the eval side binds it with
+		// i.Visibility); otherwise it defaults to private.
+		mod.SetVisibility(i.Name.Name, i.Visibility)
 		return nil
 	}
 
@@ -1966,6 +1979,10 @@ func (u *UnionDecl) Hoist(ctx context.Context, env hm.Env, fresh hm.Fresher, pas
 	if pass == 0 {
 		// Pass 0: Register the union type so it can be referenced.
 		env.Add(u.Name.Name, hm.NewScheme(nil, unionMod))
+		// Carry the declaration's visibility so the union's value binding is
+		// exported across a module boundary (the eval side binds it with
+		// u.Visibility); otherwise it defaults to private.
+		mod.SetVisibility(u.Name.Name, u.Visibility)
 		return nil
 	}
 

--- a/pkg/dang/import_dang.go
+++ b/pkg/dang/import_dang.go
@@ -5,28 +5,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/vito/dang/v2/pkg/hm"
 )
 
 // dangModule is a compiled native Dang module: its inferred public type scope
-// plus the parsed file blocks needed to evaluate its code. Exactly one is
-// produced per module directory per build and shared by every importer (keyed
-// by resolved absolute dir in the ctx-scoped Dang-module cache), so its types
-// unify across the dependency graph and its homeModule identity is stable —
-// the same guarantee the schema-module cache gives GraphQL imports.
+// plus the parsed file blocks needed to evaluate its code. Under the per-module
+// identity model, one is produced per importing module per build: all files of a
+// single module share one *dangModule per imported directory (keyed by resolved
+// absolute dir in that module's ctx-scoped Dang-module cache), so its types and
+// homeModule identity are stable within the module. But two DIFFERENT modules
+// importing the same directory each get their own *dangModule — foreign types
+// deliberately do not unify across the module boundary; behavior is shared via
+// interfaces instead.
 //
-// The module is frozen once compiled: its top-level code runs at most once (on
-// first evaluation), exactly like the prelude.
+// The module is frozen once compiled: its top-level code runs at most once per
+// instance (on first evaluation), exactly like the prelude. A directory imported
+// by N distinct modules therefore compiles and runs N times, once per instance.
 type dangModule struct {
 	dir       string
 	typeScope TypeScope
 	blocks    []*FileBlock
-
-	// inProgress marks a module whose inference is mid-flight, so a re-entrant
-	// load (an import cycle) is detected and errored rather than looping.
-	inProgress bool
 
 	once  sync.Once
 	value ValueScope
@@ -36,10 +37,12 @@ type dangModule struct {
 type dangModuleCacheKey struct{}
 
 // WithDangModuleCache attaches a dir-keyed cache of compiled Dang modules to
-// ctx. Consulted by loadDangModule so every importer of the same module
-// directory reuses one compiled *dangModule (and thus one set of *Type
+// ctx. Consulted by loadDangModule so all files of one module reuse a single
+// compiled *dangModule per imported directory (and thus one set of *Type
 // identities). Mirrors WithSchemaModuleCache. ContextWithImportConfigs
-// auto-creates one when none is attached.
+// auto-creates one when none is attached; moduleImportContext installs a FRESH
+// one per compiled module, which is what keeps each module's imports distinct
+// (the per-module identity model).
 func WithDangModuleCache(ctx context.Context, cache *sync.Map) context.Context {
 	return context.WithValue(ctx, dangModuleCacheKey{}, cache)
 }
@@ -49,49 +52,68 @@ func dangModuleCacheFromContext(ctx context.Context) *sync.Map {
 	return c
 }
 
+type compileStackKey struct{}
+
+// compileStackFromContext returns the chain of module directories currently
+// mid-compile, outermost first. It threads through ctx across the module
+// boundary (unlike the per-module Dang-module cache, which is freshened per
+// module) so a re-entrant import of a directory already on the chain is detected
+// as a cycle — a shared-cache marker cannot do this job here, because each
+// module compiles its dependencies with its OWN fresh cache and A->B->A would
+// otherwise expand a new instance every hop, forever.
+func compileStackFromContext(ctx context.Context) []string {
+	s, _ := ctx.Value(compileStackKey{}).([]string)
+	return s
+}
+
+func pushCompileStack(ctx context.Context, dir string) context.Context {
+	prev := compileStackFromContext(ctx)
+	next := make([]string, len(prev)+1)
+	copy(next, prev)
+	next[len(prev)] = dir
+	return context.WithValue(ctx, compileStackKey{}, next)
+}
+
 // loadDangModule returns the compiled module rooted at dir, compiling it on a
-// cache miss. The result is cached (keyed by resolved absolute dir) so repeated
-// and cross-file imports of the same module unify. Compilation is marked
-// in-progress in the cache so an import cycle is reported rather than looping.
+// cache miss. The result is cached (keyed by resolved absolute dir) in the
+// importing module's cache, so its files' repeated imports of that directory
+// unify. Import cycles are reported via the ctx compile-stack rather than a
+// cache marker, because each module compiles its deps with a fresh cache and a
+// marker would not survive the boundary.
 func loadDangModule(ctx context.Context, dir string) (*dangModule, error) {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
 	}
 
+	// Cycle detection against the active compile path. See compileStackFromContext.
+	stack := compileStackFromContext(ctx)
+	for i, d := range stack {
+		if d == dir {
+			chain := append(append([]string(nil), stack[i:]...), dir)
+			return nil, fmt.Errorf("import cycle detected: %s", strings.Join(chain, " -> "))
+		}
+	}
+
 	cache := dangModuleCacheFromContext(ctx)
 	if cache != nil {
 		if v, ok := cache.Load(dir); ok {
-			mod := v.(*dangModule)
-			if mod.inProgress {
-				return nil, fmt.Errorf("import cycle detected: Dang module %s imports itself (directly or transitively)", dir)
-			}
-			return mod, nil
+			return v.(*dangModule), nil
 		}
 	}
 
-	mod := &dangModule{dir: dir, inProgress: true}
-	if cache != nil {
-		// Publish the in-progress marker before inference so a transitive import
-		// back to this directory is detected as a cycle.
-		if actual, loaded := cache.LoadOrStore(dir, mod); loaded {
-			existing := actual.(*dangModule)
-			if existing.inProgress {
-				return nil, fmt.Errorf("import cycle detected: Dang module %s imports itself (directly or transitively)", dir)
-			}
-			return existing, nil
-		}
-	}
-
-	if err := mod.compile(ctx); err != nil {
-		if cache != nil {
-			// Drop the failed marker so a later pass (e.g. the LSP re-inferring
-			// after an edit) can retry from scratch.
-			cache.Delete(dir)
-		}
+	mod := &dangModule{dir: dir}
+	if err := mod.compile(pushCompileStack(ctx, dir)); err != nil {
 		return nil, err
 	}
-	mod.inProgress = false
+
+	// Store only after a successful compile: a failed load leaves no marker, so a
+	// later pass (e.g. the LSP re-inferring after an edit) retries from scratch.
+	// Imports infer sequentially per directory, so no LoadOrStore race here — the
+	// same discipline the schema-module cache relies on.
+	if cache != nil {
+		cache.Store(dir, mod)
+	}
 	return mod, nil
 }
 
@@ -156,13 +178,22 @@ func parseModuleBlocks(ctx context.Context, dir string) (context.Context, []*Fil
 }
 
 // moduleImportContext strips the importer's project/import configs and attaches
-// the module's own. The Dang-module cache is intentionally left in place so
-// nested Dang modules unify across the whole build.
+// the module's own, and gives the module FRESH schema and Dang-module caches.
+// The fresh Dang-module cache is the per-module identity model: a module
+// resolves its OWN dependencies into its OWN cache, so two different modules
+// importing the same directory each compile a distinct instance and never share
+// a *Type identity. Within a single module all files share this one cache, so a
+// module's repeated / cross-file imports of one dependency still unify. Cross-
+// module cycle detection deliberately does NOT rely on this cache — it uses the
+// ctx compile-stack (see loadDangModule) precisely because the cache is fresh
+// per module and could not carry a cycle marker across the boundary.
 func moduleImportContext(ctx context.Context, dir string) (context.Context, error) {
-	// Clear the importer's schema imports and give the module a fresh schema
-	// cache so imported GraphQL types don't alias across the module boundary.
+	// Clear the importer's schema imports and give the module fresh schema and
+	// Dang-module caches so neither GraphQL nor Dang types alias across the
+	// module boundary.
 	ctx = context.WithValue(ctx, importConfigsKey{}, []ImportConfig(nil))
 	ctx = WithSchemaModuleCache(ctx, &sync.Map{})
+	ctx = WithDangModuleCache(ctx, &sync.Map{})
 
 	configPath := filepath.Join(dir, "dang.toml")
 	if _, statErr := os.Stat(configPath); statErr == nil {

--- a/pkg/dang/import_dang.go
+++ b/pkg/dang/import_dang.go
@@ -1,0 +1,189 @@
+package dang
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/vito/dang/v2/pkg/hm"
+)
+
+// dangModule is a compiled native Dang module: its inferred public type scope
+// plus the parsed file blocks needed to evaluate its code. Exactly one is
+// produced per module directory per build and shared by every importer (keyed
+// by resolved absolute dir in the ctx-scoped Dang-module cache), so its types
+// unify across the dependency graph and its homeModule identity is stable —
+// the same guarantee the schema-module cache gives GraphQL imports.
+//
+// The module is frozen once compiled: its top-level code runs at most once (on
+// first evaluation), exactly like the prelude.
+type dangModule struct {
+	dir       string
+	typeScope TypeScope
+	blocks    []*FileBlock
+
+	// inProgress marks a module whose inference is mid-flight, so a re-entrant
+	// load (an import cycle) is detected and errored rather than looping.
+	inProgress bool
+
+	once  sync.Once
+	value ValueScope
+	err   error
+}
+
+type dangModuleCacheKey struct{}
+
+// WithDangModuleCache attaches a dir-keyed cache of compiled Dang modules to
+// ctx. Consulted by loadDangModule so every importer of the same module
+// directory reuses one compiled *dangModule (and thus one set of *Type
+// identities). Mirrors WithSchemaModuleCache. ContextWithImportConfigs
+// auto-creates one when none is attached.
+func WithDangModuleCache(ctx context.Context, cache *sync.Map) context.Context {
+	return context.WithValue(ctx, dangModuleCacheKey{}, cache)
+}
+
+func dangModuleCacheFromContext(ctx context.Context) *sync.Map {
+	c, _ := ctx.Value(dangModuleCacheKey{}).(*sync.Map)
+	return c
+}
+
+// loadDangModule returns the compiled module rooted at dir, compiling it on a
+// cache miss. The result is cached (keyed by resolved absolute dir) so repeated
+// and cross-file imports of the same module unify. Compilation is marked
+// in-progress in the cache so an import cycle is reported rather than looping.
+func loadDangModule(ctx context.Context, dir string) (*dangModule, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := dangModuleCacheFromContext(ctx)
+	if cache != nil {
+		if v, ok := cache.Load(dir); ok {
+			mod := v.(*dangModule)
+			if mod.inProgress {
+				return nil, fmt.Errorf("import cycle detected: Dang module %s imports itself (directly or transitively)", dir)
+			}
+			return mod, nil
+		}
+	}
+
+	mod := &dangModule{dir: dir, inProgress: true}
+	if cache != nil {
+		// Publish the in-progress marker before inference so a transitive import
+		// back to this directory is detected as a cycle.
+		if actual, loaded := cache.LoadOrStore(dir, mod); loaded {
+			existing := actual.(*dangModule)
+			if existing.inProgress {
+				return nil, fmt.Errorf("import cycle detected: Dang module %s imports itself (directly or transitively)", dir)
+			}
+			return existing, nil
+		}
+	}
+
+	if err := mod.compile(ctx); err != nil {
+		if cache != nil {
+			// Drop the failed marker so a later pass (e.g. the LSP re-inferring
+			// after an edit) can retry from scratch.
+			cache.Delete(dir)
+		}
+		return nil, err
+	}
+	mod.inProgress = false
+	return mod, nil
+}
+
+// compile parses and type-checks the module's directory under its OWN module
+// identity. The withModuleScope call is what makes cross-module `let` privacy
+// work: the module's declared types are stamped with this scope, so a consumer
+// compiled under a different scope is rejected by Select.Infer when it touches a
+// `let` member (and permitted for a `pub` one). See moduleScope.
+func (m *dangModule) compile(ctx context.Context) error {
+	subCtx, blocks, err := parseModuleBlocks(ctx, m.dir)
+	if err != nil {
+		return err
+	}
+	if len(blocks) == 0 {
+		return fmt.Errorf("no .dang files found in Dang module directory: %s", m.dir)
+	}
+
+	typeScope := NewPreludeTypeScope("")
+	fresh := hm.NewSimpleFresher()
+
+	subCtx = withModuleScope(subCtx, &moduleScope{label: "module:" + m.dir})
+
+	if err := InferDirectoryFiles(subCtx, blocks, typeScope, fresh); err != nil {
+		return ConvertInferError(err)
+	}
+
+	m.typeScope = typeScope
+	m.blocks = blocks
+	return nil
+}
+
+// valueScope evaluates the module's code exactly once and returns the resulting
+// public value scope. Subsequent calls return the cached scope, so a module's
+// top-level side effects run a single time regardless of how many importers it
+// has. The module's own imports resolve from their inference-time cached node
+// state, so the importer's ctx configs do not leak in here.
+func (m *dangModule) valueScope(ctx context.Context) (ValueScope, error) {
+	m.once.Do(func() {
+		vs := NewValueScope(m.typeScope)
+		// Give the module its own eval context so runtime errors point at the
+		// module's files rather than the importer's.
+		mctx := WithEvalContext(ctx, NewEvalContext(m.dir, ""))
+		if err := evaluateDirectoryFiles(mctx, m.blocks, vs); err != nil {
+			m.err = err
+			return
+		}
+		m.value = vs
+	})
+	return m.value, m.err
+}
+
+// parseModuleBlocks parses a native Dang module's .dang files with an import
+// context isolated from the importer: the module resolves its OWN dang.toml (at
+// its root) and never inherits the importer's imports or auto-imports (e.g. a
+// Dagger session the importer configured but the module never asked for).
+func parseModuleBlocks(ctx context.Context, dir string) (context.Context, []*FileBlock, error) {
+	subCtx, err := moduleImportContext(ctx, dir)
+	if err != nil {
+		return ctx, nil, err
+	}
+	return parseDirBlocks(subCtx, dir)
+}
+
+// moduleImportContext strips the importer's project/import configs and attaches
+// the module's own. The Dang-module cache is intentionally left in place so
+// nested Dang modules unify across the whole build.
+func moduleImportContext(ctx context.Context, dir string) (context.Context, error) {
+	// Clear the importer's schema imports and give the module a fresh schema
+	// cache so imported GraphQL types don't alias across the module boundary.
+	ctx = context.WithValue(ctx, importConfigsKey{}, []ImportConfig(nil))
+	ctx = WithSchemaModuleCache(ctx, &sync.Map{})
+
+	configPath := filepath.Join(dir, "dang.toml")
+	if _, statErr := os.Stat(configPath); statErr == nil {
+		config, err := LoadProjectConfig(configPath)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = ContextWithProjectConfig(ctx, configPath, config)
+		resolved, err := ResolveImportConfigs(ctx, config, dir)
+		if err != nil {
+			return ctx, err
+		}
+		if len(resolved) > 0 {
+			ctx = ContextWithImportConfigs(ctx, resolved...)
+		}
+		return ctx, nil
+	}
+
+	// No module-level dang.toml: install an empty project config so
+	// parseDirBlocks' ensureProjectImports treats the module as fully resolved
+	// and does not walk UP into the importer's directory tree.
+	ctx = ContextWithProjectConfig(ctx, configPath, &ProjectConfig{})
+	return ctx, nil
+}

--- a/pkg/dang/materialize.go
+++ b/pkg/dang/materialize.go
@@ -152,6 +152,20 @@ func diagnoseAssignment(have, want hm.Type) error {
 		return nil
 	}
 	if len(issues) == 0 {
+		haveHome, wantHome := haveMod.HomeModule(), wantMod.HomeModule()
+		if haveMod.Named == wantMod.Named && haveHome != nil && wantHome != nil && haveHome != wantHome {
+			// Same type name, distinct module identities. This is a nominal
+			// identity mismatch, not a missing `implements`: it happens when two
+			// modules each hold their own copy of a type (per-module import
+			// identity), and those copies never unify across the module boundary.
+			// Both sides stringify to the same "Widget!", so the usual
+			// "cannot use X as Y" head reads as a tautology — phrase it to make
+			// the two-different-types point explicit instead, and steer the author
+			// toward a shared interface rather than "declare an implementation",
+			// which cannot bridge the boundary.
+			return fmt.Errorf("the %q value here is a different type from the %q expected: they come from different modules and do not unify across the module boundary; share behavior through an interface instead",
+				haveMod.Named, wantMod.Named)
+		}
 		return fmt.Errorf("cannot use %s as %s: %s is structurally compatible with %s but %s is not declared as an implementation",
 			have, want, haveMod.Named, wantMod.Named, haveMod.Named)
 	}

--- a/pkg/dang/project.go
+++ b/pkg/dang/project.go
@@ -43,6 +43,16 @@ type ImportSource struct {
 	//   service = ["~/src/dagger/bin/dagger", "session"]
 	Dagger bool `toml:"dagger,omitempty"`
 
+	// Path points at a native Dang module directory (relative to dang.toml).
+	// Unlike the GraphQL source kinds above, the import binds to another Dang
+	// module compiled from source — its `pub` top-level declarations become the
+	// import's API, its `let`s stay private. Mutually exclusive with the GraphQL
+	// fields.
+	//
+	//   [imports.Helpers]
+	//   path = "./lib/helpers"
+	Path string `toml:"path,omitempty"`
+
 	// Schema is a path to a local .graphqls SDL file (relative to dang.toml).
 	// Provides type information for the LSP and type checker.
 	Schema string `toml:"schema,omitempty"`
@@ -200,6 +210,21 @@ func ResolveDaggerImport(ctx context.Context, configs []ImportConfig, dir string
 func resolveImportSource(ctx context.Context, name string, source *ImportSource, configDir string) (ImportConfig, error) {
 	ic := ImportConfig{Name: name}
 	configPath := filepath.Join(configDir, "dang.toml")
+
+	// Native Dang module import (local path). Resolved lazily from source when
+	// the import is inferred, so no client/schema is set up here. Mutually
+	// exclusive with the GraphQL source kinds.
+	if source.Path != "" {
+		if source.Dagger || source.Schema != "" || source.Endpoint != "" || len(source.Service) > 0 {
+			return ic, fmt.Errorf("'path' cannot be combined with 'dagger', 'schema', 'endpoint', or 'service'")
+		}
+		modDir := source.Path
+		if !filepath.IsAbs(modDir) {
+			modDir = filepath.Join(configDir, modDir)
+		}
+		ic.DangModuleDir = modDir
+		return ic, nil
+	}
 
 	// For Dagger imports, default the service command and set up the
 	// lazy client that starts a dagger session.

--- a/pkg/dang/project_test.go
+++ b/pkg/dang/project_test.go
@@ -155,20 +155,26 @@ func TestProjectConfigImports(t *testing.T) {
 	configDir := filepath.Dir(configPath)
 	resolved, err := ResolveImportConfigs(ctx, config, configDir)
 	require.NoError(t, err)
-	require.Len(t, resolved, 2)
+	require.Len(t, resolved, 3)
 
-	// Verify we got schemas for both imports
-	var testConfig, otherConfig ImportConfig
+	// Verify we got schemas for both GraphQL imports, and a module dir for the
+	// native Dang import (Lib), which carries no schema/client.
+	var testConfig, otherConfig, libConfig ImportConfig
 	for _, c := range resolved {
 		switch c.Name {
 		case "Test":
 			testConfig = c
 		case "Other":
 			otherConfig = c
+		case "Lib":
+			libConfig = c
 		}
 	}
 	require.NotNil(t, testConfig.Schema, "Test import should have a schema")
 	require.NotNil(t, otherConfig.Schema, "Other import should have a schema")
+	require.Nil(t, libConfig.Schema, "native Dang import should have no schema")
+	require.Nil(t, libConfig.Client, "native Dang import should have no client")
+	require.NotEmpty(t, libConfig.DangModuleDir, "native Dang import should resolve a module dir")
 
 	// Verify the schema has expected types
 	require.NotNil(t, testConfig.Schema.Types.Get("User"))
@@ -195,10 +201,12 @@ func TestLoadProjectConfig(t *testing.T) {
 	config, err := LoadProjectConfig("../../tests/dang.toml")
 	require.NoError(t, err)
 	require.NotNil(t, config)
-	require.Len(t, config.Imports, 2)
+	require.Len(t, config.Imports, 3)
 	require.NotNil(t, config.Imports["Test"])
 	require.Equal(t, "./gqlserver/schema.graphqls", config.Imports["Test"].Schema)
 	require.NotNil(t, config.Imports["Other"])
+	require.NotNil(t, config.Imports["Lib"])
+	require.Equal(t, "./importlib", config.Imports["Lib"].Path)
 }
 
 func TestDaggerImportSource(t *testing.T) {

--- a/pkg/dang/project_test.go
+++ b/pkg/dang/project_test.go
@@ -155,10 +155,10 @@ func TestProjectConfigImports(t *testing.T) {
 	configDir := filepath.Dir(configPath)
 	resolved, err := ResolveImportConfigs(ctx, config, configDir)
 	require.NoError(t, err)
-	require.Len(t, resolved, 3)
+	require.Len(t, resolved, 5)
 
-	// Verify we got schemas for both GraphQL imports, and a module dir for the
-	// native Dang import (Lib), which carries no schema/client.
+	// Verify we got schemas for both GraphQL imports, and a module dir for each
+	// native Dang import (Lib/Util/Calc), which carries no schema/client.
 	var testConfig, otherConfig, libConfig ImportConfig
 	for _, c := range resolved {
 		switch c.Name {
@@ -201,12 +201,17 @@ func TestLoadProjectConfig(t *testing.T) {
 	config, err := LoadProjectConfig("../../tests/dang.toml")
 	require.NoError(t, err)
 	require.NotNil(t, config)
-	require.Len(t, config.Imports, 3)
+	require.Len(t, config.Imports, 5)
 	require.NotNil(t, config.Imports["Test"])
 	require.Equal(t, "./gqlserver/schema.graphqls", config.Imports["Test"].Schema)
 	require.NotNil(t, config.Imports["Other"])
 	require.NotNil(t, config.Imports["Lib"])
 	require.Equal(t, "./importlib", config.Imports["Lib"].Path)
+	// Native Dang modules backing the per-module identity tests.
+	require.NotNil(t, config.Imports["Util"])
+	require.Equal(t, "./importutil", config.Imports["Util"].Path)
+	require.NotNil(t, config.Imports["Calc"])
+	require.Equal(t, "./importcalc", config.Imports["Calc"].Path)
 }
 
 func TestDaggerImportSource(t *testing.T) {

--- a/tests/dang.toml
+++ b/tests/dang.toml
@@ -9,3 +9,12 @@ service = ["go", "run", "./gqlserver/service"]
 # A native Dang module (not a GraphQL schema): imported from source.
 [imports.Lib]
 path = "./importlib"
+
+# A leaf utility module and a middle module that imports it. Together they
+# exercise the per-module instance-identity model: transitive imports, within-
+# module sharing, and cross-module type distinctness. Dormant unless imported.
+[imports.Util]
+path = "./importutil"
+
+[imports.Calc]
+path = "./importcalc"

--- a/tests/dang.toml
+++ b/tests/dang.toml
@@ -5,3 +5,7 @@ service = ["go", "run", "./gqlserver/service"]
 [imports.Other]
 schema = "./gqlserver/schema.graphqls"
 service = ["go", "run", "./gqlserver/service"]
+
+# A native Dang module (not a GraphQL schema): imported from source.
+[imports.Lib]
+path = "./importlib"

--- a/tests/errors/import_dang_private_member.dang
+++ b/tests/errors/import_dang_private_member.dang
@@ -1,0 +1,7 @@
+# `secret` is a `let` member of Greeter, private to the Lib module. Reaching it
+# from here — a different module that imports Lib — is rejected. This is the
+# cross-user-module `let` case that native Dang imports make reachable (before,
+# the only module boundary that could exercise it was prelude -> user code).
+import Lib
+
+Lib.Greeter("Dang").secret

--- a/tests/errors/import_foreign_type_mismatch.dang
+++ b/tests/errors/import_foreign_type_mismatch.dang
@@ -1,0 +1,13 @@
+# Cross-module type distinctness under the per-module import identity model.
+#
+# This module imports Util directly (getting ITS OWN copy) and Calc, which
+# imports Util through its own dang.toml (getting a SEPARATE copy). `Calc.widget`
+# is a `Util.Widget` built from Calc's copy; assigning it to a slot annotated
+# with THIS module's `Util.Widget` is rejected, because the two Util instances —
+# same directory, different module — do not unify. Foreign types don't cross the
+# module boundary; behavior is shared through interfaces instead.
+
+import Calc
+import Util
+
+let w: Util.Widget! = Calc.widget

--- a/tests/errors_test.go
+++ b/tests/errors_test.go
@@ -95,9 +95,15 @@ func runDangFile(ctx context.Context, t *testctx.T, client graphql.Client, dangF
 	ctx = ioctx.StdoutToContext(ctx, &stdout)
 	ctx = ioctx.StderrToContext(ctx, &stderr)
 
-	// Lib is a native Dang module (not a GraphQL schema), imported from source.
-	// Used by errors that exercise the cross-module `let` visibility boundary.
+	// Native Dang modules (not GraphQL schemas), imported from source. Lib backs
+	// the cross-module `let` visibility boundary; Util + Calc back the per-module
+	// type-distinctness boundary (Calc imports its own copy of Util via its
+	// dang.toml, so Calc's Util.Widget doesn't unify with an importer's).
 	libDir, err := filepath.Abs("importlib")
+	require.NoError(t, err)
+	utilDir, err := filepath.Abs("importutil")
+	require.NoError(t, err)
+	calcDir, err := filepath.Abs("importcalc")
 	require.NoError(t, err)
 
 	ctx = dang.ContextWithImportConfigs(ctx,
@@ -112,6 +118,14 @@ func runDangFile(ctx context.Context, t *testctx.T, client graphql.Client, dangF
 		dang.ImportConfig{
 			Name:          "Lib",
 			DangModuleDir: libDir,
+		},
+		dang.ImportConfig{
+			Name:          "Util",
+			DangModuleDir: utilDir,
+		},
+		dang.ImportConfig{
+			Name:          "Calc",
+			DangModuleDir: calcDir,
 		},
 	)
 
@@ -187,4 +201,31 @@ print(x)
 			}
 		})
 	}
+}
+
+// TestDangModuleImportCycle checks that a native Dang import cycle (module A
+// imports B imports A) is reported as a clean error rather than looping forever.
+// A directory that must ERROR fits neither the golden harness (the cycle message
+// embeds absolute module dirs) nor the language harness (an error there is a test
+// failure), so — like TestRunDirControlFlowSourceErrors — it runs from a temp
+// dir and asserts on the message. Under the per-module identity model each hop
+// would instantiate a fresh copy, so cycle detection tracks the active compile
+// path (a ctx stack) instead of a shared cache marker.
+func (DangSuite) TestDangModuleImportCycle(ctx context.Context, t *testctx.T) {
+	root := t.TempDir()
+
+	writeCycleModule := func(name, importsName string) {
+		modDir := filepath.Join(root, name)
+		require.NoError(t, os.MkdirAll(modDir, 0755))
+		toml := "[imports." + importsName + "]\npath = \"../" + strings.ToLower(importsName) + "\"\n"
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, "dang.toml"), []byte(toml), 0644))
+		src := "import " + importsName + "\n\npub " + name + ": Int! = 1\n"
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, name+".dang"), []byte(src), 0644))
+	}
+	writeCycleModule("a", "B")
+	writeCycleModule("b", "A")
+
+	_, err := dang.RunDir(ctx, filepath.Join(root, "a"), false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "import cycle detected")
 }

--- a/tests/errors_test.go
+++ b/tests/errors_test.go
@@ -95,6 +95,11 @@ func runDangFile(ctx context.Context, t *testctx.T, client graphql.Client, dangF
 	ctx = ioctx.StdoutToContext(ctx, &stdout)
 	ctx = ioctx.StderrToContext(ctx, &stderr)
 
+	// Lib is a native Dang module (not a GraphQL schema), imported from source.
+	// Used by errors that exercise the cross-module `let` visibility boundary.
+	libDir, err := filepath.Abs("importlib")
+	require.NoError(t, err)
+
 	ctx = dang.ContextWithImportConfigs(ctx,
 		dang.ImportConfig{
 			Name:   "Test",
@@ -104,10 +109,14 @@ func runDangFile(ctx context.Context, t *testctx.T, client graphql.Client, dangF
 			Name:   "Other",
 			Client: client, // Same client/schema, but different import name
 		},
+		dang.ImportConfig{
+			Name:          "Lib",
+			DangModuleDir: libDir,
+		},
 	)
 
 	// Run the Dang file
-	err := dang.RunFile(ctx, dangFile, false)
+	err = dang.RunFile(ctx, dangFile, false)
 	require.Error(t, err, "Test expects an error, but did not error.")
 
 	// Combine stdout and stderr output

--- a/tests/errors_test.go
+++ b/tests/errors_test.go
@@ -203,29 +203,59 @@ print(x)
 	}
 }
 
-// TestDangModuleImportCycle checks that a native Dang import cycle (module A
-// imports B imports A) is reported as a clean error rather than looping forever.
-// A directory that must ERROR fits neither the golden harness (the cycle message
-// embeds absolute module dirs) nor the language harness (an error there is a test
-// failure), so — like TestRunDirControlFlowSourceErrors — it runs from a temp
-// dir and asserts on the message. Under the per-module identity model each hop
-// would instantiate a fresh copy, so cycle detection tracks the active compile
-// path (a ctx stack) instead of a shared cache marker.
+// TestDangModuleImportCycle checks that native Dang import cycles are reported
+// as a clean error rather than looping forever. A directory that must ERROR fits
+// neither the golden harness (the cycle message embeds absolute module dirs) nor
+// the language harness (an error there is a test failure), so — like
+// TestRunDirControlFlowSourceErrors — it runs from a temp dir and asserts on the
+// message. Under the per-module identity model each hop would instantiate a fresh
+// copy, so cycle detection tracks the active compile path (a ctx stack) instead
+// of a shared cache marker; these cases exercise that stack at various depths.
 func (DangSuite) TestDangModuleImportCycle(ctx context.Context, t *testctx.T) {
-	root := t.TempDir()
-
-	writeCycleModule := func(name, importsName string) {
+	// writeModule writes a module dir `name` that imports `alias` (bound to the
+	// sibling directory `importDir` via a relative path).
+	writeModule := func(root, name, alias, importDir string) {
 		modDir := filepath.Join(root, name)
 		require.NoError(t, os.MkdirAll(modDir, 0755))
-		toml := "[imports." + importsName + "]\npath = \"../" + strings.ToLower(importsName) + "\"\n"
+		toml := "[imports." + alias + "]\npath = \"../" + importDir + "\"\n"
 		require.NoError(t, os.WriteFile(filepath.Join(modDir, "dang.toml"), []byte(toml), 0644))
-		src := "import " + importsName + "\n\npub " + name + ": Int! = 1\n"
+		src := "import " + alias + "\n\npub " + name + ": Int! = 1\n"
 		require.NoError(t, os.WriteFile(filepath.Join(modDir, name+".dang"), []byte(src), 0644))
 	}
-	writeCycleModule("a", "B")
-	writeCycleModule("b", "A")
 
-	_, err := dang.RunDir(ctx, filepath.Join(root, "a"), false)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "import cycle detected")
+	t.Run("two-node", func(ctx context.Context, t *testctx.T) {
+		root := t.TempDir()
+		writeModule(root, "a", "B", "b")
+		writeModule(root, "b", "A", "a")
+
+		_, err := dang.RunDir(ctx, filepath.Join(root, "a"), false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "import cycle detected")
+	})
+
+	t.Run("three-node", func(ctx context.Context, t *testctx.T) {
+		root := t.TempDir()
+		writeModule(root, "a", "B", "b")
+		writeModule(root, "b", "C", "c")
+		writeModule(root, "c", "A", "a")
+
+		_, err := dang.RunDir(ctx, filepath.Join(root, "a"), false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "import cycle detected")
+	})
+
+	t.Run("self-import", func(ctx context.Context, t *testctx.T) {
+		root := t.TempDir()
+		modDir := filepath.Join(root, "a")
+		require.NoError(t, os.MkdirAll(modDir, 0755))
+		// A module that imports its own directory via ".".
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, "dang.toml"),
+			[]byte("[imports.Me]\npath = \".\"\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, "a.dang"),
+			[]byte("import Me\n\npub a: Int! = 1\n"), 0644))
+
+		_, err := dang.RunDir(ctx, modDir, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "import cycle detected")
+	})
 }

--- a/tests/importcalc/calc.dang
+++ b/tests/importcalc/calc.dang
@@ -1,0 +1,14 @@
+# A middle module that imports the leaf Util module (see dang.toml). It sits
+# between an app and Util, so importing Calc exercises TRANSITIVE native imports:
+# Calc's own `import Util` must resolve, compile, and evaluate through the module
+# boundary before Calc's API is usable.
+import Util
+
+# Transitive use of a dependency's public helper.
+tripled(n: Int!): Int! { Util.double(n) + n }
+
+# Re-exposes a value whose type comes from Calc's OWN copy of Util. An importer
+# that also imports Util cannot assign this to its own Util.Widget slot, because
+# the two Util instances are distinct (per-module identity). See
+# errors/import_foreign_type_mismatch.
+widget: Util.Widget! { Util.Widget }

--- a/tests/importcalc/dang.toml
+++ b/tests/importcalc/dang.toml
@@ -1,0 +1,5 @@
+# Calc's OWN manifest, resolved when Calc is compiled as a module (relative to
+# this directory, not the importer's). This is how a native Dang module declares
+# its own dependencies; the importer never sees or shares them.
+[imports.Util]
+path = "../importutil"

--- a/tests/importlib/greeter.dang
+++ b/tests/importlib/greeter.dang
@@ -1,0 +1,25 @@
+# A native Dang module, imported by consumers via `[imports.Lib] path` in
+# dang.toml. Its typed (public-by-default) declarations form the module's API;
+# its `let`s are private to the module. This is what an importer's cross-module
+# `let` visibility is tested against — see errors/import_dang_private_member.
+
+type Greeter {
+  name: String! = "world"
+
+  # Public method: reachable by any importer as Greeter.greeting / Greeter(x).
+  greeting: String! { salutation + ", " + self.name + "!" }
+
+  # Private method: an importer that reaches for `.secret` is rejected, because
+  # `secret` belongs to this module and the importer is a different one.
+  let secret: String! { "shhh" }
+
+  # Public accessor: same-module code reads the private member freely, so an
+  # importer sees the value only through here.
+  reveal: String! { self.secret }
+}
+
+# Module-private top-level helper, used by the pub method above.
+let salutation = "Hello"
+
+# Public top-level value: reachable qualified (Lib.answer) and unqualified.
+answer: Int! = 42

--- a/tests/importlib/kinds.dang
+++ b/tests/importlib/kinds.dang
@@ -1,0 +1,30 @@
+# Extra exported declaration kinds, in a second file of the same module. Each
+# has a value-level binding (enum module, interface module, union module) that
+# must carry the declaration's visibility so it re-exports across the import
+# boundary — the same requirement objects and scalars already met.
+
+enum Color {
+  RED
+  GREEN
+  BLUE
+}
+
+interface Shape {
+  area: Int!
+}
+
+type Square implements Shape {
+  side: Int! = 2
+
+  area: Int! { self.side * self.side }
+}
+
+type Dog {
+  sound: String! = "woof"
+}
+
+type Cat {
+  sound: String! = "meow"
+}
+
+union Pet = Dog | Cat

--- a/tests/importutil/util.dang
+++ b/tests/importutil/util.dang
@@ -1,0 +1,19 @@
+# A leaf utility module imported by consumers via `[imports.Util] path` in
+# dang.toml. It has no imports of its own, so it sits at the bottom of the
+# dependency chain used to test native Dang module identity.
+#
+# Under the per-module identity model each importing module gets its OWN compiled
+# copy of this module: App's Util and Calc's Util are distinct instances even
+# though both resolve to this same directory. Their `Widget` types therefore do
+# not unify across the module boundary (see errors/import_foreign_type_mismatch),
+# while all files of a single module DO share one instance (see
+# test_import_transitive).
+
+type Widget {
+  size: Int! = 3
+
+  area: Int! { self.size * self.size }
+}
+
+# Public helper, used transitively through Calc.
+double(n: Int!): Int! { n * 2 }

--- a/tests/test_import_dang_module.dang
+++ b/tests/test_import_dang_module.dang
@@ -1,0 +1,32 @@
+# Import a native Dang module (configured as `[imports.Lib] path` in dang.toml).
+# This exercises the module boundary end to end: the module's pub API is
+# reachable here, while its `let` members are not (that case lives in
+# errors/import_dang_private_member). It is the first cross-USER-module import
+# — previously the only module boundary was prelude -> user code.
+import Lib
+
+# Qualified access to a pub type and its pub members.
+assert { Lib.Greeter("Dang").greeting == "Hello, Dang!" }
+assert { Lib.Greeter("Dang").reveal == "shhh" } # reveal is pub; it reads the let
+
+# Unqualified imported symbols resolve too, like GraphQL imports.
+assert { Greeter.greeting == "Hello, world!" }
+
+# A pub top-level value, reachable qualified and unqualified.
+assert { Lib.answer == 42 }
+assert { answer == 42 }
+
+# Enum, interface, and union kinds re-export across the boundary too — each has
+# a value-level binding reachable both qualified and unqualified.
+assert { Lib.Color.RED != Lib.Color.GREEN }
+assert { Color.RED == Lib.Color.RED } # unqualified enum value binding
+
+let sq: Shape = Lib.Square # unqualified interface type in annotation position
+assert { sq.area == 4 }
+assert { Shape != null } # unqualified interface value binding
+
+let pet: Pet = Lib.Dog # unqualified union type in annotation position
+assert { Lib.Pet != null }
+assert { Pet != null } # unqualified union value binding
+
+print(Lib.Greeter("Dang").greeting)

--- a/tests/test_import_transitive/a.dang
+++ b/tests/test_import_transitive/a.dang
@@ -1,0 +1,19 @@
+# Native Dang module identity, positive cases (the negative counterpart is
+# errors/import_foreign_type_mismatch). Two things are exercised here:
+#
+#   1. TRANSITIVE imports: Calc imports Util internally; using Calc.tripled runs
+#      Util.double across two module boundaries (App -> Calc -> Util).
+#   2. WITHIN-MODULE SHARING: this file and its sibling b.dang both `import Util`
+#      and must resolve it to the SAME instance, so a Util value produced here is
+#      assignable to a Util.Widget slot there.
+
+import Calc
+import Util
+
+# Transitive: Calc.tripled(n) == Util.double(n) + n == 3n.
+assert { Calc.tripled(2) == 6 }
+assert { Calc.tripled(10) == 30 }
+
+# A Util value produced in this file, consumed by the sibling file. Its type is
+# App's Util.Widget.
+pub appWidget = Util.Widget

--- a/tests/test_import_transitive/b.dang
+++ b/tests/test_import_transitive/b.dang
@@ -1,0 +1,8 @@
+# Sibling of a.dang in the same module. `appWidget` is declared over there; the
+# annotation below only typechecks because both files resolve `Util` to the same
+# instance (within-module sharing). If each `import` produced its own instance,
+# this file's Util.Widget would be a distinct, non-unifying type.
+import Util
+
+let checked: Util.Widget! = appWidget
+assert { checked.area == 9 }

--- a/tests/testdata/import_dang_private_member.golden
+++ b/tests/testdata/import_dang_private_member.golden
@@ -1,0 +1,10 @@
+[1m[31mError:[0m "secret" is a private member of Greeter and cannot be accessed from another module
+  [2m[34m--> errors/import_dang_private_member.dang:7:1[0m
+ [2m    |[0m
+ [2m  5 | import Lib[0m
+ [2m  6 | [0m
+ [2m[34m[1m  7 | [0mLib.Greeter("Dang").secret
+[2m       [31m^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+ [2m  8 | [0m
+ [2m    |[0m
+

--- a/tests/testdata/import_foreign_type_mismatch.golden
+++ b/tests/testdata/import_foreign_type_mismatch.golden
@@ -1,0 +1,10 @@
+[1m[31mError:[0m cannot use Widget! as Widget!: Widget is structurally compatible with Widget but Widget is not declared as an implementation
+  [2m[34m--> errors/import_foreign_type_mismatch.dang:13:23[0m
+ [2m    |[0m
+ [2m 11 | import Util[0m
+ [2m 12 | [0m
+ [2m[34m[1m 13 | [0mlet w: Util.Widget! = Calc.widget
+[2m                             [31m^^^^^^^^^^^[0m
+ [2m 14 | [0m
+ [2m    |[0m
+

--- a/tests/testdata/import_foreign_type_mismatch.golden
+++ b/tests/testdata/import_foreign_type_mismatch.golden
@@ -1,4 +1,4 @@
-[1m[31mError:[0m cannot use Widget! as Widget!: Widget is structurally compatible with Widget but Widget is not declared as an implementation
+[1m[31mError:[0m the "Widget" value here is a different type from the "Widget" expected: they come from different modules and do not unify across the module boundary; share behavior through an interface instead
   [2m[34m--> errors/import_foreign_type_mismatch.dang:13:23[0m
  [2m    |[0m
  [2m 11 | import Util[0m


### PR DESCRIPTION
## Summary

Implements native Dang-to-Dang **local path** module imports.

`[imports.X] path = "./dir"` in `dang.toml` binds `X` to a native Dang module compiled from source, with its own `pub`/`let` API surface. This makes the cross-module `let` visibility boundary reachable and tested end to end. Instance identity is **per-module** (per-`dang.toml`): each module gets its own copy of a dependency, and nothing unifies across the module boundary, which makes Go-style MVS version reconciliation moot (there is none). Includes transitive local imports, compile-stack cycle detection (two-node, three-node, and self-import cases), and a clearer cross-module type-mismatch diagnostic that explains that two same-named types come from different instances of the module.

Also fixes a latent bug surfaced along the way: `ObjectDecl.Hoist` added a `type`'s constructor scheme to the type env without setting visibility, so constructors defaulted to private and never re-exported across an import boundary.

## Test plan

- `go test ./tests/ ./pkg/dang/` — all green locally.
- New coverage: `tests/importlib/` + `tests/test_import_dang_module.dang` (positive), `tests/test_import_transitive/` (transitive), private-member and foreign-type-mismatch error goldens, and cycle-detection Go tests (2-node/3-node/self).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
