### PR TITLE
docs: document scalar bodies and static members

### DIFF
--- a/docs/lit/types/enums-scalars.md
+++ b/docs/lit/types/enums-scalars.md
@@ -69,10 +69,76 @@ scalar JSON
 
 > Meta: the `::` rule is the durable contract — literals are a convenience, non-literal values always go through an explicit cast.
 
+### Degrading to `String`
+
+```dang
+scalar URL
+
+let u: URL! = "https://example.com/a"
+
+# a scalar value degrades to String! at value-handoff boundaries — typed slots,
+# call args, returns, reassignment, ::, case-clause values — since it is a
+# string underneath
+let s: String! = u
+
+shout(msg: String!): String! { msg.toUpper }
+shout(u)                        # degrades into the String! argument → "HTTPS://EXAMPLE.COM/A"
+
+u == "https://example.com/a"    # compares by underlying string → true
+`link: ${u}`                    # interpolation / toString yield the bare string
+(u :: String!).toUpper          # a String *method* needs a String receiver: degrade first
+```
+
+## Scalar bodies {#scalar-bodies}
+
+```dang
+scalar Slug {
+  # new() runs at every materialization — a string literal in a Slug! slot, a
+  # `:: Slug!` cast, codec decode, and the derived Slug(...) constructor — and
+  # returns the canonical underlying String!, which the runtime wraps back up
+  new(raw: String!) {
+    raw.trimSpace.toLower.replace(" ", "-")
+  }
+
+  # members are methods only (a scalar holds no state beyond its string); inside
+  # one, `self` is the scalar value — degrade it to String! via a slot or cast
+  words: [String!]! { (self :: String!).split("-") }
+  first: String! { self.words[0] ?? "" }   # bare sibling call re-dispatches on self
+}
+
+# the scalar's name doubles as a constructor for any String expression
+Slug("  Hello World  ")             # Slug("hello-world")
+Slug("A b") == Slug("a-b")          # true — normalization makes equality semantic
+Slug("one two three").words         # ["one", "two", "three"]
+Slug("one two three").first         # "one"
+```
+
+```dang
+scalar Upper {
+  # a raise in the hook makes a bad value recoverable at the offending slot
+  new(raw: String!) {
+    if (raw != raw.toUpper) { raise `not upper: ${raw}` }
+    raw
+  }
+
+  # a self { } block adds statics, reached as Upper.member (see Static members)
+  self {
+    of(s: String!): Upper! { Upper(s.toUpper) }
+  }
+}
+
+let ok: Upper! = "HELLO"            # Upper("HELLO")
+Upper("nope") rescue "rejected"     # "rejected" — construction is recoverable
+Upper.of("mixed Case")             # Upper("MIXED CASE")
+```
+
+- a scalar's `self { }` block declares statics exactly like a `type`'s (see [#static-members])
+
 ## Built-in scalars
 
 - `Int!`, `Float!`, `String!`, `Boolean!`, `ID!` (see [#nullability])
 - `ID!` is its own scalar, not a `String` alias: `String!` does not unify with `ID!` (no implicit interop) — but string *literals* still coerce into `ID!` slots (`idSlot: ID! = "abc"`)
+- `Path!` and `Regexp!` are scalars carrying their own methods and a construction hook — `Path` normalizes on construction, `Regexp` compiles its pattern. `Path` is declared in the prelude with a scalar body (see [#scalar-bodies]); full method signatures for both are in [#stdlib]
 
 > Meta: scalar fields are invariant across interface implementation — `id: String!` does not satisfy `id: ID!`. Cross-ref the variance rules in [#interfaces-unions].
 

--- a/docs/lit/types/objects.md
+++ b/docs/lit/types/objects.md
@@ -23,7 +23,7 @@ type Person {
 ## Public vs. private members
 
 - a bare member is **public** — readable from outside the type; public is the default for a `type`
-- `let` — readable only inside the type's own methods/defaults (private)
+- `let` — private to the declaring **module**: readable by any type or method in the same module, rejected across a module boundary (see [#modules])
 - `pub` is still accepted as an explicit public marker, but it is redundant and `dang fmt` removes it (see [#fields])
 - whether a member is a **constructor parameter** depends on having NO default, NOT on visibility:
   - `x: T!` (no default) → required positional param
@@ -31,6 +31,14 @@ type Person {
   - `let x: T!` (no default) → required positional param too, e.g. `Foo("public_value", "private_value")`
   - `let x: T! = d` → NOT a param; the default is used
   - method/computed members (have a `{ body }`) are never constructor params
+
+```dang
+# `let` privacy is module-scoped, not type-scoped: another type in the same
+# module reaches a let member (across a module boundary it is rejected)
+type Account { let secret: String! = "hunter2" }
+type Vault { unlock(a: Account!): String! { a.secret } }
+Vault.unlock(Account)   # "hunter2"
+```
 
 ## Implicit constructor
 
@@ -99,6 +107,51 @@ fullName: String! { firstName + " " + lastName }
 
 - accessed like a plain field (`obj.fullName`, no call parens); recomputes against the current receiver
 - a defaulted-value member (`pub computedField = config.name + "_computed"`) is computed once at construction; a `{ body }` computed field is re-evaluated per access
+
+## Static members {#static-members}
+
+```dang
+type Color {
+  r: Int! = 0
+  g: Int! = 0
+  b: Int! = 0
+
+  luminance: Int! { (r + g + b) / 3 }        # an instance member
+
+  # a self { } block declares statics: they live on the type itself, reached as
+  # Color.member, never on an instance
+  self {
+    white: Color! { Color(r: 255, g: 255, b: 255) }   # a factory method
+    fromGray(v: Int!): Color! { Color(r: v, g: v, b: v) }
+    grayMid: Color! { fromGray(128) }                 # a static calling a sibling static
+    let scale = 2                                      # a private (let) static helper
+    doubled(v: Int!): Int! { v * scale }
+  }
+}
+
+Color.white.luminance          # 255
+Color.fromGray(10).r           # 10
+Color.grayMid.g                # 128
+Color.doubled(7)               # 14
+Color(r: 3, g: 6, b: 9).luminance   # 6 — instances are unaffected by statics
+Color.luminance                # 0 — a bare all-default type still auto-constructs
+```
+
+```dang
+# static stored fields hold singleton state on the type
+type Config {
+  host: String! = "localhost"
+  self {
+    limit: Int! = 100
+    default: Config! = Config    # a static holding a constructed instance
+  }
+}
+
+Config.limit          # 100
+Config.default.host   # "localhost"
+```
+
+- a scalar may also carry a `self { }` block — including static *stored* fields, even though instance stored fields on a scalar are forbidden (see [#scalar-bodies])
 
 ## Implements
 


### PR DESCRIPTION
Backfills the conceptual docs (`docs/lit/`) for #166, which shipped several user-facing language features but only touched the directives and stdlib reference pages.

## `docs/lit/types/enums-scalars.md`

- **Scalar bodies** (`#scalar-bodies`) — the `new()` materialization hook, methods, the scalar name doubling as a constructor, and a raising hook shown via `rescue`.
- **Degrading to `String`** — scalar values flowing into `String!` slots/args/returns at value-handoff boundaries, and that a `String` *method* still needs a degraded receiver.
- `Path!` and `Regexp!` added to the built-in scalars list, cross-linked to `#scalar-bodies` and `#stdlib`.

## `docs/lit/types/objects.md`

- **Static members** (`#static-members`) — `self { }` blocks: factory methods, singleton stored fields, private (`let`) static helpers, and that instances/auto-construction are unaffected.
- The `let` bullet is corrected to **module-level** visibility (reachable anywhere in the declaring module, rejected across a module boundary), with a two-type example demonstrating it.

## Notes

- Style follows the examples-first convention: each fence is a self-contained example with the important notes as code comments; I left the surrounding prose for you.
- Every fenced example was evaluated against the interpreter, and the full docs render (`go run . -i lit/index.md`) resolves all cross-references.
- These pages are not `\literate-fences` pages, so the fences render as static highlighted blocks (consistent with the rest of both pages).
